### PR TITLE
Use native2ascii to fix garbled Japanese text

### DIFF
--- a/app/src/main/resources/com/oracle/javafx/scenebuilder/app/i18n/SceneBuilderApp_ja.properties
+++ b/app/src/main/resources/com/oracle/javafx/scenebuilder/app/i18n/SceneBuilderApp_ja.properties
@@ -33,268 +33,268 @@
 # Generic labels
 # -----------------------------------------------------------------------------
 label.ok = OK
-label.cancel = 取消
-label.close = 閉じる
-label.delete = 削除
-label.copy = コピー
-label.save = 保存
-label.revert = 元に戻す
-label.do.not.save = 保存しない
-label.overwrite = 上書き
-label.review.changes = 変更をレビュー
-label.discard.changes = 変更を破棄
+label.cancel = \u53d6\u6d88
+label.close = \u9589\u3058\u308b
+label.delete = \u524a\u9664
+label.copy = \u30b3\u30d4\u30fc
+label.save = \u4fdd\u5b58
+label.revert = \u5143\u306b\u623b\u3059
+label.do.not.save = \u4fdd\u5b58\u3057\u306a\u3044
+label.overwrite = \u4e0a\u66f8\u304d
+label.review.changes = \u5909\u66f4\u3092\u30ec\u30d3\u30e5\u30fc
+label.discard.changes = \u5909\u66f4\u3092\u7834\u68c4
 
 
 # -----------------------------------------------------------------------------
 # Menu Bar
 # -----------------------------------------------------------------------------
-menu.title.file = ファイル(F)
-menu.title.edit = 編集(E)
-menu.title.view = 表示(V)
-menu.title.insert = 挿入(I)
-menu.title.insert.error = 挿入に失敗しました。
-menu.title.modify = 変更(M)
-menu.title.arrange = 配置
-menu.title.preview = プレビュー(P)
-menu.title.window = ウィンドウ(W)
-menu.title.help = ヘルプ
+menu.title.file = \u30d5\u30a1\u30a4\u30eb(F)
+menu.title.edit = \u7de8\u96c6(E)
+menu.title.view = \u8868\u793a(V)
+menu.title.insert = \u633f\u5165(I)
+menu.title.insert.error = \u633f\u5165\u306b\u5931\u6557\u3057\u307e\u3057\u305f\u3002
+menu.title.modify = \u5909\u66f4(M)
+menu.title.arrange = \u914d\u7f6e
+menu.title.preview = \u30d7\u30ec\u30d3\u30e5\u30fc(P)
+menu.title.window = \u30a6\u30a3\u30f3\u30c9\u30a6(W)
+menu.title.help = \u30d8\u30eb\u30d7
 # File menu items
-menu.title.new = 新規(N)
-menu.title.new.template = テンプレートから新規作成(T)
-menu.title.new.basic.phone.app = 基本
-menu.title.open = 開く...(O)
-menu.title.open.recent = 最近のものを開く(R)
-menu.title.open.recent.clear = メニューのクリア
-menu.title.save = 保存(S)
-menu.title.save.as = 別名保存...
-menu.title.revert = 保存済に戻す(D)
-menu.title.close = ウィンドウを閉じる(C)
-menu.title.reveal.mac = ファインダに表示
-menu.title.reveal.win.mnemonic = エクスプローラに表示(X)
-menu.title.reveal.win = エクスプローラに表示
-menu.title.reveal.linux = デスクトップに表示
-menu.title.import = インポート
+menu.title.new = \u65b0\u898f(N)
+menu.title.new.template = \u30c6\u30f3\u30d7\u30ec\u30fc\u30c8\u304b\u3089\u65b0\u898f\u4f5c\u6210(T)
+menu.title.new.basic.phone.app = \u57fa\u672c
+menu.title.open = \u958b\u304f...(O)
+menu.title.open.recent = \u6700\u8fd1\u306e\u3082\u306e\u3092\u958b\u304f(R)
+menu.title.open.recent.clear = \u30e1\u30cb\u30e5\u30fc\u306e\u30af\u30ea\u30a2
+menu.title.save = \u4fdd\u5b58(S)
+menu.title.save.as = \u5225\u540d\u4fdd\u5b58...
+menu.title.revert = \u4fdd\u5b58\u6e08\u306b\u623b\u3059(D)
+menu.title.close = \u30a6\u30a3\u30f3\u30c9\u30a6\u3092\u9589\u3058\u308b(C)
+menu.title.reveal.mac = \u30d5\u30a1\u30a4\u30f3\u30c0\u306b\u8868\u793a
+menu.title.reveal.win.mnemonic = \u30a8\u30af\u30b9\u30d7\u30ed\u30fc\u30e9\u306b\u8868\u793a(X)
+menu.title.reveal.win = \u30a8\u30af\u30b9\u30d7\u30ed\u30fc\u30e9\u306b\u8868\u793a
+menu.title.reveal.linux = \u30c7\u30b9\u30af\u30c8\u30c3\u30d7\u306b\u8868\u793a
+menu.title.import = \u30a4\u30f3\u30dd\u30fc\u30c8
 menu.title.import.fxml = FXML...
-menu.title.import.media = メディア...
-menu.title.include = インクルード
+menu.title.import.media = \u30e1\u30c7\u30a3\u30a2...
+menu.title.include = \u30a4\u30f3\u30af\u30eb\u30fc\u30c9
 menu.title.include.fxml = FXML...
-menu.title.edit.included = ''{0}''の編集
-menu.title.edit.included.default = インクルードされたファイルの編集
-menu.title.reveal.included.finder = ''{0}''をファインダに表示
-menu.title.reveal.included.explorer = ''{0}''をエクスプローラに表示
-menu.title.reveal.included.default = インクルードされたファイルを表示
-menu.title.print = 印刷…
-menu.title.preferences = プリファレンス
-menu.title.quit = 終了(Q)
+menu.title.edit.included = ''{0}''\u306e\u7de8\u96c6
+menu.title.edit.included.default = \u30a4\u30f3\u30af\u30eb\u30fc\u30c9\u3055\u308c\u305f\u30d5\u30a1\u30a4\u30eb\u306e\u7de8\u96c6
+menu.title.reveal.included.finder = ''{0}''\u3092\u30d5\u30a1\u30a4\u30f3\u30c0\u306b\u8868\u793a
+menu.title.reveal.included.explorer = ''{0}''\u3092\u30a8\u30af\u30b9\u30d7\u30ed\u30fc\u30e9\u306b\u8868\u793a
+menu.title.reveal.included.default = \u30a4\u30f3\u30af\u30eb\u30fc\u30c9\u3055\u308c\u305f\u30d5\u30a1\u30a4\u30eb\u3092\u8868\u793a
+menu.title.print = \u5370\u5237\u2026
+menu.title.preferences = \u30d7\u30ea\u30d5\u30a1\u30ec\u30f3\u30b9
+menu.title.quit = \u7d42\u4e86(Q)
 # Edit menu items
-menu.title.undo = 元に戻す(U)
-menu.title.redo = やり直し(R)
-menu.title.cut = 切取り(T)
-menu.title.copy = コピー(C)
-menu.title.paste = 貼付け(S)
-menu.title.paste.into = 内側に貼付け
-menu.title.duplicate = 複製(L)
-menu.title.delete = 削除(D)
-menu.title.select.all = すべて選択
-menu.title.select.none = 何も選択しない(N)
-menu.title.select.parent = 親の選択
-menu.title.select.next = 次を選択(X)
-menu.title.select.previous = 前を選択(O)
-menu.title.trim = ドキュメントを選択範囲まで切取り
+menu.title.undo = \u5143\u306b\u623b\u3059(U)
+menu.title.redo = \u3084\u308a\u76f4\u3057(R)
+menu.title.cut = \u5207\u53d6\u308a(T)
+menu.title.copy = \u30b3\u30d4\u30fc(C)
+menu.title.paste = \u8cbc\u4ed8\u3051(S)
+menu.title.paste.into = \u5185\u5074\u306b\u8cbc\u4ed8\u3051
+menu.title.duplicate = \u8907\u88fd(L)
+menu.title.delete = \u524a\u9664(D)
+menu.title.select.all = \u3059\u3079\u3066\u9078\u629e
+menu.title.select.none = \u4f55\u3082\u9078\u629e\u3057\u306a\u3044(N)
+menu.title.select.parent = \u89aa\u306e\u9078\u629e
+menu.title.select.next = \u6b21\u3092\u9078\u629e(X)
+menu.title.select.previous = \u524d\u3092\u9078\u629e(O)
+menu.title.trim = \u30c9\u30ad\u30e5\u30e1\u30f3\u30c8\u3092\u9078\u629e\u7bc4\u56f2\u307e\u3067\u5207\u53d6\u308a
 # View menu items
-menu.title.content = コンテンツ(C)
-menu.title.properties = プロパティ(R)
-menu.title.layout = レイアウト(L)
-menu.title.code = コード(O)
-menu.title.show.library.panel = ライブラリの表示(B)
-menu.title.hide.library.panel = ライブラリの非表示(B)
-menu.title.show.document.panel = ドキュメントの表示(D)
-menu.title.hide.document.panel = ドキュメントの非表示(D)
-menu.title.show.left.panel = 左パネルの表示(T)
-menu.title.hide.left.panel = 左パネルの非表示(T)
-menu.title.show.right.panel = 右パネルの表示(G)
-menu.title.hide.right.panel = 右パネルの非表示(G)
-menu.title.show.bottom.panel = CSSアナライザの表示(Y)
-menu.title.hide.bottom.panel = CSSアナライザの非表示(Y)
-menu.title.show.outlines = アウトラインの表示(U)
-menu.title.hide.outlines = アウトラインの非表示(U)
-menu.title.show.sample.data = サンプル・データの表示(S)
-menu.title.hide.sample.data = サンプル・データの非表示(S)
-menu.title.disable.guides = 位置合せガイドの無効化(N)
-menu.title.enable.guides = 位置合せガイドの有効化(N)
-menu.title.show.sample.controller.skeleton = サンプル・コントローラ・スケルトンの表示(K)
-menu.title.zoom = ズーム(Z)
-menu.title.zoom.in = ズーム・イン(I)
-menu.title.zoom.out = ズーム・アウト(O)
+menu.title.content = \u30b3\u30f3\u30c6\u30f3\u30c4(C)
+menu.title.properties = \u30d7\u30ed\u30d1\u30c6\u30a3(R)
+menu.title.layout = \u30ec\u30a4\u30a2\u30a6\u30c8(L)
+menu.title.code = \u30b3\u30fc\u30c9(O)
+menu.title.show.library.panel = \u30e9\u30a4\u30d6\u30e9\u30ea\u306e\u8868\u793a(B)
+menu.title.hide.library.panel = \u30e9\u30a4\u30d6\u30e9\u30ea\u306e\u975e\u8868\u793a(B)
+menu.title.show.document.panel = \u30c9\u30ad\u30e5\u30e1\u30f3\u30c8\u306e\u8868\u793a(D)
+menu.title.hide.document.panel = \u30c9\u30ad\u30e5\u30e1\u30f3\u30c8\u306e\u975e\u8868\u793a(D)
+menu.title.show.left.panel = \u5de6\u30d1\u30cd\u30eb\u306e\u8868\u793a(T)
+menu.title.hide.left.panel = \u5de6\u30d1\u30cd\u30eb\u306e\u975e\u8868\u793a(T)
+menu.title.show.right.panel = \u53f3\u30d1\u30cd\u30eb\u306e\u8868\u793a(G)
+menu.title.hide.right.panel = \u53f3\u30d1\u30cd\u30eb\u306e\u975e\u8868\u793a(G)
+menu.title.show.bottom.panel = CSS\u30a2\u30ca\u30e9\u30a4\u30b6\u306e\u8868\u793a(Y)
+menu.title.hide.bottom.panel = CSS\u30a2\u30ca\u30e9\u30a4\u30b6\u306e\u975e\u8868\u793a(Y)
+menu.title.show.outlines = \u30a2\u30a6\u30c8\u30e9\u30a4\u30f3\u306e\u8868\u793a(U)
+menu.title.hide.outlines = \u30a2\u30a6\u30c8\u30e9\u30a4\u30f3\u306e\u975e\u8868\u793a(U)
+menu.title.show.sample.data = \u30b5\u30f3\u30d7\u30eb\u30fb\u30c7\u30fc\u30bf\u306e\u8868\u793a(S)
+menu.title.hide.sample.data = \u30b5\u30f3\u30d7\u30eb\u30fb\u30c7\u30fc\u30bf\u306e\u975e\u8868\u793a(S)
+menu.title.disable.guides = \u4f4d\u7f6e\u5408\u305b\u30ac\u30a4\u30c9\u306e\u7121\u52b9\u5316(N)
+menu.title.enable.guides = \u4f4d\u7f6e\u5408\u305b\u30ac\u30a4\u30c9\u306e\u6709\u52b9\u5316(N)
+menu.title.show.sample.controller.skeleton = \u30b5\u30f3\u30d7\u30eb\u30fb\u30b3\u30f3\u30c8\u30ed\u30fc\u30e9\u30fb\u30b9\u30b1\u30eb\u30c8\u30f3\u306e\u8868\u793a(K)
+menu.title.zoom = \u30ba\u30fc\u30e0(Z)
+menu.title.zoom.in = \u30ba\u30fc\u30e0\u30fb\u30a4\u30f3(I)
+menu.title.zoom.out = \u30ba\u30fc\u30e0\u30fb\u30a2\u30a6\u30c8(O)
 # Modify menu items
-menu.title.fit = 親に合せる(T)
-menu.title.use.computed.sizes = 計算されたサイズの使用(U)
+menu.title.fit = \u89aa\u306b\u5408\u305b\u308b(T)
+menu.title.use.computed.sizes = \u8a08\u7b97\u3055\u308c\u305f\u30b5\u30a4\u30ba\u306e\u4f7f\u7528(U)
 menu.title.grid = _GridPane
-menu.title.add.effect = 効果の設定(S)
-menu.title.add.popup = ポップアップ・コントロールの追加(C)
-menu.title.add.popup.context.menu = コンテキストメニュー
-menu.title.add.popup.tooltip = ツールチップ
+menu.title.add.effect = \u52b9\u679c\u306e\u8a2d\u5b9a(S)
+menu.title.add.popup = \u30dd\u30c3\u30d7\u30a2\u30c3\u30d7\u30fb\u30b3\u30f3\u30c8\u30ed\u30fc\u30eb\u306e\u8ffd\u52a0(C)
+menu.title.add.popup.context.menu = \u30b3\u30f3\u30c6\u30ad\u30b9\u30c8\u30e1\u30cb\u30e5\u30fc
+menu.title.add.popup.tooltip = \u30c4\u30fc\u30eb\u30c1\u30c3\u30d7
 # Modify -> GridPane menu items
-menu.title.grid.select.next.row = 次の行を選択
-menu.title.grid.select.next.column = 次の列を選択
-menu.title.grid.move.row.above = 上に行を移動
-menu.title.grid.move.row.below = 下に行を移動
-menu.title.grid.move.column.before = 前に列を移動
-menu.title.grid.move.column.after = 後に列を移動
-menu.title.grid.add.row.above = 上に行を追加
-menu.title.grid.add.row.below = 下に行を追加
-menu.title.grid.add.column.before = 前に列を追加
-menu.title.grid.add.column.after = 後に列を追加
-menu.title.grid.increase.row.span = 行の高さを拡大
-menu.title.grid.decrease.row.span = 行の高さを縮小
-menu.title.grid.increase.column.span = 列の幅を拡大
-menu.title.grid.decrease.column.span = 列の幅を縮小
+menu.title.grid.select.next.row = \u6b21\u306e\u884c\u3092\u9078\u629e
+menu.title.grid.select.next.column = \u6b21\u306e\u5217\u3092\u9078\u629e
+menu.title.grid.move.row.above = \u4e0a\u306b\u884c\u3092\u79fb\u52d5
+menu.title.grid.move.row.below = \u4e0b\u306b\u884c\u3092\u79fb\u52d5
+menu.title.grid.move.column.before = \u524d\u306b\u5217\u3092\u79fb\u52d5
+menu.title.grid.move.column.after = \u5f8c\u306b\u5217\u3092\u79fb\u52d5
+menu.title.grid.add.row.above = \u4e0a\u306b\u884c\u3092\u8ffd\u52a0
+menu.title.grid.add.row.below = \u4e0b\u306b\u884c\u3092\u8ffd\u52a0
+menu.title.grid.add.column.before = \u524d\u306b\u5217\u3092\u8ffd\u52a0
+menu.title.grid.add.column.after = \u5f8c\u306b\u5217\u3092\u8ffd\u52a0
+menu.title.grid.increase.row.span = \u884c\u306e\u9ad8\u3055\u3092\u62e1\u5927
+menu.title.grid.decrease.row.span = \u884c\u306e\u9ad8\u3055\u3092\u7e2e\u5c0f
+menu.title.grid.increase.column.span = \u5217\u306e\u5e45\u3092\u62e1\u5927
+menu.title.grid.decrease.column.span = \u5217\u306e\u5e45\u3092\u7e2e\u5c0f
 # Modify -> Scene Size
-menu.title.size.phone = 335 x 600 (電話)
-menu.title.size.tablet = 900 x 600 (タブレット)
+menu.title.size.phone = 335 x 600 (\u96fb\u8a71)
+menu.title.size.tablet = 900 x 600 (\u30bf\u30d6\u30ec\u30c3\u30c8)
 menu.title.size.qvga = 320 x 240 (QVGA)
 menu.title.size.vga = 640 x 480 (VGA)
 menu.title.size.touch = 1280 x 800
 menu.title.size.hd = 1920 x 1080
 # Arrange menu items
-menu.title.front = 最前面へ移動(B)
-menu.title.back = 最背面へ移動(S)
-menu.title.forward = 前に配置(O)
-menu.title.backward = 後ろに配置(C)
-menu.title.wrap = ラップ(R)
-menu.title.unwrap = アンラップ(U)
+menu.title.front = \u6700\u524d\u9762\u3078\u79fb\u52d5(B)
+menu.title.back = \u6700\u80cc\u9762\u3078\u79fb\u52d5(S)
+menu.title.forward = \u524d\u306b\u914d\u7f6e(O)
+menu.title.backward = \u5f8c\u308d\u306b\u914d\u7f6e(C)
+menu.title.wrap = \u30e9\u30c3\u30d7(R)
+menu.title.unwrap = \u30a2\u30f3\u30e9\u30c3\u30d7(U)
 # Preview menu items
-menu.title.show.preview.in.window = ウィンドウにプレビューを表示(R)
-menu.title.show.preview.in.dialog = ダイアログにプレビューを表示
-menu.title.hide.preview = ウィンドウのプレビューを非表示(R)
+menu.title.show.preview.in.window = \u30a6\u30a3\u30f3\u30c9\u30a6\u306b\u30d7\u30ec\u30d3\u30e5\u30fc\u3092\u8868\u793a(R)
+menu.title.show.preview.in.dialog = \u30c0\u30a4\u30a2\u30ed\u30b0\u306b\u30d7\u30ec\u30d3\u30e5\u30fc\u3092\u8868\u793a
+menu.title.hide.preview = \u30a6\u30a3\u30f3\u30c9\u30a6\u306e\u30d7\u30ec\u30d3\u30e5\u30fc\u3092\u975e\u8868\u793a(R)
 
-menu.title.theme = テーマ(T)
+menu.title.theme = \u30c6\u30fc\u30de(T)
 menu.title.gluon.swatch = Gluon Swatch(G)
 
-menu.title.scene.stylesheets = Sceneスタイルシート(S)
-menu.title.add.stylesheet = スタイルシートの追加...
-menu.title.remove.stylesheet = スタイルシートの削除
-menu.title.open.stylesheet = スタイルシートを開く
-menu.title.internationalization = 国際化(N)
-menu.title.set.resource = リソースの設定...
-menu.title.remove.resource = リソースの削除
-menu.title.remove.resource.with.file = リソース "{0}" の削除
-menu.title.reveal.resource = リソースの表示
-menu.title.reveal.resource.with.file = リソース ""{0} の表示
-menu.title.resolve.unknown.types = 不明なタイプの解決...
-menu.title.preview.size = サイズのプレビュー(Z)
-menu.title.size = Sceneのサイズ(Z)
+menu.title.scene.stylesheets = Scene\u30b9\u30bf\u30a4\u30eb\u30b7\u30fc\u30c8(S)
+menu.title.add.stylesheet = \u30b9\u30bf\u30a4\u30eb\u30b7\u30fc\u30c8\u306e\u8ffd\u52a0...
+menu.title.remove.stylesheet = \u30b9\u30bf\u30a4\u30eb\u30b7\u30fc\u30c8\u306e\u524a\u9664
+menu.title.open.stylesheet = \u30b9\u30bf\u30a4\u30eb\u30b7\u30fc\u30c8\u3092\u958b\u304f
+menu.title.internationalization = \u56fd\u969b\u5316(N)
+menu.title.set.resource = \u30ea\u30bd\u30fc\u30b9\u306e\u8a2d\u5b9a...
+menu.title.remove.resource = \u30ea\u30bd\u30fc\u30b9\u306e\u524a\u9664
+menu.title.remove.resource.with.file = \u30ea\u30bd\u30fc\u30b9 "{0}" \u306e\u524a\u9664
+menu.title.reveal.resource = \u30ea\u30bd\u30fc\u30b9\u306e\u8868\u793a
+menu.title.reveal.resource.with.file = \u30ea\u30bd\u30fc\u30b9 ""{0} \u306e\u8868\u793a
+menu.title.resolve.unknown.types = \u4e0d\u660e\u306a\u30bf\u30a4\u30d7\u306e\u89e3\u6c7a...
+menu.title.preview.size = \u30b5\u30a4\u30ba\u306e\u30d7\u30ec\u30d3\u30e5\u30fc(Z)
+menu.title.size = Scene\u306e\u30b5\u30a4\u30ba(Z)
 menu.title.size.preferred = Preferred Size
 menu.title.size.preferred.with.value = Preferred Size ({0} x {1})
 # Window menu items
