### PR TITLE
fix #195 no longer use unicode escape, and specify encoding explicitl…

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -41,7 +41,6 @@ processResources {
             javaVersion: System.getProperty('java.runtime.version') + ', ' + System.getProperty('java.vendor'),
             buildDate: buildDate
         ])
-        filter(EscapeUnicode)
     }
     into buildDir
 }

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -9,7 +9,7 @@
 if "%OS%"=="Windows_NT" setlocal
 
 @rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-set DEFAULT_JVM_OPTS=
+set DEFAULT_JVM_OPTS=-Dfile.encoding=UTF-8
 
 set DIRNAME=%~dp0
 if "%DIRNAME%" == "" set DIRNAME=.


### PR DESCRIPTION
At first, in Java SE 9, resource bundle property files are loaded in UTF-8 encoding, no longer needed unicode escaped. But there is an unicode escape process in build.gradle, so remove the line.

Next, gradle's Java plugin introduces processResources task.
This task uses gradle's Copy task internally, and the Copy task is seemed to miss encoding 
when the system encoding is different from the file copied.
So, specify encoding explicitly as UTF-8 in gradlew.bat which is used on Windows OS.