-menu.title.no.window = ウィンドウ
+menu.title.no.window = \u30a6\u30a3\u30f3\u30c9\u30a6
 # Help menu items
-menu.title.scene.builder.help = Scene Builderヘルプ
-menu.title.check.updates = 更新の確認...
-menu.title.about = Scene Builderバージョン情報
+menu.title.scene.builder.help = Scene Builder\u30d8\u30eb\u30d7
+menu.title.check.updates = \u66f4\u65b0\u306e\u78ba\u8a8d...
+menu.title.about = Scene Builder\u30d0\u30fc\u30b8\u30e7\u30f3\u60c5\u5831
 
 # -----------------------------------------------------------------------------
 # Document
 # -----------------------------------------------------------------------------
-document = ドキュメント
+document = \u30c9\u30ad\u30e5\u30e1\u30f3\u30c8
 
 # -----------------------------------------------------------------------------
 # Hierarchy
 # -----------------------------------------------------------------------------
-hierarchy = 階層
-hierarchy.displays = 階層の表示
-hierarchy.show.info = 情報
+hierarchy = \u968e\u5c64
+hierarchy.displays = \u968e\u5c64\u306e\u8868\u793a
+hierarchy.show.info = \u60c5\u5831
 hierarchy.show.fxid = fx:id
-hierarchy.show.nodeid = ノードID
+hierarchy.show.nodeid = \u30ce\u30fc\u30c9ID
 
 # -----------------------------------------------------------------------------
 # Controller
 # -----------------------------------------------------------------------------
-controller = コントローラController
+controller = \u30b3\u30f3\u30c8\u30ed\u30fc\u30e9Controller
 
 # -----------------------------------------------------------------------------
 # Inspector
 # -----------------------------------------------------------------------------
-inspector = インスペクタ
-inspector.show.all = すべて表示
-inspector.show.edited = 編集済を表示
-inspector.view.sections = セクションの表示
-inspector.by.property.name = プロパティ名別に表示
-inspector.by.property.type = プロパティ・タイプ別に表示
+inspector = \u30a4\u30f3\u30b9\u30da\u30af\u30bf
+inspector.show.all = \u3059\u3079\u3066\u8868\u793a
+inspector.show.edited = \u7de8\u96c6\u6e08\u3092\u8868\u793a
+inspector.view.sections = \u30bb\u30af\u30b7\u30e7\u30f3\u306e\u8868\u793a
+inspector.by.property.name = \u30d7\u30ed\u30d1\u30c6\u30a3\u540d\u5225\u306b\u8868\u793a
+inspector.by.property.type = \u30d7\u30ed\u30d1\u30c6\u30a3\u30fb\u30bf\u30a4\u30d7\u5225\u306b\u8868\u793a
 
 # -----------------------------------------------------------------------------
 # Preferences Window
 # -----------------------------------------------------------------------------
-prefs.title = プリファレンス
-prefs.alignment.guides = 位置合せガイドの色:
-prefs.doc.width = デフォルトのルート・コンテナの幅:
-prefs.doc.height = デフォルトのルート・コンテナの高さ:
-prefs.drop.ring = ドロップおよび親リングの色:
-prefs.tooltheme = Scene Builderテーマ:
-prefs.library.displayoption = ライブラリに表示されるデフォルト・ビュー:
-prefs.hierarchy.displayoption = F階層に表示されるデフォルト情報:
-prefs.revert = 組込みデフォルト値に戻す
-prefs.background = 背景イメージ:
-prefs.cssanalyzer.columns.order = CSSアナライザの列順序:
-prefs.cssanalyzer.columns.defaults.first = "デフォルト"列が最初
-prefs.cssanalyzer.columns.defaults.last = "デフォルト"列が最後
-prefs.recent.items = 最近のアイテム
-prefs.reset.default = 組込みデフォルト値に戻す
-prefs.document.theme = デフォルトのテーマ:
-prefs.document.gluonswatch = デフォルトのGluon Swatch :
-prefs.document.gluontheme = デフォルトのGluonテーマ:
+prefs.title = \u30d7\u30ea\u30d5\u30a1\u30ec\u30f3\u30b9
+prefs.alignment.guides = \u4f4d\u7f6e\u5408\u305b\u30ac\u30a4\u30c9\u306e\u8272:
+prefs.doc.width = \u30c7\u30d5\u30a9\u30eb\u30c8\u306e\u30eb\u30fc\u30c8\u30fb\u30b3\u30f3\u30c6\u30ca\u306e\u5e45:
+prefs.doc.height = \u30c7\u30d5\u30a9\u30eb\u30c8\u306e\u30eb\u30fc\u30c8\u30fb\u30b3\u30f3\u30c6\u30ca\u306e\u9ad8\u3055:
+prefs.drop.ring = \u30c9\u30ed\u30c3\u30d7\u304a\u3088\u3073\u89aa\u30ea\u30f3\u30b0\u306e\u8272:
+prefs.tooltheme = Scene Builder\u30c6\u30fc\u30de:
+prefs.library.displayoption = \u30e9\u30a4\u30d6\u30e9\u30ea\u306b\u8868\u793a\u3055\u308c\u308b\u30c7\u30d5\u30a9\u30eb\u30c8\u30fb\u30d3\u30e5\u30fc:
+prefs.hierarchy.displayoption = F\u968e\u5c64\u306b\u8868\u793a\u3055\u308c\u308b\u30c7\u30d5\u30a9\u30eb\u30c8\u60c5\u5831:
+prefs.revert = \u7d44\u8fbc\u307f\u30c7\u30d5\u30a9\u30eb\u30c8\u5024\u306b\u623b\u3059
+prefs.background = \u80cc\u666f\u30a4\u30e1\u30fc\u30b8:
+prefs.cssanalyzer.columns.order = CSS\u30a2\u30ca\u30e9\u30a4\u30b6\u306e\u5217\u9806\u5e8f:
+prefs.cssanalyzer.columns.defaults.first = "\u30c7\u30d5\u30a9\u30eb\u30c8"\u5217\u304c\u6700\u521d
+prefs.cssanalyzer.columns.defaults.last = "\u30c7\u30d5\u30a9\u30eb\u30c8"\u5217\u304c\u6700\u5f8c
+prefs.recent.items = \u6700\u8fd1\u306e\u30a2\u30a4\u30c6\u30e0
+prefs.reset.default = \u7d44\u8fbc\u307f\u30c7\u30d5\u30a9\u30eb\u30c8\u5024\u306b\u623b\u3059
+prefs.document.theme = \u30c7\u30d5\u30a9\u30eb\u30c8\u306e\u30c6\u30fc\u30de:
+prefs.document.gluonswatch = \u30c7\u30d5\u30a9\u30eb\u30c8\u306eGluon Swatch :
+prefs.document.gluontheme = \u30c7\u30d5\u30a9\u30eb\u30c8\u306eGluon\u30c6\u30fc\u30de:
 
 # -----------------------------------------------------------------------------
 # Template Dialog
 # -----------------------------------------------------------------------------
-template.label.name = 名前:
-template.label.location = 場所:
-template.button.choose = 選択...
-template.details.title = 次のファイルが作成されます:
-template.title.new.project = 新規{0}プロジェクト
-template.location.does.not.exist = 場所{0}は存在しません
-template.name.already.exists = ディレクトリ"{0}"はすでに存在します
-template.cannot.create = "{0}"を作成できません
-template.cannot.save.file = ファイルを保存できません: {0}
+template.label.name = \u540d\u524d:
+template.label.location = \u5834\u6240:
+template.button.choose = \u9078\u629e...
+template.details.title = \u6b21\u306e\u30d5\u30a1\u30a4\u30eb\u304c\u4f5c\u6210\u3055\u308c\u307e\u3059:
+template.title.new.project = \u65b0\u898f{0}\u30d7\u30ed\u30b8\u30a7\u30af\u30c8
+template.location.does.not.exist = \u5834\u6240{0}\u306f\u5b58\u5728\u3057\u307e\u305b\u3093
+template.name.already.exists = \u30c7\u30a3\u30ec\u30af\u30c8\u30ea"{0}"\u306f\u3059\u3067\u306b\u5b58\u5728\u3057\u307e\u3059
+template.cannot.create = "{0}"\u3092\u4f5c\u6210\u3067\u304d\u307e\u305b\u3093
+template.cannot.save.file = \u30d5\u30a1\u30a4\u30eb\u3092\u4fdd\u5b58\u3067\u304d\u307e\u305b\u3093: {0}
 
 # -----------------------------------------------------------------------------
 # Library Menu within Library panel
 # -----------------------------------------------------------------------------
-library = ライブラリ
-library.panel.menu.manage.jar.fxml = JAR/FXMLマネージャ
-library.panel.menu.import.selection = 選択範囲のインポート
+library = \u30e9\u30a4\u30d6\u30e9\u30ea
+library.panel.menu.manage.jar.fxml = JAR/FXML\u30de\u30cd\u30fc\u30b8\u30e3
+library.panel.menu.import.selection = \u9078\u629e\u7bc4\u56f2\u306e\u30a4\u30f3\u30dd\u30fc\u30c8
 # Messages below are temporarily unused
-#library.panel.menu.category.view = ライブラリ・カテゴリの表示
-#library.panel.menu.category.create = ライブラリ・カテゴリの作成
-#library.panel.menu.category.remove = ライブラリ・カテゴリの削除
-#library.panel.menu.item.move = カスタム・アイテムの移動
-#library.panel.menu.item.rename = カスタム・アイテムの名前を変更
-#library.panel.menu.item.remove = カスタム・アイテムの削除
-library.panel.menu.view.list = リストの表示
-library.panel.menu.view.sections = セクションの表示
-library.panel.menu.custom = カスタム・ライブラリ・フォルダー
-library.panel.menu.custom.report = JAR解析レポートの表示
+#library.panel.menu.category.view = \u30e9\u30a4\u30d6\u30e9\u30ea\u30fb\u30ab\u30c6\u30b4\u30ea\u306e\u8868\u793a
+#library.panel.menu.category.create = \u30e9\u30a4\u30d6\u30e9\u30ea\u30fb\u30ab\u30c6\u30b4\u30ea\u306e\u4f5c\u6210
+#library.panel.menu.category.remove = \u30e9\u30a4\u30d6\u30e9\u30ea\u30fb\u30ab\u30c6\u30b4\u30ea\u306e\u524a\u9664
+#library.panel.menu.item.move = \u30ab\u30b9\u30bf\u30e0\u30fb\u30a2\u30a4\u30c6\u30e0\u306e\u79fb\u52d5
+#library.panel.menu.item.rename = \u30ab\u30b9\u30bf\u30e0\u30fb\u30a2\u30a4\u30c6\u30e0\u306e\u540d\u524d\u3092\u5909\u66f4
+#library.panel.menu.item.remove = \u30ab\u30b9\u30bf\u30e0\u30fb\u30a2\u30a4\u30c6\u30e0\u306e\u524a\u9664
+library.panel.menu.view.list = \u30ea\u30b9\u30c8\u306e\u8868\u793a
+library.panel.menu.view.sections = \u30bb\u30af\u30b7\u30e7\u30f3\u306e\u8868\u793a
+library.panel.menu.custom = \u30ab\u30b9\u30bf\u30e0\u30fb\u30e9\u30a4\u30d6\u30e9\u30ea\u30fb\u30d5\u30a9\u30eb\u30c0\u30fc
+library.panel.menu.custom.report = JAR\u89e3\u6790\u30ec\u30dd\u30fc\u30c8\u306e\u8868\u793a
 
 # -----------------------------------------------------------------------------
 # About Window
 # -----------------------------------------------------------------------------
-about.title = JavaFX Scene Builderバージョン情報
-about.build.information = ビルド情報
-about.build.date = 日付: {0}
-about.build.java.version = Javaバージョン: {0}
-about.copyright = Copyright (c) 2012, 2014, Oracle and/or its affiliates. All rights reserved.\n\nこのソフトウェアおよび関連ドキュメントの使用と開示は、ライセンス契約の制約条件に従うものとし、知的財産に関する法律により保護されています。ライセンス契約で明示的に許諾されている場合もしくは法律によって認められている場合を除き、形式、手段に関係なく、いかなる部分も使用、複写、複製、翻訳、放送、修正、ライセンス供与、送信、配布、発表、実行、公開または表示することはできません。このソフトウェアのリバース・エンジニアリング、逆アセンブル、逆コンパイルは互換性のために法律によって規定されている場合を除き、禁止されています。\n\nここに記載された情報は予告なしに変更される場合があります。また、誤りがないことの保証はいたしかねます。\n\n誤りを見つけた場合は、オラクル社までご連絡ください。このソフトウェアまたは関連ドキュメントが、米国政府機関もしくは米国政府機関に代わってこのソフトウェアまたは関連ドキュメントをライセンスされた者に提供される場合は、次のNoticeが適用されます。Government, the following notice is applicable:\n\nU.S. GOVERNMENT RIGHTS Programs, software, databases, and related documentation and technical data delivered to U.S. Government customers are "commercial computer software" or "commercial technical data" pursuant to the applicable Federal Acquisition Regulation and agency-specific supplemental regulations. As such, the use, duplication, disclosure, modification, and adaptation shall be subject to the restrictions and license terms set forth in the applicable Government contract, and, to the extent applicable by the terms of the Government contract, the additional rights set forth in FAR 52.227-19, Commercial Computer Software License (December 2007). Oracle USA, Inc., 500 Oracle Parkway, Redwood City, CA 94065.\n\nこのソフトウェアは様々な情報管理アプリケーションでの一般的な使用のために開発されたものです。このソフトウェアは、危険が伴うアプリケーション(人的傷害を発生させる可能性があるアプリケーションを含む)への用途を目的として開発されていません。このソフトウェアを危険が伴うアプリケーションで使用する際、このソフトウェアを安全に使用するために、適切な安全装置、バックアップ、冗長性(redundancy)、その他の対策を講じることは使用者の責任となります。このソフトウェアを危険が伴うアプリケーションで使用したことに起因して損害が発生しても、オラクル社およびその関連会社は一切の責任を負いかねます。\n\nOracleはOracle Corporationおよびその関連企業の登録商標です。その他の名称は、それぞれの所有者の商標または登録商標です。\n\nこのソフトウェアおよびドキュメントは、第三者のコンテンツ、製品、サービスへのアクセス、あるいはそれらに関する情報を提供することがあります。オラクル社およびその関連会社は、第三者のコンテンツ、製品、サービスに関して一切の責任を負わず、いかなる保証もいたしません。オラクル社およびその関連会社は、第三者のコンテンツ、製品、サービスへのアクセスまたは使用によって損失、費用、あるいは損害が発生しても、一切の責任を負いかねます。
+about.title = JavaFX Scene Builder\u30d0\u30fc\u30b8\u30e7\u30f3\u60c5\u5831
+about.build.information = \u30d3\u30eb\u30c9\u60c5\u5831
+about.build.date = \u65e5\u4ed8: {0}
+about.build.java.version = Java\u30d0\u30fc\u30b8\u30e7\u30f3: {0}
+about.copyright = Copyright (c) 2012, 2014, Oracle and/or its affiliates. All rights reserved.\n\n\u3053\u306e\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u304a\u3088\u3073\u95a2\u9023\u30c9\u30ad\u30e5\u30e1\u30f3\u30c8\u306e\u4f7f\u7528\u3068\u958b\u793a\u306f\u3001\u30e9\u30a4\u30bb\u30f3\u30b9\u5951\u7d04\u306e\u5236\u7d04\u6761\u4ef6\u306b\u5f93\u3046\u3082\u306e\u3068\u3057\u3001\u77e5\u7684\u8ca1\u7523\u306b\u95a2\u3059\u308b\u6cd5\u5f8b\u306b\u3088\u308a\u4fdd\u8b77\u3055\u308c\u3066\u3044\u307e\u3059\u3002\u30e9\u30a4\u30bb\u30f3\u30b9\u5951\u7d04\u3067\u660e\u793a\u7684\u306b\u8a31\u8afe\u3055\u308c\u3066\u3044\u308b\u5834\u5408\u3082\u3057\u304f\u306f\u6cd5\u5f8b\u306b\u3088\u3063\u3066\u8a8d\u3081\u3089\u308c\u3066\u3044\u308b\u5834\u5408\u3092\u9664\u304d\u3001\u5f62\u5f0f\u3001\u624b\u6bb5\u306b\u95a2\u4fc2\u306a\u304f\u3001\u3044\u304b\u306a\u308b\u90e8\u5206\u3082\u4f7f\u7528\u3001\u8907\u5199\u3001\u8907\u88fd\u3001\u7ffb\u8a33\u3001\u653e\u9001\u3001\u4fee\u6b63\u3001\u30e9\u30a4\u30bb\u30f3\u30b9\u4f9b\u4e0e\u3001\u9001\u4fe1\u3001\u914d\u5e03\u3001\u767a\u8868\u3001\u5b9f\u884c\u3001\u516c\u958b\u307e\u305f\u306f\u8868\u793a\u3059\u308b\u3053\u3068\u306f\u3067\u304d\u307e\u305b\u3093\u3002\u3053\u306e\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u306e\u30ea\u30d0\u30fc\u30b9\u30fb\u30a8\u30f3\u30b8\u30cb\u30a2\u30ea\u30f3\u30b0\u3001\u9006\u30a2\u30bb\u30f3\u30d6\u30eb\u3001\u9006\u30b3\u30f3\u30d1\u30a4\u30eb\u306f\u4e92\u63db\u6027\u306e\u305f\u3081\u306b\u6cd5\u5f8b\u306b\u3088\u3063\u3066\u898f\u5b9a\u3055\u308c\u3066\u3044\u308b\u5834\u5408\u3092\u9664\u304d\u3001\u7981\u6b62\u3055\u308c\u3066\u3044\u307e\u3059\u3002\n\n\u3053\u3053\u306b\u8a18\u8f09\u3055\u308c\u305f\u60c5\u5831\u306f\u4e88\u544a\u306a\u3057\u306b\u5909\u66f4\u3055\u308c\u308b\u5834\u5408\u304c\u3042\u308a\u307e\u3059\u3002\u307e\u305f\u3001\u8aa4\u308a\u304c\u306a\u3044\u3053\u3068\u306e\u4fdd\u8a3c\u306f\u3044\u305f\u3057\u304b\u306d\u307e\u3059\u3002\n\n\u8aa4\u308a\u3092\u898b\u3064\u3051\u305f\u5834\u5408\u306f\u3001\u30aa\u30e9\u30af\u30eb\u793e\u307e\u3067\u3054\u9023\u7d61\u304f\u3060\u3055\u3044\u3002\u3053\u306e\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u307e\u305f\u306f\u95a2\u9023\u30c9\u30ad\u30e5\u30e1\u30f3\u30c8\u304c\u3001\u7c73\u56fd\u653f\u5e9c\u6a5f\u95a2\u3082\u3057\u304f\u306f\u7c73\u56fd\u653f\u5e9c\u6a5f\u95a2\u306b\u4ee3\u308f\u3063\u3066\u3053\u306e\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u307e\u305f\u306f\u95a2\u9023\u30c9\u30ad\u30e5\u30e1\u30f3\u30c8\u3092\u30e9\u30a4\u30bb\u30f3\u30b9\u3055\u308c\u305f\u8005\u306b\u63d0\u4f9b\u3055\u308c\u308b\u5834\u5408\u306f\u3001\u6b21\u306eNotice\u304c\u9069\u7528\u3055\u308c\u307e\u3059\u3002Government, the following notice is applicable:\n\nU.S. GOVERNMENT RIGHTS Programs, software, databases, and related documentation and technical data delivered to U.S. Government customers are "commercial computer software" or "commercial technical data" pursuant to the applicable Federal Acquisition Regulation and agency-specific supplemental regulations. As such, the use, duplication, disclosure, modification, and adaptation shall be subject to the restrictions and license terms set forth in the applicable Government contract, and, to the extent applicable by the terms of the Government contract, the additional rights set forth in FAR 52.227-19, Commercial Computer Software License (December 2007). Oracle USA, Inc., 500 Oracle Parkway, Redwood City, CA 94065.\n\n\u3053\u306e\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u306f\u69d8\u3005\u306a\u60c5\u5831\u7ba1\u7406\u30a2\u30d7\u30ea\u30b1\u30fc\u30b7\u30e7\u30f3\u3067\u306e\u4e00\u822c\u7684\u306a\u4f7f\u7528\u306e\u305f\u3081\u306b\u958b\u767a\u3055\u308c\u305f\u3082\u306e\u3067\u3059\u3002\u3053\u306e\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u306f\u3001\u5371\u967a\u304c\u4f34\u3046\u30a2\u30d7\u30ea\u30b1\u30fc\u30b7\u30e7\u30f3(\u4eba\u7684\u50b7\u5bb3\u3092\u767a\u751f\u3055\u305b\u308b\u53ef\u80fd\u6027\u304c\u3042\u308b\u30a2\u30d7\u30ea\u30b1\u30fc\u30b7\u30e7\u30f3\u3092\u542b\u3080)\u3078\u306e\u7528\u9014\u3092\u76ee\u7684\u3068\u3057\u3066\u958b\u767a\u3055\u308c\u3066\u3044\u307e\u305b\u3093\u3002\u3053\u306e\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u3092\u5371\u967a\u304c\u4f34\u3046\u30a2\u30d7\u30ea\u30b1\u30fc\u30b7\u30e7\u30f3\u3067\u4f7f\u7528\u3059\u308b\u969b\u3001\u3053\u306e\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u3092\u5b89\u5168\u306b\u4f7f\u7528\u3059\u308b\u305f\u3081\u306b\u3001\u9069\u5207\u306a\u5b89\u5168\u88c5\u7f6e\u3001\u30d0\u30c3\u30af\u30a2\u30c3\u30d7\u3001\u5197\u9577\u6027(redundancy)\u3001\u305d\u306e\u4ed6\u306e\u5bfe\u7b56\u3092\u8b1b\u3058\u308b\u3053\u3068\u306f\u4f7f\u7528\u8005\u306e\u8cac\u4efb\u3068\u306a\u308a\u307e\u3059\u3002\u3053\u306e\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u3092\u5371\u967a\u304c\u4f34\u3046\u30a2\u30d7\u30ea\u30b1\u30fc\u30b7\u30e7\u30f3\u3067\u4f7f\u7528\u3057\u305f\u3053\u3068\u306b\u8d77\u56e0\u3057\u3066\u640d\u5bb3\u304c\u767a\u751f\u3057\u3066\u3082\u3001\u30aa\u30e9\u30af\u30eb\u793e\u304a\u3088\u3073\u305d\u306e\u95a2\u9023\u4f1a\u793e\u306f\u4e00\u5207\u306e\u8cac\u4efb\u3092\u8ca0\u3044\u304b\u306d\u307e\u3059\u3002\n\nOracle\u306fOracle Corporation\u304a\u3088\u3073\u305d\u306e\u95a2\u9023\u4f01\u696d\u306e\u767b\u9332\u5546\u6a19\u3067\u3059\u3002\u305d\u306e\u4ed6\u306e\u540d\u79f0\u306f\u3001\u305d\u308c\u305e\u308c\u306e\u6240\u6709\u8005\u306e\u5546\u6a19\u307e\u305f\u306f\u767b\u9332\u5546\u6a19\u3067\u3059\u3002\n\n\u3053\u306e\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u304a\u3088\u3073\u30c9\u30ad\u30e5\u30e1\u30f3\u30c8\u306f\u3001\u7b2c\u4e09\u8005\u306e\u30b3\u30f3\u30c6\u30f3\u30c4\u3001\u88fd\u54c1\u3001\u30b5\u30fc\u30d3\u30b9\u3078\u306e\u30a2\u30af\u30bb\u30b9\u3001\u3042\u308b\u3044\u306f\u305d\u308c\u3089\u306b\u95a2\u3059\u308b\u60c5\u5831\u3092\u63d0\u4f9b\u3059\u308b\u3053\u3068\u304c\u3042\u308a\u307e\u3059\u3002\u30aa\u30e9\u30af\u30eb\u793e\u304a\u3088\u3073\u305d\u306e\u95a2\u9023\u4f1a\u793e\u306f\u3001\u7b2c\u4e09\u8005\u306e\u30b3\u30f3\u30c6\u30f3\u30c4\u3001\u88fd\u54c1\u3001\u30b5\u30fc\u30d3\u30b9\u306b\u95a2\u3057\u3066\u4e00\u5207\u306e\u8cac\u4efb\u3092\u8ca0\u308f\u305a\u3001\u3044\u304b\u306a\u308b\u4fdd\u8a3c\u3082\u3044\u305f\u3057\u307e\u305b\u3093\u3002\u30aa\u30e9\u30af\u30eb\u793e\u304a\u3088\u3073\u305d\u306e\u95a2\u9023\u4f1a\u793e\u306f\u3001\u7b2c\u4e09\u8005\u306e\u30b3\u30f3\u30c6\u30f3\u30c4\u3001\u88fd\u54c1\u3001\u30b5\u30fc\u30d3\u30b9\u3078\u306e\u30a2\u30af\u30bb\u30b9\u307e\u305f\u306f\u4f7f\u7528\u306b\u3088\u3063\u3066\u640d\u5931\u3001\u8cbb\u7528\u3001\u3042\u308b\u3044\u306f\u640d\u5bb3\u304c\u767a\u751f\u3057\u3066\u3082\u3001\u4e00\u5207\u306e\u8cac\u4efb\u3092\u8ca0\u3044\u304b\u306d\u307e\u3059\u3002
 about.copyright.open = Copyright (c) 2015-2017, Gluon.\nAll rights reserved. Use is subject to license terms.\n\nThis file is available and licensed under the following license:\n\nRedistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:\n\n - Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.\n - Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.\n - Neither the name of Gluon nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.\n\nTHIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 # Hardware acceleration is a boolean: its value depends on the FX toolkit and pipeline in use.
-about.fx.hardware.acceleration = ハードウェア・アクセラレーション
-about.fx.hardware.acceleration.enabled = 有効
-about.fx.hardware.acceleration.disabled = 無効
-about.fx.pipeline = パイプライン
-about.fx.toolkit = ツールキット
-about.logging.title = ログ
-about.logging.body.first = デフォルト設定でのログ出力の保存先は{0}というファイルです (後ろに ''.'' および番号が付くこともあります)。
-about.logging.body.second = デフォルトのファイル・パスは{0}です
-about.operating.system = オペレーティング・システム
-about.product.version = 製品バージョン
+about.fx.hardware.acceleration = \u30cf\u30fc\u30c9\u30a6\u30a7\u30a2\u30fb\u30a2\u30af\u30bb\u30e9\u30ec\u30fc\u30b7\u30e7\u30f3
+about.fx.hardware.acceleration.enabled = \u6709\u52b9
+about.fx.hardware.acceleration.disabled = \u7121\u52b9
+about.fx.pipeline = \u30d1\u30a4\u30d7\u30e9\u30a4\u30f3
+about.fx.toolkit = \u30c4\u30fc\u30eb\u30ad\u30c3\u30c8
+about.logging.title = \u30ed\u30b0
+about.logging.body.first = \u30c7\u30d5\u30a9\u30eb\u30c8\u8a2d\u5b9a\u3067\u306e\u30ed\u30b0\u51fa\u529b\u306e\u4fdd\u5b58\u5148\u306f{0}\u3068\u3044\u3046\u30d5\u30a1\u30a4\u30eb\u3067\u3059 (\u5f8c\u308d\u306b ''.'' \u304a\u3088\u3073\u756a\u53f7\u304c\u4ed8\u304f\u3053\u3068\u3082\u3042\u308a\u307e\u3059)\u3002
+about.logging.body.second = \u30c7\u30d5\u30a9\u30eb\u30c8\u306e\u30d5\u30a1\u30a4\u30eb\u30fb\u30d1\u30b9\u306f{0}\u3067\u3059
+about.operating.system = \u30aa\u30da\u30ec\u30fc\u30c6\u30a3\u30f3\u30b0\u30fb\u30b7\u30b9\u30c6\u30e0
+about.product.version = \u88fd\u54c1\u30d0\u30fc\u30b8\u30e7\u30f3
 
 # -----------------------------------------------------------------------------
 # Themes
@@ -304,18 +304,18 @@ title.theme.gluon_mobile_dark = Gluon Mobile Dark
 title.theme.gluon_mobile_light = Gluon Mobile Light
 title.theme.modena = Modena (FX8)
 title.theme.modena_touch = Modena Touch (FX8)
-title.theme.modena_high_contrast_black_on_white = Modena高コントラスト - 白地に黒 (FX8)
-title.theme.modena_high_contrast_white_on_black = Modena高コントラスト - 黒地に白 (FX8)
-title.theme.modena_high_contrast_yellow_on_black = Modena高コントラスト - 黒地に黄 (FX8)
-title.theme.modena_touch_high_contrast_black_on_white = Modena Touch高コントラスト - 白地に黒 (FX8)
-title.theme.modena_touch_high_contrast_white_on_black = Modena Touch高コントラスト - 黒地に白 (FX8)
-title.theme.modena_touch_high_contrast_yellow_on_black = Modena Touch高コントラスト - 黒地に黄 (FX8)
+title.theme.modena_high_contrast_black_on_white = Modena\u9ad8\u30b3\u30f3\u30c8\u30e9\u30b9\u30c8 - \u767d\u5730\u306b\u9ed2 (FX8)
+title.theme.modena_high_contrast_white_on_black = Modena\u9ad8\u30b3\u30f3\u30c8\u30e9\u30b9\u30c8 - \u9ed2\u5730\u306b\u767d (FX8)
+title.theme.modena_high_contrast_yellow_on_black = Modena\u9ad8\u30b3\u30f3\u30c8\u30e9\u30b9\u30c8 - \u9ed2\u5730\u306b\u9ec4 (FX8)
+title.theme.modena_touch_high_contrast_black_on_white = Modena Touch\u9ad8\u30b3\u30f3\u30c8\u30e9\u30b9\u30c8 - \u767d\u5730\u306b\u9ed2 (FX8)
+title.theme.modena_touch_high_contrast_white_on_black = Modena Touch\u9ad8\u30b3\u30f3\u30c8\u30e9\u30b9\u30c8 - \u9ed2\u5730\u306b\u767d (FX8)
+title.theme.modena_touch_high_contrast_yellow_on_black = Modena Touch\u9ad8\u30b3\u30f3\u30c8\u30e9\u30b9\u30c8 - \u9ed2\u5730\u306b\u9ec4 (FX8)
 title.theme.caspian = Caspian (FX2)
 title.theme.caspian_embedded = Caspian Embedded (FX2)
 title.theme.caspian_embedded_qvga = Caspian Embedded QVGA (FX2)
-title.theme.caspian_high_contrast = Caspian高コントラスト (FX2)
-title.theme.caspian_embedded_high_contrast = Caspian Embedded高コントラスト (FX2)
-title.theme.caspian_embedded_qvga_high_contrast = Caspian Embedded QVGA高コントラスト (FX2)
+title.theme.caspian_high_contrast = Caspian\u9ad8\u30b3\u30f3\u30c8\u30e9\u30b9\u30c8 (FX2)
+title.theme.caspian_embedded_high_contrast = Caspian Embedded\u9ad8\u30b3\u30f3\u30c8\u30e9\u30b9\u30c8 (FX2)
+title.theme.caspian_embedded_qvga_high_contrast = Caspian Embedded QVGA\u9ad8\u30b3\u30f3\u30c8\u30e9\u30b9\u30c8 (FX2)
 # Gluon Swatches
 title.gluon.swatch.blue = Blue Swatch
 title.gluon.swatch.cyan = Cyan Swatch
@@ -343,187 +343,187 @@ title.gluon.theme.dark = Dark Theme
 # -----------------------------------------------------------------------------
 # Registration Window
 # -----------------------------------------------------------------------------
-registration.title = Gluonに登録
-registration.info = JavaFX Scene Builderへようこそ。JavaFXのユーザ・インターフェイスを素早く作るのに最高の手段です。更新、新機能、技術的なtipsなどをお知らせするために、ご連絡を取れるようにしたいと思っています。お知らせを希望しない場合は、下のチェックボックスのチェックを外してください。
-registration.alert.invalid_email_address = 正しい電子メール・アドレスが必要です。
-registration.email_address = 電子メール・アドレス:
-registration.opt_in = 最新情報を受け取る
-registration.register = 登録
-registration.cancel = 取消
+registration.title = Gluon\u306b\u767b\u9332
+registration.info = JavaFX Scene Builder\u3078\u3088\u3046\u3053\u305d\u3002JavaFX\u306e\u30e6\u30fc\u30b6\u30fb\u30a4\u30f3\u30bf\u30fc\u30d5\u30a7\u30a4\u30b9\u3092\u7d20\u65e9\u304f\u4f5c\u308b\u306e\u306b\u6700\u9ad8\u306e\u624b\u6bb5\u3067\u3059\u3002\u66f4\u65b0\u3001\u65b0\u6a5f\u80fd\u3001\u6280\u8853\u7684\u306atips\u306a\u3069\u3092\u304a\u77e5\u3089\u305b\u3059\u308b\u305f\u3081\u306b\u3001\u3054\u9023\u7d61\u3092\u53d6\u308c\u308b\u3088\u3046\u306b\u3057\u305f\u3044\u3068\u601d\u3063\u3066\u3044\u307e\u3059\u3002\u304a\u77e5\u3089\u305b\u3092\u5e0c\u671b\u3057\u306a\u3044\u5834\u5408\u306f\u3001\u4e0b\u306e\u30c1\u30a7\u30c3\u30af\u30dc\u30c3\u30af\u30b9\u306e\u30c1\u30a7\u30c3\u30af\u3092\u5916\u3057\u3066\u304f\u3060\u3055\u3044\u3002
+registration.alert.invalid_email_address = \u6b63\u3057\u3044\u96fb\u5b50\u30e1\u30fc\u30eb\u30fb\u30a2\u30c9\u30ec\u30b9\u304c\u5fc5\u8981\u3067\u3059\u3002
+registration.email_address = \u96fb\u5b50\u30e1\u30fc\u30eb\u30fb\u30a2\u30c9\u30ec\u30b9:
+registration.opt_in = \u6700\u65b0\u60c5\u5831\u3092\u53d7\u3051\u53d6\u308b
+registration.register = \u767b\u9332
+registration.cancel = \u53d6\u6d88
 
 # -----------------------------------------------------------------------------
 # Message bar
 # -----------------------------------------------------------------------------
-message.bar.file.dirty = ファイルには未保存の変更があります。
-message.bar.details = クリックすると警告メッセージのリストにアクセスします。
+message.bar.file.dirty = \u30d5\u30a1\u30a4\u30eb\u306b\u306f\u672a\u4fdd\u5b58\u306e\u5909\u66f4\u304c\u3042\u308a\u307e\u3059\u3002
+message.bar.details = \u30af\u30ea\u30c3\u30af\u3059\u308b\u3068\u8b66\u544a\u30e1\u30c3\u30bb\u30fc\u30b8\u306e\u30ea\u30b9\u30c8\u306b\u30a2\u30af\u30bb\u30b9\u3057\u307e\u3059\u3002
 
 # -----------------------------------------------------------------------------
 # Message panel
 # -----------------------------------------------------------------------------
-message.panel.clear = クリア
+message.panel.clear = \u30af\u30ea\u30a2
 
 # -----------------------------------------------------------------------------
 # Info panel
 # -----------------------------------------------------------------------------
-info.label.assigned = 割り当てられたfx:id
-info.label.component = コンポーネント
-info.label.use.fx.root = ''fx:root''構成を使用する
+info.label.assigned = \u5272\u308a\u5f53\u3066\u3089\u308c\u305ffx:id
+info.label.component = \u30b3\u30f3\u30dd\u30fc\u30cd\u30f3\u30c8
+info.label.use.fx.root = ''fx:root''\u69cb\u6210\u3092\u4f7f\u7528\u3059\u308b
 # Used after number 1
-info.label.item = アイテム
+info.label.item = \u30a2\u30a4\u30c6\u30e0
 # Used after any number greater than 1
-info.label.items = 複数アイテム
+info.label.items = \u8907\u6570\u30a2\u30a4\u30c6\u30e0
 # The parameter is the name of a Java class
-info.tooltip.controller = コントローラ・クラスは{0}を継承する必要があります
+info.tooltip.controller = \u30b3\u30f3\u30c8\u30ed\u30fc\u30e9\u30fb\u30af\u30e9\u30b9\u306f{0}\u3092\u7d99\u627f\u3059\u308b\u5fc5\u8981\u304c\u3042\u308a\u307e\u3059
 
 # -----------------------------------------------------------------------------
 # Menu Bar
 # -----------------------------------------------------------------------------
-menubar.no.lib.item = ライブラリ・アイテムなし
+menubar.no.lib.item = \u30e9\u30a4\u30d6\u30e9\u30ea\u30fb\u30a2\u30a4\u30c6\u30e0\u306a\u3057
 
 # -----------------------------------------------------------------------------
 # Alert
 # -----------------------------------------------------------------------------
-alert.title.open = 開く...
-alert.title.copy = コピー
-alert.title.start = スタートアップ
-alert.title.messagebox = 外部プログラムで開く
+alert.title.open = \u958b\u304f...
+alert.title.copy = \u30b3\u30d4\u30fc
+alert.title.start = \u30b9\u30bf\u30fc\u30c8\u30a2\u30c3\u30d7
+alert.title.messagebox = \u5916\u90e8\u30d7\u30ed\u30b0\u30e9\u30e0\u3067\u958b\u304f
 
-alert.open.failure1.message = ''{0}''を開けませんでした
-alert.open.failure1.details = 開くのに失敗しました。選択されたファイルが有効なFXMLドキュメントであることを確認してください。
-alert.open.failureN.message = 指定されたファイルを開けませんでした
-alert.open.failureN.details = 開くのに失敗しました。それらのファイルが有効なFXMLドキュメントであることを確認してください。
-alert.open.failureMofN.message = {0}個のファイルを開けませんでした
-alert.open.failureMofN.details = いくつかのファイルを開くのに失敗しました。それらのファイルが有効なFXMLドキュメントであることを確認してください。
-alert.review.question.message = ドキュメントのうち{0}個に未保存の変更があります。終了する前にそれらをレビューしますか。
-alert.review.question.details = レビューしないと、変更は失われます。
-alert.overwrite.message = ファイル''{0}''は外部で変更されました。上書きしますか。
-alert.overwrite.details = 別のアプリケーションによってファイルが変更されました。上書きすると、このアプリケーションで行った変更は破棄されます。
-alert.save.question.message = ファイル''{0}''に加えた変更を保存しますか。
-alert.save.question.details = 保存しないと、変更は失われます。
-alert.save.failure.message = ''{0}''を保存できませんでした
-alert.save.failure.details = 書込みに失敗しました。ファイル・システムとパーミッションを確認してください。
-alert.save.conflict.message = ファイル''{0}''はすでに開いています
-alert.save.conflict.details = まず閉じてから再試行してください。
-alert.start.failure.message = 開始できませんでした
-alert.start.failure.details = アプリケーションの開始中に予期しない問題が起きました。この問題をサポートに報告してください。
-alert.messagebox.failure.message = 開く操作を処理できませんでした
-alert.messagebox.failure.details = 開く操作中に予期しない問題が起きました。この問題をサポートに報告してください。
-alert.revert.question.message = 最後に保存した''{0}''に戻しますか。
-alert.revert.question.details = 現在の変更は失われます。
-alert.reveal.failure.message = ''{0}''を表示できませんでした
-alert.reveal.failure.details = 元に戻すのに失敗しました。オペレーティング・システムのログを確認してください。
-alert.copy.failure.message = コピー
-alert.help.failure.message = ''{0}''にアクセスできませんでした
-alert.delete.fxid1of1.message = このコンポーネントにはfx:idがあります。このコンポーネントを削除しますか。
-alert.delete.fxid1ofN.message = このコンポーネントにはfx:idがあります。これらのコンポーネントを削除しますか。
-alert.delete.fxidNofN.message = 一部のコンポーネントにfx:idがあります。これらのコンポーネントを削除しますか。
-alert.delete.fxidKofN.message = 一部のコンポーネントにfx:idがあります。これらのコンポーネントを削除しますか。
-alert.delete.fxid.details = fx:idが設定されたコンポーネントはアプリケーションのソース・コードから参照されている可能性があります。これらを削除すると、ソース・コードの更新が必要になります。
-alert.save.noextension.message = 本当に''{0}''を''.fxml''拡張子なしで保存しますか。
-alert.save.noextension.details = '.fxml'拡張子を付けるのか推奨されます。それによってScene Builderがファイル・システム上にあるFXMLドキュメントを認識できます。
-alert.save.noextension.details.overwrite = 註: そのファイル''{0}''は既に存在します. 置き換えると内容が上書きされます.
-alert.save.noextension.savewith = '.fxml'を付けて保存
-alert.save.noextension.savewithout = '.fxml'を付けずに保存
-alert.open.failure.charset.not.found = 指定された文字集合は設定できません。
-alert.open.failure.charset.not.found.details = ドキュメントのエンコーディングが原因の可能性があります。
+alert.open.failure1.message = ''{0}''\u3092\u958b\u3051\u307e\u305b\u3093\u3067\u3057\u305f
+alert.open.failure1.details = \u958b\u304f\u306e\u306b\u5931\u6557\u3057\u307e\u3057\u305f\u3002\u9078\u629e\u3055\u308c\u305f\u30d5\u30a1\u30a4\u30eb\u304c\u6709\u52b9\u306aFXML\u30c9\u30ad\u30e5\u30e1\u30f3\u30c8\u3067\u3042\u308b\u3053\u3068\u3092\u78ba\u8a8d\u3057\u3066\u304f\u3060\u3055\u3044\u3002
+alert.open.failureN.message = \u6307\u5b9a\u3055\u308c\u305f\u30d5\u30a1\u30a4\u30eb\u3092\u958b\u3051\u307e\u305b\u3093\u3067\u3057\u305f
+alert.open.failureN.details = \u958b\u304f\u306e\u306b\u5931\u6557\u3057\u307e\u3057\u305f\u3002\u305d\u308c\u3089\u306e\u30d5\u30a1\u30a4\u30eb\u304c\u6709\u52b9\u306aFXML\u30c9\u30ad\u30e5\u30e1\u30f3\u30c8\u3067\u3042\u308b\u3053\u3068\u3092\u78ba\u8a8d\u3057\u3066\u304f\u3060\u3055\u3044\u3002
+alert.open.failureMofN.message = {0}\u500b\u306e\u30d5\u30a1\u30a4\u30eb\u3092\u958b\u3051\u307e\u305b\u3093\u3067\u3057\u305f
+alert.open.failureMofN.details = \u3044\u304f\u3064\u304b\u306e\u30d5\u30a1\u30a4\u30eb\u3092\u958b\u304f\u306e\u306b\u5931\u6557\u3057\u307e\u3057\u305f\u3002\u305d\u308c\u3089\u306e\u30d5\u30a1\u30a4\u30eb\u304c\u6709\u52b9\u306aFXML\u30c9\u30ad\u30e5\u30e1\u30f3\u30c8\u3067\u3042\u308b\u3053\u3068\u3092\u78ba\u8a8d\u3057\u3066\u304f\u3060\u3055\u3044\u3002
+alert.review.question.message = \u30c9\u30ad\u30e5\u30e1\u30f3\u30c8\u306e\u3046\u3061{0}\u500b\u306b\u672a\u4fdd\u5b58\u306e\u5909\u66f4\u304c\u3042\u308a\u307e\u3059\u3002\u7d42\u4e86\u3059\u308b\u524d\u306b\u305d\u308c\u3089\u3092\u30ec\u30d3\u30e5\u30fc\u3057\u307e\u3059\u304b\u3002
+alert.review.question.details = \u30ec\u30d3\u30e5\u30fc\u3057\u306a\u3044\u3068\u3001\u5909\u66f4\u306f\u5931\u308f\u308c\u307e\u3059\u3002
+alert.overwrite.message = \u30d5\u30a1\u30a4\u30eb''{0}''\u306f\u5916\u90e8\u3067\u5909\u66f4\u3055\u308c\u307e\u3057\u305f\u3002\u4e0a\u66f8\u304d\u3057\u307e\u3059\u304b\u3002
+alert.overwrite.details = \u5225\u306e\u30a2\u30d7\u30ea\u30b1\u30fc\u30b7\u30e7\u30f3\u306b\u3088\u3063\u3066\u30d5\u30a1\u30a4\u30eb\u304c\u5909\u66f4\u3055\u308c\u307e\u3057\u305f\u3002\u4e0a\u66f8\u304d\u3059\u308b\u3068\u3001\u3053\u306e\u30a2\u30d7\u30ea\u30b1\u30fc\u30b7\u30e7\u30f3\u3067\u884c\u3063\u305f\u5909\u66f4\u306f\u7834\u68c4\u3055\u308c\u307e\u3059\u3002
+alert.save.question.message = \u30d5\u30a1\u30a4\u30eb''{0}''\u306b\u52a0\u3048\u305f\u5909\u66f4\u3092\u4fdd\u5b58\u3057\u307e\u3059\u304b\u3002
+alert.save.question.details = \u4fdd\u5b58\u3057\u306a\u3044\u3068\u3001\u5909\u66f4\u306f\u5931\u308f\u308c\u307e\u3059\u3002
+alert.save.failure.message = ''{0}''\u3092\u4fdd\u5b58\u3067\u304d\u307e\u305b\u3093\u3067\u3057\u305f
+alert.save.failure.details = \u66f8\u8fbc\u307f\u306b\u5931\u6557\u3057\u307e\u3057\u305f\u3002\u30d5\u30a1\u30a4\u30eb\u30fb\u30b7\u30b9\u30c6\u30e0\u3068\u30d1\u30fc\u30df\u30c3\u30b7\u30e7\u30f3\u3092\u78ba\u8a8d\u3057\u3066\u304f\u3060\u3055\u3044\u3002
+alert.save.conflict.message = \u30d5\u30a1\u30a4\u30eb''{0}''\u306f\u3059\u3067\u306b\u958b\u3044\u3066\u3044\u307e\u3059
+alert.save.conflict.details = \u307e\u305a\u9589\u3058\u3066\u304b\u3089\u518d\u8a66\u884c\u3057\u3066\u304f\u3060\u3055\u3044\u3002
+alert.start.failure.message = \u958b\u59cb\u3067\u304d\u307e\u305b\u3093\u3067\u3057\u305f
+alert.start.failure.details = \u30a2\u30d7\u30ea\u30b1\u30fc\u30b7\u30e7\u30f3\u306e\u958b\u59cb\u4e2d\u306b\u4e88\u671f\u3057\u306a\u3044\u554f\u984c\u304c\u8d77\u304d\u307e\u3057\u305f\u3002\u3053\u306e\u554f\u984c\u3092\u30b5\u30dd\u30fc\u30c8\u306b\u5831\u544a\u3057\u3066\u304f\u3060\u3055\u3044\u3002
+alert.messagebox.failure.message = \u958b\u304f\u64cd\u4f5c\u3092\u51e6\u7406\u3067\u304d\u307e\u305b\u3093\u3067\u3057\u305f
+alert.messagebox.failure.details = \u958b\u304f\u64cd\u4f5c\u4e2d\u306b\u4e88\u671f\u3057\u306a\u3044\u554f\u984c\u304c\u8d77\u304d\u307e\u3057\u305f\u3002\u3053\u306e\u554f\u984c\u3092\u30b5\u30dd\u30fc\u30c8\u306b\u5831\u544a\u3057\u3066\u304f\u3060\u3055\u3044\u3002
+alert.revert.question.message = \u6700\u5f8c\u306b\u4fdd\u5b58\u3057\u305f''{0}''\u306b\u623b\u3057\u307e\u3059\u304b\u3002
+alert.revert.question.details = \u73fe\u5728\u306e\u5909\u66f4\u306f\u5931\u308f\u308c\u307e\u3059\u3002
+alert.reveal.failure.message = ''{0}''\u3092\u8868\u793a\u3067\u304d\u307e\u305b\u3093\u3067\u3057\u305f
+alert.reveal.failure.details = \u5143\u306b\u623b\u3059\u306e\u306b\u5931\u6557\u3057\u307e\u3057\u305f\u3002\u30aa\u30da\u30ec\u30fc\u30c6\u30a3\u30f3\u30b0\u30fb\u30b7\u30b9\u30c6\u30e0\u306e\u30ed\u30b0\u3092\u78ba\u8a8d\u3057\u3066\u304f\u3060\u3055\u3044\u3002
+alert.copy.failure.message = \u30b3\u30d4\u30fc
+alert.help.failure.message = ''{0}''\u306b\u30a2\u30af\u30bb\u30b9\u3067\u304d\u307e\u305b\u3093\u3067\u3057\u305f
+alert.delete.fxid1of1.message = \u3053\u306e\u30b3\u30f3\u30dd\u30fc\u30cd\u30f3\u30c8\u306b\u306ffx:id\u304c\u3042\u308a\u307e\u3059\u3002\u3053\u306e\u30b3\u30f3\u30dd\u30fc\u30cd\u30f3\u30c8\u3092\u524a\u9664\u3057\u307e\u3059\u304b\u3002
+alert.delete.fxid1ofN.message = \u3053\u306e\u30b3\u30f3\u30dd\u30fc\u30cd\u30f3\u30c8\u306b\u306ffx:id\u304c\u3042\u308a\u307e\u3059\u3002\u3053\u308c\u3089\u306e\u30b3\u30f3\u30dd\u30fc\u30cd\u30f3\u30c8\u3092\u524a\u9664\u3057\u307e\u3059\u304b\u3002
+alert.delete.fxidNofN.message = \u4e00\u90e8\u306e\u30b3\u30f3\u30dd\u30fc\u30cd\u30f3\u30c8\u306bfx:id\u304c\u3042\u308a\u307e\u3059\u3002\u3053\u308c\u3089\u306e\u30b3\u30f3\u30dd\u30fc\u30cd\u30f3\u30c8\u3092\u524a\u9664\u3057\u307e\u3059\u304b\u3002
+alert.delete.fxidKofN.message = \u4e00\u90e8\u306e\u30b3\u30f3\u30dd\u30fc\u30cd\u30f3\u30c8\u306bfx:id\u304c\u3042\u308a\u307e\u3059\u3002\u3053\u308c\u3089\u306e\u30b3\u30f3\u30dd\u30fc\u30cd\u30f3\u30c8\u3092\u524a\u9664\u3057\u307e\u3059\u304b\u3002
+alert.delete.fxid.details = fx:id\u304c\u8a2d\u5b9a\u3055\u308c\u305f\u30b3\u30f3\u30dd\u30fc\u30cd\u30f3\u30c8\u306f\u30a2\u30d7\u30ea\u30b1\u30fc\u30b7\u30e7\u30f3\u306e\u30bd\u30fc\u30b9\u30fb\u30b3\u30fc\u30c9\u304b\u3089\u53c2\u7167\u3055\u308c\u3066\u3044\u308b\u53ef\u80fd\u6027\u304c\u3042\u308a\u307e\u3059\u3002\u3053\u308c\u3089\u3092\u524a\u9664\u3059\u308b\u3068\u3001\u30bd\u30fc\u30b9\u30fb\u30b3\u30fc\u30c9\u306e\u66f4\u65b0\u304c\u5fc5\u8981\u306b\u306a\u308a\u307e\u3059\u3002
+alert.save.noextension.message = \u672c\u5f53\u306b''{0}''\u3092''.fxml''\u62e1\u5f35\u5b50\u306a\u3057\u3067\u4fdd\u5b58\u3057\u307e\u3059\u304b\u3002
+alert.save.noextension.details = '.fxml'\u62e1\u5f35\u5b50\u3092\u4ed8\u3051\u308b\u306e\u304b\u63a8\u5968\u3055\u308c\u307e\u3059\u3002\u305d\u308c\u306b\u3088\u3063\u3066Scene Builder\u304c\u30d5\u30a1\u30a4\u30eb\u30fb\u30b7\u30b9\u30c6\u30e0\u4e0a\u306b\u3042\u308bFXML\u30c9\u30ad\u30e5\u30e1\u30f3\u30c8\u3092\u8a8d\u8b58\u3067\u304d\u307e\u3059\u3002
+alert.save.noextension.details.overwrite = \u8a3b: \u305d\u306e\u30d5\u30a1\u30a4\u30eb''{0}''\u306f\u65e2\u306b\u5b58\u5728\u3057\u307e\u3059. \u7f6e\u304d\u63db\u3048\u308b\u3068\u5185\u5bb9\u304c\u4e0a\u66f8\u304d\u3055\u308c\u307e\u3059.
+alert.save.noextension.savewith = '.fxml'\u3092\u4ed8\u3051\u3066\u4fdd\u5b58
+alert.save.noextension.savewithout = '.fxml'\u3092\u4ed8\u3051\u305a\u306b\u4fdd\u5b58
+alert.open.failure.charset.not.found = \u6307\u5b9a\u3055\u308c\u305f\u6587\u5b57\u96c6\u5408\u306f\u8a2d\u5b9a\u3067\u304d\u307e\u305b\u3093\u3002
+alert.open.failure.charset.not.found.details = \u30c9\u30ad\u30e5\u30e1\u30f3\u30c8\u306e\u30a8\u30f3\u30b3\u30fc\u30c7\u30a3\u30f3\u30b0\u304c\u539f\u56e0\u306e\u53ef\u80fd\u6027\u304c\u3042\u308a\u307e\u3059\u3002
 
 # -----------------------------------------------------------------------------
 # Log Messages
 # -----------------------------------------------------------------------------
-log.info.save.confirmation = 変更を''{0}''に保存しました
-log.info.reload = 変更を''{0}''から読み込みました
-log.info.file.deleted = ファイル''{0}''は削除されました
-log.user.exploration.0 = ユーザ・ライブラリを探索 (FXMLもJARファイルも見つかりませんでした)
-log.user.exploration.1 = ユーザ・ライブラリを探索 (''{0}''を読み込みました)
-log.user.fxml.exploration.n = ユーザ・ライブラリを探索 ({0}個のFXMLファイルを読み込みました)
-log.user.jar.exploration.n = ユーザ・ライブラリを探索 ({0}個のJARファイルを読み込みました)
-log.user.fxml.jar.exploration.1.1 = ユーザ・ライブラリを探索 (''{0}''と''{1}''を読み込みました)
-log.user.fxml.jar.exploration.n.1 = ユーザ・ライブラリを探索 ({0}個のFXMLファイルと''{1}''を読み込みました)
-log.user.fxml.jar.exploration.1.n = ユーザ・ライブラリを探索 (''{0}''と{1}個のJARファイルを読み込みました)
-log.user.fxml.jar.exploration.n.n = ユーザ・ライブラリを探索 ({0}個のFXMLファイルと{1}個のJARファイルを読み込みました)
+log.info.save.confirmation = \u5909\u66f4\u3092''{0}''\u306b\u4fdd\u5b58\u3057\u307e\u3057\u305f
+log.info.reload = \u5909\u66f4\u3092''{0}''\u304b\u3089\u8aad\u307f\u8fbc\u307f\u307e\u3057\u305f
+log.info.file.deleted = \u30d5\u30a1\u30a4\u30eb''{0}''\u306f\u524a\u9664\u3055\u308c\u307e\u3057\u305f
+log.user.exploration.0 = \u30e6\u30fc\u30b6\u30fb\u30e9\u30a4\u30d6\u30e9\u30ea\u3092\u63a2\u7d22 (FXML\u3082JAR\u30d5\u30a1\u30a4\u30eb\u3082\u898b\u3064\u304b\u308a\u307e\u305b\u3093\u3067\u3057\u305f)
+log.user.exploration.1 = \u30e6\u30fc\u30b6\u30fb\u30e9\u30a4\u30d6\u30e9\u30ea\u3092\u63a2\u7d22 (''{0}''\u3092\u8aad\u307f\u8fbc\u307f\u307e\u3057\u305f)
+log.user.fxml.exploration.n = \u30e6\u30fc\u30b6\u30fb\u30e9\u30a4\u30d6\u30e9\u30ea\u3092\u63a2\u7d22 ({0}\u500b\u306eFXML\u30d5\u30a1\u30a4\u30eb\u3092\u8aad\u307f\u8fbc\u307f\u307e\u3057\u305f)
+log.user.jar.exploration.n = \u30e6\u30fc\u30b6\u30fb\u30e9\u30a4\u30d6\u30e9\u30ea\u3092\u63a2\u7d22 ({0}\u500b\u306eJAR\u30d5\u30a1\u30a4\u30eb\u3092\u8aad\u307f\u8fbc\u307f\u307e\u3057\u305f)
+log.user.fxml.jar.exploration.1.1 = \u30e6\u30fc\u30b6\u30fb\u30e9\u30a4\u30d6\u30e9\u30ea\u3092\u63a2\u7d22 (''{0}''\u3068''{1}''\u3092\u8aad\u307f\u8fbc\u307f\u307e\u3057\u305f)
+log.user.fxml.jar.exploration.n.1 = \u30e6\u30fc\u30b6\u30fb\u30e9\u30a4\u30d6\u30e9\u30ea\u3092\u63a2\u7d22 ({0}\u500b\u306eFXML\u30d5\u30a1\u30a4\u30eb\u3068''{1}''\u3092\u8aad\u307f\u8fbc\u307f\u307e\u3057\u305f)
+log.user.fxml.jar.exploration.1.n = \u30e6\u30fc\u30b6\u30fb\u30e9\u30a4\u30d6\u30e9\u30ea\u3092\u63a2\u7d22 (''{0}''\u3068{1}\u500b\u306eJAR\u30d5\u30a1\u30a4\u30eb\u3092\u8aad\u307f\u8fbc\u307f\u307e\u3057\u305f)
+log.user.fxml.jar.exploration.n.n = \u30e6\u30fc\u30b6\u30fb\u30e9\u30a4\u30d6\u30e9\u30ea\u3092\u63a2\u7d22 ({0}\u500b\u306eFXML\u30d5\u30a1\u30a4\u30eb\u3068{1}\u500b\u306eJAR\u30d5\u30a1\u30a4\u30eb\u3092\u8aad\u307f\u8fbc\u307f\u307e\u3057\u305f)
 
 # -----------------------------------------------------------------------------
 # Preview Window
 # -----------------------------------------------------------------------------
-resource.filechooser.filter.msg = プロパティ・ファイル
+resource.filechooser.filter.msg = \u30d7\u30ed\u30d1\u30c6\u30a3\u30fb\u30d5\u30a1\u30a4\u30eb
 # Used as menu item label when no style sheet has been added
-scenestylesheet.none = なし
+scenestylesheet.none = \u306a\u3057
 
 # -----------------------------------------------------------------------------
 # Other
 # -----------------------------------------------------------------------------
-file.filter.label.audio = オーディオ・ドキュメント
-file.filter.label.fxml = FXMLドキュメント
-file.filter.label.image = イメージ・ドキュメント
-file.filter.label.media = メディア・ドキュメント
-file.filter.label.video = ビデオ・ドキュメント
-error.file.open.title = ファイルを開くのに失敗しました
+file.filter.label.audio = \u30aa\u30fc\u30c7\u30a3\u30aa\u30fb\u30c9\u30ad\u30e5\u30e1\u30f3\u30c8
+file.filter.label.fxml = FXML\u30c9\u30ad\u30e5\u30e1\u30f3\u30c8
+file.filter.label.image = \u30a4\u30e1\u30fc\u30b8\u30fb\u30c9\u30ad\u30e5\u30e1\u30f3\u30c8
+file.filter.label.media = \u30e1\u30c7\u30a3\u30a2\u30fb\u30c9\u30ad\u30e5\u30e1\u30f3\u30c8
+file.filter.label.video = \u30d3\u30c7\u30aa\u30fb\u30c9\u30ad\u30e5\u30e1\u30f3\u30c8
+error.file.open.title = \u30d5\u30a1\u30a4\u30eb\u3092\u958b\u304f\u306e\u306b\u5931\u6557\u3057\u307e\u3057\u305f
 # {0} is a file path
-error.file.open.message = ファイル{0}を開けません
-error.filesystem.details = ファイル・システムを確認してください。
-error.file.reveal.title = ファイルを見つけるのに失敗しました
-error.file.reveal.message = ファイル{0}が見つかりません
+error.file.open.message = \u30d5\u30a1\u30a4\u30eb{0}\u3092\u958b\u3051\u307e\u305b\u3093
+error.filesystem.details = \u30d5\u30a1\u30a4\u30eb\u30fb\u30b7\u30b9\u30c6\u30e0\u3092\u78ba\u8a8d\u3057\u3066\u304f\u3060\u3055\u3044\u3002
+error.file.reveal.title = \u30d5\u30a1\u30a4\u30eb\u3092\u898b\u3064\u3051\u308b\u306e\u306b\u5931\u6557\u3057\u307e\u3057\u305f
+error.file.reveal.message = \u30d5\u30a1\u30a4\u30eb{0}\u304c\u898b\u3064\u304b\u308a\u307e\u305b\u3093
 #
-log.start = JavaFX Scene Builderが開始
-log.stop = JavaFX Scene Builderが停止
+log.start = JavaFX Scene Builder\u304c\u958b\u59cb
+log.stop = JavaFX Scene Builder\u304c\u505c\u6b62
 
 # -----------------------------------------------------------------------------
 # CSS Panel
 # -----------------------------------------------------------------------------
-csspanel = CSSアナライザ
-csspanel.copy.path = スタイル設定可能なパスをコピー
-csspanel.rules = ルール
-csspanel.show.default.values = デフォルト値を持つプロパティを表示
-csspanel.hide.default.values = デフォルト値を持つプロパティを非表示
-csspanel.defaults.split = デフォルトを分割
-csspanel.defaults.join = デフォルトを結合
-csspanel.table = 表
-csspanel.text = テキスト
-csspanel.view.as = 表示モード
+csspanel = CSS\u30a2\u30ca\u30e9\u30a4\u30b6
+csspanel.copy.path = \u30b9\u30bf\u30a4\u30eb\u8a2d\u5b9a\u53ef\u80fd\u306a\u30d1\u30b9\u3092\u30b3\u30d4\u30fc
+csspanel.rules = \u30eb\u30fc\u30eb
+csspanel.show.default.values = \u30c7\u30d5\u30a9\u30eb\u30c8\u5024\u3092\u6301\u3064\u30d7\u30ed\u30d1\u30c6\u30a3\u3092\u8868\u793a
+csspanel.hide.default.values = \u30c7\u30d5\u30a9\u30eb\u30c8\u5024\u3092\u6301\u3064\u30d7\u30ed\u30d1\u30c6\u30a3\u3092\u975e\u8868\u793a
+csspanel.defaults.split = \u30c7\u30d5\u30a9\u30eb\u30c8\u3092\u5206\u5272
+csspanel.defaults.join = \u30c7\u30d5\u30a9\u30eb\u30c8\u3092\u7d50\u5408
+csspanel.table = \u8868
+csspanel.text = \u30c6\u30ad\u30b9\u30c8
+csspanel.view.as = \u8868\u793a\u30e2\u30fc\u30c9
 
 # -----------------------------------------------------------------------------
 # JAR Analysis Report dialog
 # -----------------------------------------------------------------------------
 # The parameter is a time stamp
-jar.analysis.report.timestamp = {0}の解析が完了
-jar.analysis.report.title = JAR解析レポート
-jar.analysis.exception = 例外:
-jar.analysis.not.node = ノード以外:
+jar.analysis.report.timestamp = {0}\u306e\u89e3\u6790\u304c\u5b8c\u4e86
+jar.analysis.report.title = JAR\u89e3\u6790\u30ec\u30dd\u30fc\u30c8
+jar.analysis.exception = \u4f8b\u5916:
+jar.analysis.not.node = \u30ce\u30fc\u30c9\u4ee5\u5916:
 
 # -----------------------------------------------------------------------------
 # Welcome Dialog
 # -----------------------------------------------------------------------------
 welcome.title = Gluon Scene Builder
-welcome.recent.items.header = 最近のもの
-welcome.recent.items.no.recent.items = 最近のプロジェクトなし
-welcome.new.project.label = 新規プロジェクト
-welcome.open.project.label = プロジェクトを開く
+welcome.recent.items.header = \u6700\u8fd1\u306e\u3082\u306e
+welcome.recent.items.no.recent.items = \u6700\u8fd1\u306e\u30d7\u30ed\u30b8\u30a7\u30af\u30c8\u306a\u3057
+welcome.new.project.label = \u65b0\u898f\u30d7\u30ed\u30b8\u30a7\u30af\u30c8
+welcome.open.project.label = \u30d7\u30ed\u30b8\u30a7\u30af\u30c8\u3092\u958b\u304f
 # -- Template (this keys are replicated from SceneBuilderKit.properties)
-template.title.header.desktop = デスクトップ
-template.title.header.phone = モバイル
-template.title.new.empty.app = 空
-template.title.new.basic.desktop.app = 基本アプリケーション
-template.title.new.complex.desktop.app = 複合アプリケーション
-template.title.new.empty.phone.app = 空のスクリーン
-template.title.new.basic.phone.app = 基本スクリーン
+template.title.header.desktop = \u30c7\u30b9\u30af\u30c8\u30c3\u30d7
+template.title.header.phone = \u30e2\u30d0\u30a4\u30eb
+template.title.new.empty.app = \u7a7a
+template.title.new.basic.desktop.app = \u57fa\u672c\u30a2\u30d7\u30ea\u30b1\u30fc\u30b7\u30e7\u30f3
+template.title.new.complex.desktop.app = \u8907\u5408\u30a2\u30d7\u30ea\u30b1\u30fc\u30b7\u30e7\u30f3
+template.title.new.empty.phone.app = \u7a7a\u306e\u30b9\u30af\u30ea\u30fc\u30f3
+template.title.new.basic.phone.app = \u57fa\u672c\u30b9\u30af\u30ea\u30fc\u30f3
 
 # -----------------------------------------------------------------------------
 # Download latest version dialog
 # -----------------------------------------------------------------------------
-download.scene.builder.title = Scene Builderのダウンロード
-download.scene.builder.header.label = Scene Builderが最新版ではありません。
-download.scene.builder.current.version.label = 現在のバージョン:
-download.scene.builder.last.version.number.label = 最新のバージョン:
-download.scene.builder.remind.later.label = 後で知らせる
-download.scene.builder.ignore.label = 無視
-download.scene.builder.download.label = ダウンロード
-download.scene.builder.learn.mode.label = もっと知る
+download.scene.builder.title = Scene Builder\u306e\u30c0\u30a6\u30f3\u30ed\u30fc\u30c9
+download.scene.builder.header.label = Scene Builder\u304c\u6700\u65b0\u7248\u3067\u306f\u3042\u308a\u307e\u305b\u3093\u3002
+download.scene.builder.current.version.label = \u73fe\u5728\u306e\u30d0\u30fc\u30b8\u30e7\u30f3:
+download.scene.builder.last.version.number.label = \u6700\u65b0\u306e\u30d0\u30fc\u30b8\u30e7\u30f3:
+download.scene.builder.remind.later.label = \u5f8c\u3067\u77e5\u3089\u305b\u308b
+download.scene.builder.ignore.label = \u7121\u8996
+download.scene.builder.download.label = \u30c0\u30a6\u30f3\u30ed\u30fc\u30c9
+download.scene.builder.learn.mode.label = \u3082\u3063\u3068\u77e5\u308b
 
 # -----------------------------------------------------------------------------
 # Check for updates
 # -----------------------------------------------------------------------------
-check_for_updates.alert.error.message = サーバで最新版を確認できません。
+check_for_updates.alert.error.message = \u30b5\u30fc\u30d0\u3067\u6700\u65b0\u7248\u3092\u78ba\u8a8d\u3067\u304d\u307e\u305b\u3093\u3002
 check_for_updates.alert.error.title = Scene Builder
-check_for_updates.alert.up_to_date.message = Scene Builderの最新版がインストール済みです。
+check_for_updates.alert.up_to_date.message = Scene Builder\u306e\u6700\u65b0\u7248\u304c\u30a4\u30f3\u30b9\u30c8\u30fc\u30eb\u6e08\u307f\u3067\u3059\u3002
 check_for_updates.alert.up_to_date.title = Scene Builder
-check_for_updates.alert.headertext = 更新の確認
+check_for_updates.alert.headertext = \u66f4\u65b0\u306e\u78ba\u8a8d

--- a/kit/src/main/resources/com/oracle/javafx/scenebuilder/kit/i18n/SceneBuilderKit_ja.properties
+++ b/kit/src/main/resources/com/oracle/javafx/scenebuilder/kit/i18n/SceneBuilderKit_ja.properties
@@ -33,146 +33,146 @@
 # Generic labels
 # -----------------------------------------------------------------------------
 label.ok = OK
-label.cancel = 取消
-label.close = 閉じる
-label.copy = コピー
+label.cancel = \u53d6\u6d88
+label.close = \u9589\u3058\u308b
+label.copy = \u30b3\u30d4\u30fc
 
-label.action.edit.trim = ドキュメントを選択範囲まで切取り
-label.action.edit.delete.n = オブジェクト{0}の削除
-label.action.edit.paste.1 = {0}の貼付け
-label.action.edit.paste.n = オブジェクト{0}の貼付け
-label.action.edit.paste.unresolve = 未解決のオブジェクトの貼付け
-label.action.edit.paste.collection = コレクションの貼付け
-label.action.edit.paste.into.1 = {0}の内側に貼付け
-label.action.edit.paste.into.n = オブジェクト{0}の内側に貼付け
-label.action.edit.paste.into.unresolve = 未解決のオブジェクトの内側に貼付け
-label.action.edit.paste.into.collection = コレクションの内側に貼付け
-label.action.edit.duplicate.1 = {0}の複製
-label.action.edit.duplicate.n = オブジェクト{0}の複製
-label.action.edit.duplicate.unresolve = 未解決のオブジェクトの複製
-label.action.edit.duplicate.collection = コレクションの複製
-label.action.edit.resize.column = 列のサイズ変更
-label.action.edit.resize.row = 行のサイズ変更
-label.action.edit.add.context.menu = コンテキストメニューの追加
-label.action.edit.add.context.menu.menu.item = 未指定のアクション
-label.action.edit.add.tooltip = ツールチップの追加
-label.action.edit.set.1 = {0}を{1}に設定
-label.action.edit.set.n = {0}を{1}オブジェクトに設定
+label.action.edit.trim = \u30c9\u30ad\u30e5\u30e1\u30f3\u30c8\u3092\u9078\u629e\u7bc4\u56f2\u307e\u3067\u5207\u53d6\u308a
+label.action.edit.delete.n = \u30aa\u30d6\u30b8\u30a7\u30af\u30c8{0}\u306e\u524a\u9664
+label.action.edit.paste.1 = {0}\u306e\u8cbc\u4ed8\u3051
+label.action.edit.paste.n = \u30aa\u30d6\u30b8\u30a7\u30af\u30c8{0}\u306e\u8cbc\u4ed8\u3051
+label.action.edit.paste.unresolve = \u672a\u89e3\u6c7a\u306e\u30aa\u30d6\u30b8\u30a7\u30af\u30c8\u306e\u8cbc\u4ed8\u3051
+label.action.edit.paste.collection = \u30b3\u30ec\u30af\u30b7\u30e7\u30f3\u306e\u8cbc\u4ed8\u3051
+label.action.edit.paste.into.1 = {0}\u306e\u5185\u5074\u306b\u8cbc\u4ed8\u3051
+label.action.edit.paste.into.n = \u30aa\u30d6\u30b8\u30a7\u30af\u30c8{0}\u306e\u5185\u5074\u306b\u8cbc\u4ed8\u3051
+label.action.edit.paste.into.unresolve = \u672a\u89e3\u6c7a\u306e\u30aa\u30d6\u30b8\u30a7\u30af\u30c8\u306e\u5185\u5074\u306b\u8cbc\u4ed8\u3051
+label.action.edit.paste.into.collection = \u30b3\u30ec\u30af\u30b7\u30e7\u30f3\u306e\u5185\u5074\u306b\u8cbc\u4ed8\u3051
+label.action.edit.duplicate.1 = {0}\u306e\u8907\u88fd
+label.action.edit.duplicate.n = \u30aa\u30d6\u30b8\u30a7\u30af\u30c8{0}\u306e\u8907\u88fd
+label.action.edit.duplicate.unresolve = \u672a\u89e3\u6c7a\u306e\u30aa\u30d6\u30b8\u30a7\u30af\u30c8\u306e\u8907\u88fd
+label.action.edit.duplicate.collection = \u30b3\u30ec\u30af\u30b7\u30e7\u30f3\u306e\u8907\u88fd
+label.action.edit.resize.column = \u5217\u306e\u30b5\u30a4\u30ba\u5909\u66f4
+label.action.edit.resize.row = \u884c\u306e\u30b5\u30a4\u30ba\u5909\u66f4
+label.action.edit.add.context.menu = \u30b3\u30f3\u30c6\u30ad\u30b9\u30c8\u30e1\u30cb\u30e5\u30fc\u306e\u8ffd\u52a0
+label.action.edit.add.context.menu.menu.item = \u672a\u6307\u5b9a\u306e\u30a2\u30af\u30b7\u30e7\u30f3
+label.action.edit.add.tooltip = \u30c4\u30fc\u30eb\u30c1\u30c3\u30d7\u306e\u8ffd\u52a0
+label.action.edit.set.1 = {0}\u3092{1}\u306b\u8a2d\u5b9a
+label.action.edit.set.n = {0}\u3092{1}\u30aa\u30d6\u30b8\u30a7\u30af\u30c8\u306b\u8a2d\u5b9a
 
-label.search.noresults = 結果が見つかりません
+label.search.noresults = \u7d50\u679c\u304c\u898b\u3064\u304b\u308a\u307e\u305b\u3093
 
-label.qualifier.empty = (空)
-label.qualifier.horizontal = (水平)
-label.qualifier.vertical = (垂直)
+label.qualifier.empty = (\u7a7a)
+label.qualifier.horizontal = (\u6c34\u5e73)
+label.qualifier.vertical = (\u5782\u76f4)
 
 # -----------------------------------------------------------------------------
 # Log Messages
 # -----------------------------------------------------------------------------
-log.info.explore.jar = JAR {0}の探索を開始
-log.warning.inline.edit.internationalized.strings = 国際化された文字列をインライン編集できません
-log.warning.color.creation.error.hexadecimal = 16進値''{0}''の色を作成できません
-log.warning.image.location.does.not.exist = 画像''{0}''は存在しません
-log.warning.invalid.fxid = ID ''{0}''は有効なJava識別子ではありません
-log.warning.no.injectable.fxid = ID ''{0}''のFXMLコントローラ・クラスに注入可能なフィールドが見つかりません
-log.warning.duplicate.fxid = ID ''{0}''の要素がFXMLコントローラにすでに注入されています
-log.warning.layout.failed = レイアウトの失敗 (''{0}'')
+log.info.explore.jar = JAR {0}\u306e\u63a2\u7d22\u3092\u958b\u59cb
+log.warning.inline.edit.internationalized.strings = \u56fd\u969b\u5316\u3055\u308c\u305f\u6587\u5b57\u5217\u3092\u30a4\u30f3\u30e9\u30a4\u30f3\u7de8\u96c6\u3067\u304d\u307e\u305b\u3093
+log.warning.color.creation.error.hexadecimal = 16\u9032\u5024''{0}''\u306e\u8272\u3092\u4f5c\u6210\u3067\u304d\u307e\u305b\u3093
+log.warning.image.location.does.not.exist = \u753b\u50cf''{0}''\u306f\u5b58\u5728\u3057\u307e\u305b\u3093
+log.warning.invalid.fxid = ID ''{0}''\u306f\u6709\u52b9\u306aJava\u8b58\u5225\u5b50\u3067\u306f\u3042\u308a\u307e\u305b\u3093
+log.warning.no.injectable.fxid = ID ''{0}''\u306eFXML\u30b3\u30f3\u30c8\u30ed\u30fc\u30e9\u30fb\u30af\u30e9\u30b9\u306b\u6ce8\u5165\u53ef\u80fd\u306a\u30d5\u30a3\u30fc\u30eb\u30c9\u304c\u898b\u3064\u304b\u308a\u307e\u305b\u3093
+log.warning.duplicate.fxid = ID ''{0}''\u306e\u8981\u7d20\u304cFXML\u30b3\u30f3\u30c8\u30ed\u30fc\u30e9\u306b\u3059\u3067\u306b\u6ce8\u5165\u3055\u308c\u3066\u3044\u307e\u3059
+log.warning.layout.failed = \u30ec\u30a4\u30a2\u30a6\u30c8\u306e\u5931\u6557 (''{0}'')
 
 # -----------------------------------------------------------------------------
 # Library Panel
 # -----------------------------------------------------------------------------
-lib.filechooser.filter.msg = JARファイルまたはFXMLドキュメント
-library.panel.menu.view.list = リストの表示
-library.panel.menu.view.sections = セクションの表示
+lib.filechooser.filter.msg = JAR\u30d5\u30a1\u30a4\u30eb\u307e\u305f\u306fFXML\u30c9\u30ad\u30e5\u30e1\u30f3\u30c8
+library.panel.menu.view.list = \u30ea\u30b9\u30c8\u306e\u8868\u793a
+library.panel.menu.view.sections = \u30bb\u30af\u30b7\u30e7\u30f3\u306e\u8868\u793a
 
 # -----------------------------------------------------------------------------
 # Hierarchy Panel
 # -----------------------------------------------------------------------------
-hierarchy.placeholder.insert = 挿入
-hierarchy.placeholder.insert.graphic = グラフィックの挿入
-hierarchy.column.header.classname = クラス名
-hierarchy.column.header.info = 情報
-hierarchy.displayoption.info = 情報
+hierarchy.placeholder.insert = \u633f\u5165
+hierarchy.placeholder.insert.graphic = \u30b0\u30e9\u30d5\u30a3\u30c3\u30af\u306e\u633f\u5165
+hierarchy.column.header.classname = \u30af\u30e9\u30b9\u540d
+hierarchy.column.header.info = \u60c5\u5831
+hierarchy.displayoption.info = \u60c5\u5831
 hierarchy.displayoption.fxid = fx:id
-hierarchy.displayoption.nodeid = ノードID
-hierarchy.unresolved.class = 未解決のクラス
-hierarchy.unresolved.location = 未解決の場所
-hierarchy.unresolved.resource = 未解決のリソース
-hierarchy.unsupported.expression = Scene Builderで未サポート
+hierarchy.displayoption.nodeid = \u30ce\u30fc\u30c9ID
+hierarchy.unresolved.class = \u672a\u89e3\u6c7a\u306e\u30af\u30e9\u30b9
+hierarchy.unresolved.location = \u672a\u89e3\u6c7a\u306e\u5834\u6240
+hierarchy.unresolved.resource = \u672a\u89e3\u6c7a\u306e\u30ea\u30bd\u30fc\u30b9
+hierarchy.unsupported.expression = Scene Builder\u3067\u672a\u30b5\u30dd\u30fc\u30c8
 
 # -----------------------------------------------------------------------------
 # Content Panel
 # -----------------------------------------------------------------------------
-content.label.status.cannot.display = このドキュメントの内容は表示できません
-content.label.status.invitation = ライブラリ・アイテムをここにドラッグ...
-contant.label.status.fxomdocument.null = FXOMDocumentがnullです
-content.log.cannot.display.selected.1 = 選択されたオブジェクトはコンテント・パネルに表示できません
-content.log.cannot.display.selected.all = 選択されたオブジェクトはコンテント・パネルに表示できません
-content.log.cannot.display.selected.n = 選択されたオブジェクト{1}個のうち{0}個はコンテント・パネルに表示できません
+content.label.status.cannot.display = \u3053\u306e\u30c9\u30ad\u30e5\u30e1\u30f3\u30c8\u306e\u5185\u5bb9\u306f\u8868\u793a\u3067\u304d\u307e\u305b\u3093
+content.label.status.invitation = \u30e9\u30a4\u30d6\u30e9\u30ea\u30fb\u30a2\u30a4\u30c6\u30e0\u3092\u3053\u3053\u306b\u30c9\u30e9\u30c3\u30b0...
+contant.label.status.fxomdocument.null = FXOMDocument\u304cnull\u3067\u3059
+content.log.cannot.display.selected.1 = \u9078\u629e\u3055\u308c\u305f\u30aa\u30d6\u30b8\u30a7\u30af\u30c8\u306f\u30b3\u30f3\u30c6\u30f3\u30c8\u30fb\u30d1\u30cd\u30eb\u306b\u8868\u793a\u3067\u304d\u307e\u305b\u3093
+content.log.cannot.display.selected.all = \u9078\u629e\u3055\u308c\u305f\u30aa\u30d6\u30b8\u30a7\u30af\u30c8\u306f\u30b3\u30f3\u30c6\u30f3\u30c8\u30fb\u30d1\u30cd\u30eb\u306b\u8868\u793a\u3067\u304d\u307e\u305b\u3093
+content.log.cannot.display.selected.n = \u9078\u629e\u3055\u308c\u305f\u30aa\u30d6\u30b8\u30a7\u30af\u30c8{1}\u500b\u306e\u3046\u3061{0}\u500b\u306f\u30b3\u30f3\u30c6\u30f3\u30c8\u30fb\u30d1\u30cd\u30eb\u306b\u8868\u793a\u3067\u304d\u307e\u305b\u3093
 
 # -----------------------------------------------------------------------------
 # Inspector Panel
 # -----------------------------------------------------------------------------
-inspector.cursor.chooseimage = 画像の選択...
-inspector.cursor.inherited = 継承 (デフォルト)
-inspector.cursor.inheritedparent = 親を継承 (デフォルト)
-inspector.cursor.custom = カスタム・カーソル
-inspector.event.invalid.method = メソッド名{0}は不正です。有効なJava識別子ではありません
-inspector.event.menu.methodmode = メソッド名モードに切替え
-inspector.event.menu.scriptmode = スクリプト・モードに切替え
-inspector.i18n.dummykey = キーが未指定
-inspector.i18n.multiline = 複数行モードに切替え
-inspector.i18n.off = 国際化文字列の削除
-inspector.i18n.on = 国際化文字列で置換
-inspector.i18n.singleline = 単一行モードに切替え
-inspector.insets.setall = トップの値をすべてへ伝搬
-inspector.editors.prompttext.empty = 空
-inspector.editors.resetvalue = デフォルトに戻す
-inspector.error.cancel = 値を修正
-inspector.error.previousvalue = 前の値に戻す
-inspector.error.title = プロパティ・エラー
-inspector.error.message = 不正な値
-inspector.error.details = {0}は{1}に対して不正です
-inspector.font.invalidfamily = ファミリに対して不正な値: {0}
-inspector.font.invalidstyle = スタイルに対して不正な値: {0}
-inspector.font.samefamilystyle = 複数のフォントのファミリとスタイルが同じ: {0}
-inspector.keycombination.invalidkeycode = {0}に対するキー・コードが見付かりません
-inspector.keycombination.modifier = 修飾子
-inspector.keycombination.mainkey = メイン・キー
-inspector.keycombination.none = なし
-inspector.keycombination.clear = すべてクリア
-inspector.keycombination.null = なし
-inspector.list.remove = 削除
-inspector.list.moveup = 上に移動
-inspector.list.movedown = 下に移動
-inspector.list.open = {0}を開く
-inspector.list.reveal.finder = {0}をファインダに表示
-inspector.list.reveal.explorer = {0}をエクスプローラに表示
-inspector.message.no.properties = このセクションのプロパティはありません
-inspector.message.no.propertiesedited = プロパティは編集されていません
-inspector.message.no.resolved = セクションが未解決の参照を含んでいます
-inspector.message.no.selected = 選択なし
-inspector.message.no.thingforinspector = 表示する情報なし
-inspector.message.searchpattern.empty = 検索パターンが空です
-inspector.rectangle2D.not.defined = 定義されていません
-inspector.select.css.filter = スタイルシート・ファイル
-inspector.select.css.title = スタイルシートの追加
-inspector.select.image = イメージ・ファイル
-inspector.style.parsingerror = インライン・スタイルの解析のCSSエラー:  ''{0}''
-inspector.style.valuetypeerror = CSS値タイプのエラー:  ''{0}''
-inspector.stylesheet.alreadyexist = スタイルシート{0}は既に追加されています
-inspector.stylesheet.cannotopen = {0}を開けません
-inspector.stylesheet.cannotreveal = {0}を表示できません
-inspector.css.tooltip = このプロパティの値はCSSでオーバーライドされています
-inspector.css.showcss = CSSの表示
-inspector.css.overridden = このプロパティ[0]の値はCSSでオーバーライドされています
-inspector.resource.documentrelative = ドキュメントの相対パスに切替え
-inspector.resource.classpathrelative = クラスパスの相対パスに切替え
-inspector.resource.absolute = 絶対パスに切替え
-inspector.sectiontitle.multiple = 複数の選択
-inspector.duration.milliseconds = ミリ秒
-inspector.duration.seconds = 病
-inspector.duration.minutes = 分
-inspector.duration.hours = 時間
+inspector.cursor.chooseimage = \u753b\u50cf\u306e\u9078\u629e...
+inspector.cursor.inherited = \u7d99\u627f (\u30c7\u30d5\u30a9\u30eb\u30c8)
+inspector.cursor.inheritedparent = \u89aa\u3092\u7d99\u627f (\u30c7\u30d5\u30a9\u30eb\u30c8)
+inspector.cursor.custom = \u30ab\u30b9\u30bf\u30e0\u30fb\u30ab\u30fc\u30bd\u30eb
+inspector.event.invalid.method = \u30e1\u30bd\u30c3\u30c9\u540d{0}\u306f\u4e0d\u6b63\u3067\u3059\u3002\u6709\u52b9\u306aJava\u8b58\u5225\u5b50\u3067\u306f\u3042\u308a\u307e\u305b\u3093
+inspector.event.menu.methodmode = \u30e1\u30bd\u30c3\u30c9\u540d\u30e2\u30fc\u30c9\u306b\u5207\u66ff\u3048
+inspector.event.menu.scriptmode = \u30b9\u30af\u30ea\u30d7\u30c8\u30fb\u30e2\u30fc\u30c9\u306b\u5207\u66ff\u3048
+inspector.i18n.dummykey = \u30ad\u30fc\u304c\u672a\u6307\u5b9a
+inspector.i18n.multiline = \u8907\u6570\u884c\u30e2\u30fc\u30c9\u306b\u5207\u66ff\u3048
+inspector.i18n.off = \u56fd\u969b\u5316\u6587\u5b57\u5217\u306e\u524a\u9664
+inspector.i18n.on = \u56fd\u969b\u5316\u6587\u5b57\u5217\u3067\u7f6e\u63db
+inspector.i18n.singleline = \u5358\u4e00\u884c\u30e2\u30fc\u30c9\u306b\u5207\u66ff\u3048
+inspector.insets.setall = \u30c8\u30c3\u30d7\u306e\u5024\u3092\u3059\u3079\u3066\u3078\u4f1d\u642c
+inspector.editors.prompttext.empty = \u7a7a
+inspector.editors.resetvalue = \u30c7\u30d5\u30a9\u30eb\u30c8\u306b\u623b\u3059
+inspector.error.cancel = \u5024\u3092\u4fee\u6b63
+inspector.error.previousvalue = \u524d\u306e\u5024\u306b\u623b\u3059
+inspector.error.title = \u30d7\u30ed\u30d1\u30c6\u30a3\u30fb\u30a8\u30e9\u30fc
+inspector.error.message = \u4e0d\u6b63\u306a\u5024
+inspector.error.details = {0}\u306f{1}\u306b\u5bfe\u3057\u3066\u4e0d\u6b63\u3067\u3059
+inspector.font.invalidfamily = \u30d5\u30a1\u30df\u30ea\u306b\u5bfe\u3057\u3066\u4e0d\u6b63\u306a\u5024: {0}
+inspector.font.invalidstyle = \u30b9\u30bf\u30a4\u30eb\u306b\u5bfe\u3057\u3066\u4e0d\u6b63\u306a\u5024: {0}
+inspector.font.samefamilystyle = \u8907\u6570\u306e\u30d5\u30a9\u30f3\u30c8\u306e\u30d5\u30a1\u30df\u30ea\u3068\u30b9\u30bf\u30a4\u30eb\u304c\u540c\u3058: {0}
+inspector.keycombination.invalidkeycode = {0}\u306b\u5bfe\u3059\u308b\u30ad\u30fc\u30fb\u30b3\u30fc\u30c9\u304c\u898b\u4ed8\u304b\u308a\u307e\u305b\u3093
+inspector.keycombination.modifier = \u4fee\u98fe\u5b50
+inspector.keycombination.mainkey = \u30e1\u30a4\u30f3\u30fb\u30ad\u30fc
+inspector.keycombination.none = \u306a\u3057
+inspector.keycombination.clear = \u3059\u3079\u3066\u30af\u30ea\u30a2
+inspector.keycombination.null = \u306a\u3057
+inspector.list.remove = \u524a\u9664
+inspector.list.moveup = \u4e0a\u306b\u79fb\u52d5
+inspector.list.movedown = \u4e0b\u306b\u79fb\u52d5
+inspector.list.open = {0}\u3092\u958b\u304f
+inspector.list.reveal.finder = {0}\u3092\u30d5\u30a1\u30a4\u30f3\u30c0\u306b\u8868\u793a
+inspector.list.reveal.explorer = {0}\u3092\u30a8\u30af\u30b9\u30d7\u30ed\u30fc\u30e9\u306b\u8868\u793a
+inspector.message.no.properties = \u3053\u306e\u30bb\u30af\u30b7\u30e7\u30f3\u306e\u30d7\u30ed\u30d1\u30c6\u30a3\u306f\u3042\u308a\u307e\u305b\u3093
+inspector.message.no.propertiesedited = \u30d7\u30ed\u30d1\u30c6\u30a3\u306f\u7de8\u96c6\u3055\u308c\u3066\u3044\u307e\u305b\u3093
+inspector.message.no.resolved = \u30bb\u30af\u30b7\u30e7\u30f3\u304c\u672a\u89e3\u6c7a\u306e\u53c2\u7167\u3092\u542b\u3093\u3067\u3044\u307e\u3059
+inspector.message.no.selected = \u9078\u629e\u306a\u3057
+inspector.message.no.thingforinspector = \u8868\u793a\u3059\u308b\u60c5\u5831\u306a\u3057
+inspector.message.searchpattern.empty = \u691c\u7d22\u30d1\u30bf\u30fc\u30f3\u304c\u7a7a\u3067\u3059
+inspector.rectangle2D.not.defined = \u5b9a\u7fa9\u3055\u308c\u3066\u3044\u307e\u305b\u3093
+inspector.select.css.filter = \u30b9\u30bf\u30a4\u30eb\u30b7\u30fc\u30c8\u30fb\u30d5\u30a1\u30a4\u30eb
+inspector.select.css.title = \u30b9\u30bf\u30a4\u30eb\u30b7\u30fc\u30c8\u306e\u8ffd\u52a0
+inspector.select.image = \u30a4\u30e1\u30fc\u30b8\u30fb\u30d5\u30a1\u30a4\u30eb
+inspector.style.parsingerror = \u30a4\u30f3\u30e9\u30a4\u30f3\u30fb\u30b9\u30bf\u30a4\u30eb\u306e\u89e3\u6790\u306eCSS\u30a8\u30e9\u30fc:  ''{0}''
+inspector.style.valuetypeerror = CSS\u5024\u30bf\u30a4\u30d7\u306e\u30a8\u30e9\u30fc:  ''{0}''
+inspector.stylesheet.alreadyexist = \u30b9\u30bf\u30a4\u30eb\u30b7\u30fc\u30c8{0}\u306f\u65e2\u306b\u8ffd\u52a0\u3055\u308c\u3066\u3044\u307e\u3059
+inspector.stylesheet.cannotopen = {0}\u3092\u958b\u3051\u307e\u305b\u3093
+inspector.stylesheet.cannotreveal = {0}\u3092\u8868\u793a\u3067\u304d\u307e\u305b\u3093
+inspector.css.tooltip = \u3053\u306e\u30d7\u30ed\u30d1\u30c6\u30a3\u306e\u5024\u306fCSS\u3067\u30aa\u30fc\u30d0\u30fc\u30e9\u30a4\u30c9\u3055\u308c\u3066\u3044\u307e\u3059
+inspector.css.showcss = CSS\u306e\u8868\u793a
+inspector.css.overridden = \u3053\u306e\u30d7\u30ed\u30d1\u30c6\u30a3[0]\u306e\u5024\u306fCSS\u3067\u30aa\u30fc\u30d0\u30fc\u30e9\u30a4\u30c9\u3055\u308c\u3066\u3044\u307e\u3059
+inspector.resource.documentrelative = \u30c9\u30ad\u30e5\u30e1\u30f3\u30c8\u306e\u76f8\u5bfe\u30d1\u30b9\u306b\u5207\u66ff\u3048
+inspector.resource.classpathrelative = \u30af\u30e9\u30b9\u30d1\u30b9\u306e\u76f8\u5bfe\u30d1\u30b9\u306b\u5207\u66ff\u3048
+inspector.resource.absolute = \u7d76\u5bfe\u30d1\u30b9\u306b\u5207\u66ff\u3048
+inspector.sectiontitle.multiple = \u8907\u6570\u306e\u9078\u629e
+inspector.duration.milliseconds = \u30df\u30ea\u79d2
+inspector.duration.seconds = \u75c5
+inspector.duration.minutes = \u5206
+inspector.duration.hours = \u6642\u9593
 
 # -----------------------------------------------------------------------------
 # CSS Panel
@@ -181,327 +181,327 @@ inspector.duration.hours = 時間
 # -----------------------------------------------------------------------------
 # Drag Controller
 # -----------------------------------------------------------------------------
-drop.job.move.single.unresolved = 未解決のオブジェクトに移動
-drop.job.move.single.resolved = {0}の移動
-drop.job.move.multiple.homogeneous = {0}の{1}の移動
-drop.job.move.multiple.heterogeneous = {0}のオブジェクトの移動
-drop.job.insert.library.item = 挿入
-drop.job.insert.from.single.file = "{0}"から挿入
-drop.job.insert.from.multiple.files = {0}個のファイルの挿入
+drop.job.move.single.unresolved = \u672a\u89e3\u6c7a\u306e\u30aa\u30d6\u30b8\u30a7\u30af\u30c8\u306b\u79fb\u52d5
+drop.job.move.single.resolved = {0}\u306e\u79fb\u52d5
+drop.job.move.multiple.homogeneous = {0}\u306e{1}\u306e\u79fb\u52d5
+drop.job.move.multiple.heterogeneous = {0}\u306e\u30aa\u30d6\u30b8\u30a7\u30af\u30c8\u306e\u79fb\u52d5
+drop.job.insert.library.item = \u633f\u5165
+drop.job.insert.from.single.file = "{0}"\u304b\u3089\u633f\u5165
+drop.job.insert.from.multiple.files = {0}\u500b\u306e\u30d5\u30a1\u30a4\u30eb\u306e\u633f\u5165
 
 # -----------------------------------------------------------------------------
 # Import dialog
 # -----------------------------------------------------------------------------
 # Import Jar file in Library
-import.button.import.component = コンポーネントのインポート
-import.button.import.components = 複数コンポーネントのインポート
-import.button.import.jar = Jarのインポート (非UIコンポーネント)
-import.button.import.jars = 複数Jarのインポート (非UIコンポーネント)
-import.choice.builtin = 組込み
-import.items.processing = 処理中...
-import.note = カスタム・コンポーネントはScene Builder VM内に読込まれ、振る舞いが変化することがあります
-import.num.item = アイテム
-import.num.items = 複数アイテム
-import.preview.select = アイテムの選択
-import.preview.unable = アイテムをインスタンス化できません
-import.preview.width.height = 幅 x 高さ:
-import.preview.width.height.default = デフォルトの幅 x 高さ:
-import.toggle.checkall = すべてチェック
-import.toggle.uncheckall = すべてチェックを外す
-import.window.title = インポート・ダイアログ
-import.welcome.processing = 処理中...
-import.work.cancelled = 取消されました
-import.work.exploring = {0}を探索中
-import.error.title = インポートに失敗しました
-import.error.message = インポートを完了できませんでした
-import.error.details = インポート対象を確認して再試行してください。
+import.button.import.component = \u30b3\u30f3\u30dd\u30fc\u30cd\u30f3\u30c8\u306e\u30a4\u30f3\u30dd\u30fc\u30c8
+import.button.import.components = \u8907\u6570\u30b3\u30f3\u30dd\u30fc\u30cd\u30f3\u30c8\u306e\u30a4\u30f3\u30dd\u30fc\u30c8
+import.button.import.jar = Jar\u306e\u30a4\u30f3\u30dd\u30fc\u30c8 (\u975eUI\u30b3\u30f3\u30dd\u30fc\u30cd\u30f3\u30c8)
+import.button.import.jars = \u8907\u6570Jar\u306e\u30a4\u30f3\u30dd\u30fc\u30c8 (\u975eUI\u30b3\u30f3\u30dd\u30fc\u30cd\u30f3\u30c8)
+import.choice.builtin = \u7d44\u8fbc\u307f
+import.items.processing = \u51e6\u7406\u4e2d...
+import.note = \u30ab\u30b9\u30bf\u30e0\u30fb\u30b3\u30f3\u30dd\u30fc\u30cd\u30f3\u30c8\u306fScene Builder VM\u5185\u306b\u8aad\u8fbc\u307e\u308c\u3001\u632f\u308b\u821e\u3044\u304c\u5909\u5316\u3059\u308b\u3053\u3068\u304c\u3042\u308a\u307e\u3059
+import.num.item = \u30a2\u30a4\u30c6\u30e0
+import.num.items = \u8907\u6570\u30a2\u30a4\u30c6\u30e0
+import.preview.select = \u30a2\u30a4\u30c6\u30e0\u306e\u9078\u629e
+import.preview.unable = \u30a2\u30a4\u30c6\u30e0\u3092\u30a4\u30f3\u30b9\u30bf\u30f3\u30b9\u5316\u3067\u304d\u307e\u305b\u3093
+import.preview.width.height = \u5e45 x \u9ad8\u3055:
+import.preview.width.height.default = \u30c7\u30d5\u30a9\u30eb\u30c8\u306e\u5e45 x \u9ad8\u3055:
+import.toggle.checkall = \u3059\u3079\u3066\u30c1\u30a7\u30c3\u30af
+import.toggle.uncheckall = \u3059\u3079\u3066\u30c1\u30a7\u30c3\u30af\u3092\u5916\u3059
+import.window.title = \u30a4\u30f3\u30dd\u30fc\u30c8\u30fb\u30c0\u30a4\u30a2\u30ed\u30b0
+import.welcome.processing = \u51e6\u7406\u4e2d...
+import.work.cancelled = \u53d6\u6d88\u3055\u308c\u307e\u3057\u305f
+import.work.exploring = {0}\u3092\u63a2\u7d22\u4e2d
+import.error.title = \u30a4\u30f3\u30dd\u30fc\u30c8\u306b\u5931\u6557\u3057\u307e\u3057\u305f
+import.error.message = \u30a4\u30f3\u30dd\u30fc\u30c8\u3092\u5b8c\u4e86\u3067\u304d\u307e\u305b\u3093\u3067\u3057\u305f
+import.error.details = \u30a4\u30f3\u30dd\u30fc\u30c8\u5bfe\u8c61\u3092\u78ba\u8a8d\u3057\u3066\u518d\u8a66\u884c\u3057\u3066\u304f\u3060\u3055\u3044\u3002
 # File -> Import -> FXML / Media
-import.from.file = ''{0}''からインポート
-import.from.file.failed = ''{0}''のインポートに失敗しました
-import.from.file.failed.target = ''{0}''の''{1}''以下へのインポートに失敗しました
+import.from.file = ''{0}''\u304b\u3089\u30a4\u30f3\u30dd\u30fc\u30c8
+import.from.file.failed = ''{0}''\u306e\u30a4\u30f3\u30dd\u30fc\u30c8\u306b\u5931\u6557\u3057\u307e\u3057\u305f
+import.from.file.failed.target = ''{0}''\u306e''{1}''\u4ee5\u4e0b\u3078\u306e\u30a4\u30f3\u30dd\u30fc\u30c8\u306b\u5931\u6557\u3057\u307e\u3057\u305f
 # File -> Include -> FXML
-include.file = ''{0}''のインクルード
-include.file.failed = ''{0}''のインクルードに失敗しました
-include.file.failed.target = ''{0}''の''{1}''以下へのインクルードに失敗しました
+include.file = ''{0}''\u306e\u30a4\u30f3\u30af\u30eb\u30fc\u30c9
+include.file.failed = ''{0}''\u306e\u30a4\u30f3\u30af\u30eb\u30fc\u30c9\u306b\u5931\u6557\u3057\u307e\u3057\u305f
+include.file.failed.target = ''{0}''\u306e''{1}''\u4ee5\u4e0b\u3078\u306e\u30a4\u30f3\u30af\u30eb\u30fc\u30c9\u306b\u5931\u6557\u3057\u307e\u3057\u305f
 
 # -----------------------------------------------------------------------------
 # Library Dialog
 # -----------------------------------------------------------------------------
-no.items.found = アイテムがありません
-library.dialog.title=ライブラリ・マネージャ
+no.items.found = \u30a2\u30a4\u30c6\u30e0\u304c\u3042\u308a\u307e\u305b\u3093
+library.dialog.title=\u30e9\u30a4\u30d6\u30e9\u30ea\u30fb\u30de\u30cd\u30fc\u30b8\u30e3
 
-library.dialog.hyperlink.release = レポジトリを検索
-library.dialog.hyperlink.manually = ライブラリをレポジトリから手作業で追加
-library.dialog.hyperlink.jar = ライブラリ/FXMLをファイル・システムから追加
-library.dialog.hyperlink.repositories = レポジトリを管理
+library.dialog.hyperlink.release = \u30ec\u30dd\u30b8\u30c8\u30ea\u3092\u691c\u7d22
+library.dialog.hyperlink.manually = \u30e9\u30a4\u30d6\u30e9\u30ea\u3092\u30ec\u30dd\u30b8\u30c8\u30ea\u304b\u3089\u624b\u4f5c\u696d\u3067\u8ffd\u52a0
+library.dialog.hyperlink.jar = \u30e9\u30a4\u30d6\u30e9\u30ea/FXML\u3092\u30d5\u30a1\u30a4\u30eb\u30fb\u30b7\u30b9\u30c6\u30e0\u304b\u3089\u8ffd\u52a0
+library.dialog.hyperlink.repositories = \u30ec\u30dd\u30b8\u30c8\u30ea\u3092\u7ba1\u7406
 
-library.dialog.label.installed = インストールされたライブラリ/FXMLファイル:
-library.dialog.label.install = アクション:
+library.dialog.label.installed = \u30a4\u30f3\u30b9\u30c8\u30fc\u30eb\u3055\u308c\u305f\u30e9\u30a4\u30d6\u30e9\u30ea/FXML\u30d5\u30a1\u30a4\u30eb:
+library.dialog.label.install = \u30a2\u30af\u30b7\u30e7\u30f3:
 
-library.dialog.button.edit.tooltip = 押すとライブラリ/FXMLファイルを編集
-library.dialog.button.delete.tooltip = 押すとライブラリ/FXMLファイルを削除
+library.dialog.button.edit.tooltip = \u62bc\u3059\u3068\u30e9\u30a4\u30d6\u30e9\u30ea/FXML\u30d5\u30a1\u30a4\u30eb\u3092\u7de8\u96c6
+library.dialog.button.delete.tooltip = \u62bc\u3059\u3068\u30e9\u30a4\u30d6\u30e9\u30ea/FXML\u30d5\u30a1\u30a4\u30eb\u3092\u524a\u9664
 
-library.dialog.button.close = 閉じる
+library.dialog.button.close = \u9589\u3058\u308b
 
 # -----------------------------------------------------------------------------
 # Maven Dialog
 # -----------------------------------------------------------------------------
-maven.dialog.title = ライブラリをレポジトリから追加
-maven.dialog.label = ライブラリのグループIDとアーティファクトIDを入力
-maven.dialog.groupID = グループID:
-maven.dialog.artifactID = アーティファクトID:
-maven.dialog.version = バージョン:
-maven.dialog.install = JARの追加
-maven.dialog.install.tooltip = 押すとJARおよび依存関係がありそうなものを追加
-maven.dialog.cancel = 取消
+maven.dialog.title = \u30e9\u30a4\u30d6\u30e9\u30ea\u3092\u30ec\u30dd\u30b8\u30c8\u30ea\u304b\u3089\u8ffd\u52a0
+maven.dialog.label = \u30e9\u30a4\u30d6\u30e9\u30ea\u306e\u30b0\u30eb\u30fc\u30d7ID\u3068\u30a2\u30fc\u30c6\u30a3\u30d5\u30a1\u30af\u30c8ID\u3092\u5165\u529b
+maven.dialog.groupID = \u30b0\u30eb\u30fc\u30d7ID:
+maven.dialog.artifactID = \u30a2\u30fc\u30c6\u30a3\u30d5\u30a1\u30af\u30c8ID:
+maven.dialog.version = \u30d0\u30fc\u30b8\u30e7\u30f3:
+maven.dialog.install = JAR\u306e\u8ffd\u52a0
+maven.dialog.install.tooltip = \u62bc\u3059\u3068JAR\u304a\u3088\u3073\u4f9d\u5b58\u95a2\u4fc2\u304c\u3042\u308a\u305d\u3046\u306a\u3082\u306e\u3092\u8ffd\u52a0
+maven.dialog.cancel = \u53d6\u6d88
 # -----------------------------------------------------------------------------
 # Search Maven Dialog
 # -----------------------------------------------------------------------------
-search.maven.dialog.title = ライブラリをレポジトリで検索
-search.maven.dialog.button.search = 検索
-search.maven.dialog.button.search.tooltip = クエリをいくつかのレポジトリで検索
-search.maven.dialog.button.cancel = 取消
-search.maven.dialog.button.cancel.tooltip = 取消して検索を停止
-search.maven.dialog.search = グループまたはアーティファクトのID:
-search.maven.dialog.search.results = 検索結果:
-search.maven.dialog.creation.failed = DefaultServiceLocatorを作成できません
-search.maven.dialog.install = JARの追加
-search.maven.dialog.install.tooltip = 押すとJARおよび依存関係がありそうなものを追加
-search.maven.dialog.cancel = 取消
-search.maven.dialog.installing = {0}を解決中...
+search.maven.dialog.title = \u30e9\u30a4\u30d6\u30e9\u30ea\u3092\u30ec\u30dd\u30b8\u30c8\u30ea\u3067\u691c\u7d22
+search.maven.dialog.button.search = \u691c\u7d22
+search.maven.dialog.button.search.tooltip = \u30af\u30a8\u30ea\u3092\u3044\u304f\u3064\u304b\u306e\u30ec\u30dd\u30b8\u30c8\u30ea\u3067\u691c\u7d22
+search.maven.dialog.button.cancel = \u53d6\u6d88
+search.maven.dialog.button.cancel.tooltip = \u53d6\u6d88\u3057\u3066\u691c\u7d22\u3092\u505c\u6b62
+search.maven.dialog.search = \u30b0\u30eb\u30fc\u30d7\u307e\u305f\u306f\u30a2\u30fc\u30c6\u30a3\u30d5\u30a1\u30af\u30c8\u306eID:
+search.maven.dialog.search.results = \u691c\u7d22\u7d50\u679c:
+search.maven.dialog.creation.failed = DefaultServiceLocator\u3092\u4f5c\u6210\u3067\u304d\u307e\u305b\u3093
+search.maven.dialog.install = JAR\u306e\u8ffd\u52a0
+search.maven.dialog.install.tooltip = \u62bc\u3059\u3068JAR\u304a\u3088\u3073\u4f9d\u5b58\u95a2\u4fc2\u304c\u3042\u308a\u305d\u3046\u306a\u3082\u306e\u3092\u8ffd\u52a0
+search.maven.dialog.cancel = \u53d6\u6d88
+search.maven.dialog.installing = {0}\u3092\u89e3\u6c7a\u4e2d...
 # -----------------------------------------------------------------------------
 # Repository Manager
 # -----------------------------------------------------------------------------
-repository.manager.title = レポジトリ・マネージャ
-repository.manager.label.installed = レポジトリのリスト
-repository.manager.label.install = レポジトリの追加
+repository.manager.title = \u30ec\u30dd\u30b8\u30c8\u30ea\u30fb\u30de\u30cd\u30fc\u30b8\u30e3
+repository.manager.label.installed = \u30ec\u30dd\u30b8\u30c8\u30ea\u306e\u30ea\u30b9\u30c8
+repository.manager.label.install = \u30ec\u30dd\u30b8\u30c8\u30ea\u306e\u8ffd\u52a0
 repository.manager.button.close = OK
-repository.manager.button.install = レポジトリの追加
+repository.manager.button.install = \u30ec\u30dd\u30b8\u30c8\u30ea\u306e\u8ffd\u52a0
 
-repository.manager.button.edit.tooltip = 押すとレポジトリを追加
-repository.manager.button.delete.tooltip = 押すとレポジトリを削除
+repository.manager.button.edit.tooltip = \u62bc\u3059\u3068\u30ec\u30dd\u30b8\u30c8\u30ea\u3092\u8ffd\u52a0
+repository.manager.button.delete.tooltip = \u62bc\u3059\u3068\u30ec\u30dd\u30b8\u30c8\u30ea\u3092\u524a\u9664
 
 # -----------------------------------------------------------------------------
 # Repository Dialog
 # -----------------------------------------------------------------------------
-repository.dialog.title.add = レポジトリの追加
-repository.dialog.title.update = レポジトリの更新
-repository.dialog.nameId = 名前:
-repository.dialog.type = タイプ:
+repository.dialog.title.add = \u30ec\u30dd\u30b8\u30c8\u30ea\u306e\u8ffd\u52a0
+repository.dialog.title.update = \u30ec\u30dd\u30b8\u30c8\u30ea\u306e\u66f4\u65b0
+repository.dialog.nameId = \u540d\u524d:
+repository.dialog.type = \u30bf\u30a4\u30d7:
 repository.dialog.url = URL:
 
-repository.dialog.test = テスト
-repository.dialog.result = エラーは見つかりませんでした
+repository.dialog.test = \u30c6\u30b9\u30c8
+repository.dialog.result = \u30a8\u30e9\u30fc\u306f\u898b\u3064\u304b\u308a\u307e\u305b\u3093\u3067\u3057\u305f
 
-repository.dialog.cancel = 取消
-repository.dialog.add = 追加
-repository.dialog.add.tooltip = 押すとレポジトリを追加
-repository.dialog.update = 更新
-repository.dialog.update.tooltip = 押すとレポジトリを更新
+repository.dialog.cancel = \u53d6\u6d88
+repository.dialog.add = \u8ffd\u52a0
+repository.dialog.add.tooltip = \u62bc\u3059\u3068\u30ec\u30dd\u30b8\u30c8\u30ea\u3092\u8ffd\u52a0
+repository.dialog.update = \u66f4\u65b0
+repository.dialog.update.tooltip = \u62bc\u3059\u3068\u30ec\u30dd\u30b8\u30c8\u30ea\u3092\u66f4\u65b0
 
-repository.dialog.private = プライベート・レポジトリ
-repository.dialog.user = ユーザ名:
-repository.dialog.password = パスワード:
+repository.dialog.private = \u30d7\u30e9\u30a4\u30d9\u30fc\u30c8\u30fb\u30ec\u30dd\u30b8\u30c8\u30ea
+repository.dialog.user = \u30e6\u30fc\u30b6\u540d:
+repository.dialog.password = \u30d1\u30b9\u30ef\u30fc\u30c9:
 
 # -----------------------------------------------------------------------------
 # File watching
 # -----------------------------------------------------------------------------
 
-file.watching.file.created=ファイル"{0}"が作成されました:
-file.watching.file.deleted=ファイル"{0}"は削除されました
-file.watching.file.modified=ファイル"{0}"は変更されました
+file.watching.file.created=\u30d5\u30a1\u30a4\u30eb"{0}"\u304c\u4f5c\u6210\u3055\u308c\u307e\u3057\u305f:
+file.watching.file.deleted=\u30d5\u30a1\u30a4\u30eb"{0}"\u306f\u524a\u9664\u3055\u308c\u307e\u3057\u305f
+file.watching.file.modified=\u30d5\u30a1\u30a4\u30eb"{0}"\u306f\u5909\u66f4\u3055\u308c\u307e\u3057\u305f
 
 # -----------------------------------------------------------------------------
 # Context menus
 # -----------------------------------------------------------------------------
 # Edit menu items
-menu.title.cut = 切取り
-menu.title.copy = コピー
-menu.title.paste = 貼付け
-menu.title.paste.into = 内側に貼付け
-menu.title.duplicate = 複製
-menu.title.delete = 削除
-menu.title.select.parent = 親の選択
+menu.title.cut = \u5207\u53d6\u308a
+menu.title.copy = \u30b3\u30d4\u30fc
+menu.title.paste = \u8cbc\u4ed8\u3051
+menu.title.paste.into = \u5185\u5074\u306b\u8cbc\u4ed8\u3051
+menu.title.duplicate = \u8907\u88fd
+menu.title.delete = \u524a\u9664
+menu.title.select.parent = \u89aa\u306e\u9078\u629e
 # Modify menu items
-menu.title.fit = 親に合せる
-menu.title.use.computed.sizes = 計算されたサイズの使用
+menu.title.fit = \u89aa\u306b\u5408\u305b\u308b
+menu.title.use.computed.sizes = \u8a08\u7b97\u3055\u308c\u305f\u30b5\u30a4\u30ba\u306e\u4f7f\u7528
 menu.title.grid = GridPane
-menu.title.edit.included.default = インクルードされたファイルの編集
-menu.title.reveal.included.default = インクルードされたファイルを表示
+menu.title.edit.included.default = \u30a4\u30f3\u30af\u30eb\u30fc\u30c9\u3055\u308c\u305f\u30d5\u30a1\u30a4\u30eb\u306e\u7de8\u96c6
+menu.title.reveal.included.default = \u30a4\u30f3\u30af\u30eb\u30fc\u30c9\u3055\u308c\u305f\u30d5\u30a1\u30a4\u30eb\u3092\u8868\u793a
 # Modify -> GridPane menu items
-menu.title.grid.move.row.above = 上に行を移動
-menu.title.grid.move.row.below = 下に行を移動
-menu.title.grid.move.column.before = 前に列を移動
-menu.title.grid.move.column.after = 後に列を移動
-menu.title.grid.add.row.above = 上に行を追加
-menu.title.grid.add.row.below = 下に行を追加
-menu.title.grid.add.column.before = 前に列を追加
-menu.title.grid.add.column.after = 後に列を追加
-menu.title.grid.increase.row.span = 行の高さを拡大
-menu.title.grid.decrease.row.span = 行の高さを縮小
-menu.title.grid.increase.column.span = 列の幅を拡大
-menu.title.grid.decrease.column.span = 列の幅を縮小
+menu.title.grid.move.row.above = \u4e0a\u306b\u884c\u3092\u79fb\u52d5
+menu.title.grid.move.row.below = \u4e0b\u306b\u884c\u3092\u79fb\u52d5
+menu.title.grid.move.column.before = \u524d\u306b\u5217\u3092\u79fb\u52d5
+menu.title.grid.move.column.after = \u5f8c\u306b\u5217\u3092\u79fb\u52d5
+menu.title.grid.add.row.above = \u4e0a\u306b\u884c\u3092\u8ffd\u52a0
+menu.title.grid.add.row.below = \u4e0b\u306b\u884c\u3092\u8ffd\u52a0
+menu.title.grid.add.column.before = \u524d\u306b\u5217\u3092\u8ffd\u52a0
+menu.title.grid.add.column.after = \u5f8c\u306b\u5217\u3092\u8ffd\u52a0
+menu.title.grid.increase.row.span = \u884c\u306e\u9ad8\u3055\u3092\u62e1\u5927
+menu.title.grid.decrease.row.span = \u884c\u306e\u9ad8\u3055\u3092\u7e2e\u5c0f
+menu.title.grid.increase.column.span = \u5217\u306e\u5e45\u3092\u62e1\u5927
+menu.title.grid.decrease.column.span = \u5217\u306e\u5e45\u3092\u7e2e\u5c0f
 # Arrange menu items
-menu.title.front = 最前面へ移動
-menu.title.back = 最背面へ移動
-menu.title.forward = 前に配置
-menu.title.backward = 後ろに配置
-menu.title.wrap = ラップ
-menu.title.unwrap = アンラップ
+menu.title.front = \u6700\u524d\u9762\u3078\u79fb\u52d5
+menu.title.back = \u6700\u80cc\u9762\u3078\u79fb\u52d5
+menu.title.forward = \u524d\u306b\u914d\u7f6e
+menu.title.backward = \u5f8c\u308d\u306b\u914d\u7f6e
+menu.title.wrap = \u30e9\u30c3\u30d7
+menu.title.unwrap = \u30a2\u30f3\u30e9\u30c3\u30d7
 
 # -----------------------------------------------------------------------------
 # Preview Window
 # -----------------------------------------------------------------------------
-preview.no.document = ドキュメントなし
-preview.not.node = ノード以外
-scenestylesheet.filechooser.filter.msg = CSSおよびBSSファイル
+preview.no.document = \u30c9\u30ad\u30e5\u30e1\u30f3\u30c8\u306a\u3057
+preview.not.node = \u30ce\u30fc\u30c9\u4ee5\u5916
+scenestylesheet.filechooser.filter.msg = CSS\u304a\u3088\u3073BSS\u30d5\u30a1\u30a4\u30eb
 
 
 # -----------------------------------------------------------------------------
 # Selection Bar
 # -----------------------------------------------------------------------------
-selectionbar.no.selected = 選択なし
-selectionbar.not.object = 選択された要素はオブジェクトではありません
+selectionbar.no.selected = \u9078\u629e\u306a\u3057
+selectionbar.not.object = \u9078\u629e\u3055\u308c\u305f\u8981\u7d20\u306f\u30aa\u30d6\u30b8\u30a7\u30af\u30c8\u3067\u306f\u3042\u308a\u307e\u305b\u3093
 
 # -----------------------------------------------------------------------------
 # Preferences
 # -----------------------------------------------------------------------------
-prefs.background.value1 = 青グリッド
-prefs.background.value2 = ニュートラル・グリッド
-prefs.background.value3 = ニュートラル・ユニフォーム
+prefs.background.value1 = \u9752\u30b0\u30ea\u30c3\u30c9
+prefs.background.value2 = \u30cb\u30e5\u30fc\u30c8\u30e9\u30eb\u30fb\u30b0\u30ea\u30c3\u30c9
+prefs.background.value3 = \u30cb\u30e5\u30fc\u30c8\u30e9\u30eb\u30fb\u30e6\u30cb\u30d5\u30a9\u30fc\u30e0
 
-template.title.header.desktop = デスクトップ
-template.title.header.phone = モバイル
-template.title.new.empty.app = 空
-template.title.new.basic.desktop.app = 基本アプリケーション
-template.title.new.complex.desktop.app = 複合アプリケーション
-template.title.new.empty.phone.app = 空のスクリーン
-template.title.new.basic.phone.app = 基本スクリーン
+template.title.header.desktop = \u30c7\u30b9\u30af\u30c8\u30c3\u30d7
+template.title.header.phone = \u30e2\u30d0\u30a4\u30eb
+template.title.new.empty.app = \u7a7a
+template.title.new.basic.desktop.app = \u57fa\u672c\u30a2\u30d7\u30ea\u30b1\u30fc\u30b7\u30e7\u30f3
+template.title.new.complex.desktop.app = \u8907\u5408\u30a2\u30d7\u30ea\u30b1\u30fc\u30b7\u30e7\u30f3
+template.title.new.empty.phone.app = \u7a7a\u306e\u30b9\u30af\u30ea\u30fc\u30f3
+template.title.new.basic.phone.app = \u57fa\u672c\u30b9\u30af\u30ea\u30fc\u30f3
 
 # -----------------------------------------------------------------------------
 # Other
 # -----------------------------------------------------------------------------
-alert.import.reject.dependencies.title = ユーザ・ライブラリの更新は拒否されました
-alert.import.reject.dependencies.message = オブジェクトが自己完結していないため、ライブラリに追加できません
-alert.import.reject.dependencies.details = 選択されたオブジェクトのいくつかが画像、メディア、あるいは他のFXMLファイルへの参照を含んでいますこれらのオブジェクトはライブラリにドロップできませんこれらの参照を取り除くか、他のオブジェクトを試す必要があります
-error.import.reject.dependencies.scan.title = ユーザ・ライブラリの更新は拒否されました
-error.import.reject.dependencies.scan.message = FXMLの依存関係の調査中にエラーが起きました
-error.import.reject.dependencies.scan.details = 画像、メディア、あるいは他のFXMLファイルへの参照を確認してください
-search.prompt = 検索
-error.dialog.label.details = 詳細の表示...
-error.copy.title = コピーに失敗しました
+alert.import.reject.dependencies.title = \u30e6\u30fc\u30b6\u30fb\u30e9\u30a4\u30d6\u30e9\u30ea\u306e\u66f4\u65b0\u306f\u62d2\u5426\u3055\u308c\u307e\u3057\u305f
+alert.import.reject.dependencies.message = \u30aa\u30d6\u30b8\u30a7\u30af\u30c8\u304c\u81ea\u5df1\u5b8c\u7d50\u3057\u3066\u3044\u306a\u3044\u305f\u3081\u3001\u30e9\u30a4\u30d6\u30e9\u30ea\u306b\u8ffd\u52a0\u3067\u304d\u307e\u305b\u3093
+alert.import.reject.dependencies.details = \u9078\u629e\u3055\u308c\u305f\u30aa\u30d6\u30b8\u30a7\u30af\u30c8\u306e\u3044\u304f\u3064\u304b\u304c\u753b\u50cf\u3001\u30e1\u30c7\u30a3\u30a2\u3001\u3042\u308b\u3044\u306f\u4ed6\u306eFXML\u30d5\u30a1\u30a4\u30eb\u3078\u306e\u53c2\u7167\u3092\u542b\u3093\u3067\u3044\u307e\u3059\u3053\u308c\u3089\u306e\u30aa\u30d6\u30b8\u30a7\u30af\u30c8\u306f\u30e9\u30a4\u30d6\u30e9\u30ea\u306b\u30c9\u30ed\u30c3\u30d7\u3067\u304d\u307e\u305b\u3093\u3053\u308c\u3089\u306e\u53c2\u7167\u3092\u53d6\u308a\u9664\u304f\u304b\u3001\u4ed6\u306e\u30aa\u30d6\u30b8\u30a7\u30af\u30c8\u3092\u8a66\u3059\u5fc5\u8981\u304c\u3042\u308a\u307e\u3059
+error.import.reject.dependencies.scan.title = \u30e6\u30fc\u30b6\u30fb\u30e9\u30a4\u30d6\u30e9\u30ea\u306e\u66f4\u65b0\u306f\u62d2\u5426\u3055\u308c\u307e\u3057\u305f
+error.import.reject.dependencies.scan.message = FXML\u306e\u4f9d\u5b58\u95a2\u4fc2\u306e\u8abf\u67fb\u4e2d\u306b\u30a8\u30e9\u30fc\u304c\u8d77\u304d\u307e\u3057\u305f
+error.import.reject.dependencies.scan.details = \u753b\u50cf\u3001\u30e1\u30c7\u30a3\u30a2\u3001\u3042\u308b\u3044\u306f\u4ed6\u306eFXML\u30d5\u30a1\u30a4\u30eb\u3078\u306e\u53c2\u7167\u3092\u78ba\u8a8d\u3057\u3066\u304f\u3060\u3055\u3044
+search.prompt = \u691c\u7d22
+error.dialog.label.details = \u8a73\u7d30\u306e\u8868\u793a...
+error.copy.title = \u30b3\u30d4\u30fc\u306b\u5931\u6557\u3057\u307e\u3057\u305f
 # {0} is a file path, {1} a directory path
-error.copy.message.single = ファイル{0}を{1}にコピーしようとしてエラーが起きました
+error.copy.message.single = \u30d5\u30a1\u30a4\u30eb{0}\u3092{1}\u306b\u30b3\u30d4\u30fc\u3057\u3088\u3046\u3068\u3057\u3066\u30a8\u30e9\u30fc\u304c\u8d77\u304d\u307e\u3057\u305f
 # {0} is a number >= 2, {1} a directory path
-error.copy.message.multiple = {1}へコピーしようとした{0}個のファイルでそれぞれエラーが起きました
-error.disk.space.title = ディスク空き容量の計算に失敗しました
-error.disk.space.message = ディスクの空き容量を計算できません
-error.dir.create.title = ディレクトリ作成に失敗しました
+error.copy.message.multiple = {1}\u3078\u30b3\u30d4\u30fc\u3057\u3088\u3046\u3068\u3057\u305f{0}\u500b\u306e\u30d5\u30a1\u30a4\u30eb\u3067\u305d\u308c\u305e\u308c\u30a8\u30e9\u30fc\u304c\u8d77\u304d\u307e\u3057\u305f
+error.disk.space.title = \u30c7\u30a3\u30b9\u30af\u7a7a\u304d\u5bb9\u91cf\u306e\u8a08\u7b97\u306b\u5931\u6557\u3057\u307e\u3057\u305f
+error.disk.space.message = \u30c7\u30a3\u30b9\u30af\u306e\u7a7a\u304d\u5bb9\u91cf\u3092\u8a08\u7b97\u3067\u304d\u307e\u305b\u3093
+error.dir.create.title = \u30c7\u30a3\u30ec\u30af\u30c8\u30ea\u4f5c\u6210\u306b\u5931\u6557\u3057\u307e\u3057\u305f
 # {0} is a directory path
-error.dir.create.message = ディレクトリ{0}を作成できません
-error.file.create.title = ファイル作成に失敗しました
+error.dir.create.message = \u30c7\u30a3\u30ec\u30af\u30c8\u30ea{0}\u3092\u4f5c\u6210\u3067\u304d\u307e\u305b\u3093
+error.file.create.title = \u30d5\u30a1\u30a4\u30eb\u4f5c\u6210\u306b\u5931\u6557\u3057\u307e\u3057\u305f
 # {0} is a file path
-error.file.create.message = ファイル{0}を作成できません
-error.file.open.message = ファイル{0}を開けません
-error.file.open.title = ファイルを開くのに失敗しました
-error.write.details = ファイル・システムを確認してください。
-error.file.reveal.title = ファイルを見つけるのに失敗しました
-error.file.reveal.message = ファイル{0}が見つかりません
+error.file.create.message = \u30d5\u30a1\u30a4\u30eb{0}\u3092\u4f5c\u6210\u3067\u304d\u307e\u305b\u3093
+error.file.open.message = \u30d5\u30a1\u30a4\u30eb{0}\u3092\u958b\u3051\u307e\u305b\u3093
+error.file.open.title = \u30d5\u30a1\u30a4\u30eb\u3092\u958b\u304f\u306e\u306b\u5931\u6557\u3057\u307e\u3057\u305f
+error.write.details = \u30d5\u30a1\u30a4\u30eb\u30fb\u30b7\u30b9\u30c6\u30e0\u3092\u78ba\u8a8d\u3057\u3066\u304f\u3060\u3055\u3044\u3002
+error.file.reveal.title = \u30d5\u30a1\u30a4\u30eb\u3092\u898b\u3064\u3051\u308b\u306e\u306b\u5931\u6557\u3057\u307e\u3057\u305f
+error.file.reveal.message = \u30d5\u30a1\u30a4\u30eb{0}\u304c\u898b\u3064\u304b\u308a\u307e\u305b\u3093
 
 #maven
-log.user.maven.installed = {0}はローカル・レポジトリにインストールされています
-log.user.maven.failed = {0}のインストールに失敗しました
-log.user.maven.updated = {0}個のコンポーネントが更新されました
+log.user.maven.installed = {0}\u306f\u30ed\u30fc\u30ab\u30eb\u30fb\u30ec\u30dd\u30b8\u30c8\u30ea\u306b\u30a4\u30f3\u30b9\u30c8\u30fc\u30eb\u3055\u308c\u3066\u3044\u307e\u3059
+log.user.maven.failed = {0}\u306e\u30a4\u30f3\u30b9\u30c8\u30fc\u30eb\u306b\u5931\u6557\u3057\u307e\u3057\u305f
+log.user.maven.updated = {0}\u500b\u306e\u30b3\u30f3\u30dd\u30fc\u30cd\u30f3\u30c8\u304c\u66f4\u65b0\u3055\u308c\u307e\u3057\u305f
 
 #repositories
-log.user.repository.added = {0}がレポジトリのリストに追加されました
-log.user.repository.removed = {0}はレポジトリのリストから削除されました
-log.user.repository.updated = {0}は更新されました
+log.user.repository.added = {0}\u304c\u30ec\u30dd\u30b8\u30c8\u30ea\u306e\u30ea\u30b9\u30c8\u306b\u8ffd\u52a0\u3055\u308c\u307e\u3057\u305f
+log.user.repository.removed = {0}\u306f\u30ec\u30dd\u30b8\u30c8\u30ea\u306e\u30ea\u30b9\u30c8\u304b\u3089\u524a\u9664\u3055\u308c\u307e\u3057\u305f
+log.user.repository.updated = {0}\u306f\u66f4\u65b0\u3055\u308c\u307e\u3057\u305f
 
 ################ CSS Panel FXML
-csspanel.col.api.defaults = APIのデフォルト
-csspanel.col.defaults = デフォルト
-csspanel.col.inline = インライン・スタイル
-csspanel.col.inspector = インスペクタ
-csspanel.col.properties = プロパティ
-csspanel.col.stylesheets = スタイルシート
-csspanel.col.theme.defaults = FXテーマのデフォルト
-csspanel.hide.default.values = デフォルト値を持つプロパティを非表示
-csspanel.join = デフォルトを結合
-csspanel.styleable.path = スタイル設定可能なパス:
-csspanel.selection.tooltip = CSS選択モード
-csspanel.picking.tooltip = CSSピッキング・モード
+csspanel.col.api.defaults = API\u306e\u30c7\u30d5\u30a9\u30eb\u30c8
+csspanel.col.defaults = \u30c7\u30d5\u30a9\u30eb\u30c8
+csspanel.col.inline = \u30a4\u30f3\u30e9\u30a4\u30f3\u30fb\u30b9\u30bf\u30a4\u30eb
+csspanel.col.inspector = \u30a4\u30f3\u30b9\u30da\u30af\u30bf
+csspanel.col.properties = \u30d7\u30ed\u30d1\u30c6\u30a3
+csspanel.col.stylesheets = \u30b9\u30bf\u30a4\u30eb\u30b7\u30fc\u30c8
+csspanel.col.theme.defaults = FX\u30c6\u30fc\u30de\u306e\u30c7\u30d5\u30a9\u30eb\u30c8
+csspanel.hide.default.values = \u30c7\u30d5\u30a9\u30eb\u30c8\u5024\u3092\u6301\u3064\u30d7\u30ed\u30d1\u30c6\u30a3\u3092\u975e\u8868\u793a
+csspanel.join = \u30c7\u30d5\u30a9\u30eb\u30c8\u3092\u7d50\u5408
+csspanel.styleable.path = \u30b9\u30bf\u30a4\u30eb\u8a2d\u5b9a\u53ef\u80fd\u306a\u30d1\u30b9:
+csspanel.selection.tooltip = CSS\u9078\u629e\u30e2\u30fc\u30c9
+csspanel.picking.tooltip = CSS\u30d4\u30c3\u30ad\u30f3\u30b0\u30fb\u30e2\u30fc\u30c9
 
 ################ CSS Panel Controller only
-csspanel = CSSアナライザ
-csspanel.api.defaults.navigation = API (組込み)
-csspanel.api.origin = ノード
-csspanel.fxtheme.defaults.navigation = FXテーマ
-csspanel.fxtheme.origin = FXテーマのスタイルシート
-csspanel.copy = コピー
-csspanel.inherited = 継承
-csspanel.no.matching.rule = 一致するルールがありません
-csspanel.node.property = プロパティ
-csspanel.reveal.inspector = インスペクタに表示...
-csspanel.reveal.finder = {0}をファインダに表示
-csspanel.reveal.explorer = {0}をエクスプローラに表示
-csspanel.open.stylesheet = {0}を開く
-csspanel.multiselection = 複数の選択
+csspanel = CSS\u30a2\u30ca\u30e9\u30a4\u30b6
+csspanel.api.defaults.navigation = API (\u7d44\u8fbc\u307f)
+csspanel.api.origin = \u30ce\u30fc\u30c9
+csspanel.fxtheme.defaults.navigation = FX\u30c6\u30fc\u30de
+csspanel.fxtheme.origin = FX\u30c6\u30fc\u30de\u306e\u30b9\u30bf\u30a4\u30eb\u30b7\u30fc\u30c8
+csspanel.copy = \u30b3\u30d4\u30fc
+csspanel.inherited = \u7d99\u627f
+csspanel.no.matching.rule = \u4e00\u81f4\u3059\u308b\u30eb\u30fc\u30eb\u304c\u3042\u308a\u307e\u305b\u3093
+csspanel.node.property = \u30d7\u30ed\u30d1\u30c6\u30a3
+csspanel.reveal.inspector = \u30a4\u30f3\u30b9\u30da\u30af\u30bf\u306b\u8868\u793a...
+csspanel.reveal.finder = {0}\u3092\u30d5\u30a1\u30a4\u30f3\u30c0\u306b\u8868\u793a
+csspanel.reveal.explorer = {0}\u3092\u30a8\u30af\u30b9\u30d7\u30ed\u30fc\u30e9\u306b\u8868\u793a
+csspanel.open.stylesheet = {0}\u3092\u958b\u304f
+csspanel.multiselection = \u8907\u6570\u306e\u9078\u629e
 
 ################ Description of Jobs
-job.decrease.column.span = 列の幅を縮小
-job.increase.column.span = 列の幅を拡大
-job.decrease.row.span = 行の高さを縮小
-job.increase.row.span = 行の高さを拡大
-job.set.size = 定義済みサイズ{0} x {1}を使用
-job.set.toggle.group = トグル・グループの設定
-job.toggle.fx.root = fx:rootをトグル
-job.set.fxid = fx:idを''{0}''に設定
-job.remove.fxid = fx:id ''{0}''の削除
+job.decrease.column.span = \u5217\u306e\u5e45\u3092\u7e2e\u5c0f
+job.increase.column.span = \u5217\u306e\u5e45\u3092\u62e1\u5927
+job.decrease.row.span = \u884c\u306e\u9ad8\u3055\u3092\u7e2e\u5c0f
+job.increase.row.span = \u884c\u306e\u9ad8\u3055\u3092\u62e1\u5927
+job.set.size = \u5b9a\u7fa9\u6e08\u307f\u30b5\u30a4\u30ba{0} x {1}\u3092\u4f7f\u7528
+job.set.toggle.group = \u30c8\u30b0\u30eb\u30fb\u30b0\u30eb\u30fc\u30d7\u306e\u8a2d\u5b9a
+job.toggle.fx.root = fx:root\u3092\u30c8\u30b0\u30eb
+job.set.fxid = fx:id\u3092''{0}''\u306b\u8a2d\u5b9a
+job.remove.fxid = fx:id ''{0}''\u306e\u524a\u9664
 
 ################ Alert when Gluon Mobile theme is not set
 alert.theme.gluon.mobile.title = Scene Builder
-alert.theme.gluon.mobile.headertext = Gluon Mobileテーマは設定されていません
-alert.theme.gluon.mobile.contenttext = Gluon Mobileテーマを設定せずにGluonコントロールを使うと、正しく動作しないことがあります
-alert.theme.gluon.mobile.setgluontheme = Gluonテーマの設定
-alert.theme.gluon.mobile.ignore = 無視
+alert.theme.gluon.mobile.headertext = Gluon Mobile\u30c6\u30fc\u30de\u306f\u8a2d\u5b9a\u3055\u308c\u3066\u3044\u307e\u305b\u3093
+alert.theme.gluon.mobile.contenttext = Gluon Mobile\u30c6\u30fc\u30de\u3092\u8a2d\u5b9a\u305b\u305a\u306bGluon\u30b3\u30f3\u30c8\u30ed\u30fc\u30eb\u3092\u4f7f\u3046\u3068\u3001\u6b63\u3057\u304f\u52d5\u4f5c\u3057\u306a\u3044\u3053\u3068\u304c\u3042\u308a\u307e\u3059
+alert.theme.gluon.mobile.setgluontheme = Gluon\u30c6\u30fc\u30de\u306e\u8a2d\u5b9a
+alert.theme.gluon.mobile.ignore = \u7121\u8996
 
 ################ Alert when importing Gluon controls
 alert.importing.gluon.title = Scene Builder
-alert.importing.gluon.headertext = Gluonコントロールをインポートしています
-alert.importing.gluon.contenttext = このバージョンのScene BuilderではGluonコントロールが既に提供されているため、これらのコントロールはインポートされません
+alert.importing.gluon.headertext = Gluon\u30b3\u30f3\u30c8\u30ed\u30fc\u30eb\u3092\u30a4\u30f3\u30dd\u30fc\u30c8\u3057\u3066\u3044\u307e\u3059
+alert.importing.gluon.contenttext = \u3053\u306e\u30d0\u30fc\u30b8\u30e7\u30f3\u306eScene Builder\u3067\u306fGluon\u30b3\u30f3\u30c8\u30ed\u30fc\u30eb\u304c\u65e2\u306b\u63d0\u4f9b\u3055\u308c\u3066\u3044\u308b\u305f\u3081\u3001\u3053\u308c\u3089\u306e\u30b3\u30f3\u30c8\u30ed\u30fc\u30eb\u306f\u30a4\u30f3\u30dd\u30fc\u30c8\u3055\u308c\u307e\u305b\u3093
 alert.importing.gluon.ok.button = OK
 
 ################ Scene Builder theme
-prefs.tool.theme.default = デフォルトのテーマ
+prefs.tool.theme.default = \u30c7\u30d5\u30a9\u30eb\u30c8\u306e\u30c6\u30fc\u30de
 prefs.tool.theme.dark = Dark Theme
 
 ################ Skeleton window
-skeleton.add.comments = コメント
-skeleton.empty = 空のドキュメントからはスケルトンを構築できません
+skeleton.add.comments = \u30b3\u30e1\u30f3\u30c8
+skeleton.empty = \u7a7a\u306e\u30c9\u30ad\u30e5\u30e1\u30f3\u30c8\u304b\u3089\u306f\u30b9\u30b1\u30eb\u30c8\u30f3\u3092\u69cb\u7bc9\u3067\u304d\u307e\u305b\u3093
 skeleton.format.full = Full
 # Parameter is a fxml file name
-skeleton.window.title = "{0}"コントローラ・クラスのサンプル・スケルトン
+skeleton.window.title = "{0}"\u30b3\u30f3\u30c8\u30ed\u30fc\u30e9\u30fb\u30af\u30e9\u30b9\u306e\u30b5\u30f3\u30d7\u30eb\u30fb\u30b9\u30b1\u30eb\u30c8\u30f3
 
 ################# Templates Window
-template.dialog.title = テンプレート
+template.dialog.title = \u30c6\u30f3\u30d7\u30ec\u30fc\u30c8
 
 ################# Generic Labels
-label.untitled = 無題
-label.no.document = ドキュメントなし
+label.untitled = \u7121\u984c
+label.no.document = \u30c9\u30ad\u30e5\u30e1\u30f3\u30c8\u306a\u3057
 
 # -----------------------------------------------------------------------------
 # Other (from app i18n)
 # -----------------------------------------------------------------------------
-file.filter.label.fxml = FXMLドキュメント
+file.filter.label.fxml = FXML\u30c9\u30ad\u30e5\u30e1\u30f3\u30c8
 
 # -----------------------------------------------------------------------------
 # Alert (from app i18n)
 # -----------------------------------------------------------------------------
-alert.title.open = 開く...
+alert.title.open = \u958b\u304f...
 
-alert.open.failure.charset.not.found = 指定された文字集合は設定できません。
-alert.open.failure.charset.not.found.details = ドキュメントのエンコーディングが原因の可能性があります。
+alert.open.failure.charset.not.found = \u6307\u5b9a\u3055\u308c\u305f\u6587\u5b57\u96c6\u5408\u306f\u8a2d\u5b9a\u3067\u304d\u307e\u305b\u3093\u3002
+alert.open.failure.charset.not.found.details = \u30c9\u30ad\u30e5\u30e1\u30f3\u30c8\u306e\u30a8\u30f3\u30b3\u30fc\u30c7\u30a3\u30f3\u30b0\u304c\u539f\u56e0\u306e\u53ef\u80fd\u6027\u304c\u3042\u308a\u307e\u3059\u3002
 
 # -----------------------------------------------------------------------------
 # Themes (from app i18n)
@@ -511,18 +511,18 @@ title.theme.gluon_mobile_dark = Gluon Mobile Dark
 title.theme.gluon_mobile_light = Gluon Mobile Light
 title.theme.modena = Modena (FX8)
 title.theme.modena_touch = Modena Touch (FX8)
-title.theme.modena_high_contrast_black_on_white = Modena高コントラスト - 白地に黒 (FX8)
-title.theme.modena_high_contrast_white_on_black = Modena高コントラスト - 黒地に白 (FX8)
-title.theme.modena_high_contrast_yellow_on_black = Modena高コントラスト - 黒地に黄 (FX8)
-title.theme.modena_touch_high_contrast_black_on_white = Modena Touch高コントラスト - 白地に黒 (FX8)
-title.theme.modena_touch_high_contrast_white_on_black = Modena Touch高コントラスト - 黒地に白 (FX8)
-title.theme.modena_touch_high_contrast_yellow_on_black = Modena Touch高コントラスト - 黒地に黄 (FX8)
+title.theme.modena_high_contrast_black_on_white = Modena\u9ad8\u30b3\u30f3\u30c8\u30e9\u30b9\u30c8 - \u767d\u5730\u306b\u9ed2 (FX8)
+title.theme.modena_high_contrast_white_on_black = Modena\u9ad8\u30b3\u30f3\u30c8\u30e9\u30b9\u30c8 - \u9ed2\u5730\u306b\u767d (FX8)
+title.theme.modena_high_contrast_yellow_on_black = Modena\u9ad8\u30b3\u30f3\u30c8\u30e9\u30b9\u30c8 - \u9ed2\u5730\u306b\u9ec4 (FX8)
+title.theme.modena_touch_high_contrast_black_on_white = Modena Touch\u9ad8\u30b3\u30f3\u30c8\u30e9\u30b9\u30c8 - \u767d\u5730\u306b\u9ed2 (FX8)
+title.theme.modena_touch_high_contrast_white_on_black = Modena Touch\u9ad8\u30b3\u30f3\u30c8\u30e9\u30b9\u30c8 - \u9ed2\u5730\u306b\u767d (FX8)
+title.theme.modena_touch_high_contrast_yellow_on_black = Modena Touch\u9ad8\u30b3\u30f3\u30c8\u30e9\u30b9\u30c8 - \u9ed2\u5730\u306b\u9ec4 (FX8)
 title.theme.caspian = Caspian (FX2)
 title.theme.caspian_embedded = Caspian Embedded (FX2)
 title.theme.caspian_embedded_qvga = Caspian Embedded QVGA (FX2)
-title.theme.caspian_high_contrast = Caspian高コントラスト (FX2)
-title.theme.caspian_embedded_high_contrast = Caspian Embedded高コントラスト (FX2)
-title.theme.caspian_embedded_qvga_high_contrast = Caspian Embedded QVGA高コントラスト (FX2)
+title.theme.caspian_high_contrast = Caspian\u9ad8\u30b3\u30f3\u30c8\u30e9\u30b9\u30c8 (FX2)
+title.theme.caspian_embedded_high_contrast = Caspian Embedded\u9ad8\u30b3\u30f3\u30c8\u30e9\u30b9\u30c8 (FX2)
+title.theme.caspian_embedded_qvga_high_contrast = Caspian Embedded QVGA\u9ad8\u30b3\u30f3\u30c8\u30e9\u30b9\u30c8 (FX2)
 # Gluon Swatches
 title.gluon.swatch.blue = Blue Swatch
 title.gluon.swatch.cyan = Cyan Swatch


### PR DESCRIPTION
In Scene Builder Windows Installer 64-bit which is available from https://gluonhq.com/products/scene-builder/#download , all of the menu text are garbled and unreadable on Japanese locale. 'Executable Jar' seems to be mostly OK, but some of the text are still garbled.

I compared dist.jar from the Windows version and scenebuilder-8.5.0-all.jar from the Executable Jar, and found that two com/oracle/javafx/scenebuilder/app/i18n/SceneBuilderApp_ja.properties are different, so I think that the dist.jar contains wrong properties file.

I also found that the rest of the text are become readable if I replaced SceneBuilderKit_ja.properties with encoded with ```native2ascii```.