### PR TITLE
Store Color as an object instead of its web string representation

### DIFF
--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/inspector/InspectorPanelController.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/inspector/InspectorPanelController.java
@@ -58,6 +58,7 @@ import com.oracle.javafx.scenebuilder.kit.metadata.property.value.effect.EffectP
 import com.oracle.javafx.scenebuilder.kit.metadata.property.value.keycombination.KeyCombinationPropertyMetadata;
 import com.oracle.javafx.scenebuilder.kit.metadata.property.value.list.ListValuePropertyMetadata;
 import com.oracle.javafx.scenebuilder.kit.metadata.property.value.list.StringListPropertyMetadata;
+import com.oracle.javafx.scenebuilder.kit.metadata.property.value.paint.ColorPropertyMetadata;
 import com.oracle.javafx.scenebuilder.kit.metadata.property.value.paint.PaintPropertyMetadata;
 import com.oracle.javafx.scenebuilder.kit.metadata.util.InspectorPath;
 import com.oracle.javafx.scenebuilder.kit.metadata.util.PropertyName;
@@ -69,7 +70,6 @@ import javafx.application.Platform;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.value.ChangeListener;
-import javafx.beans.value.ObservableValue;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.geometry.HPos;
@@ -192,6 +192,8 @@ public class InspectorPanelController extends AbstractFxmlPanelController {
     private final Stack<Editor> buttonTypeEditorPool = new Stack<>();
     private final Stack<Editor> includeFxmlEditorPool = new Stack<>();
     private final Stack<Editor> charsetEditorPool = new Stack<>();
+    private final Stack<Editor> colorEditorPool = new Stack<>();
+
     // ...
     //
     // Subsection title pool
@@ -233,31 +235,13 @@ public class InspectorPanelController extends AbstractFxmlPanelController {
         this.editorController = editorController;
         this.availableCharsets = CharsetEditor.getStandardCharsets();
         viewModeProperty.setValue(ViewMode.SECTION);
-        viewModeProperty.addListener(new ChangeListener<ViewMode>() {
-            @Override
-            public void changed(ObservableValue<? extends ViewMode> arg0,
-                    ViewMode previousMode, ViewMode mode) {
-                viewModeChanged(previousMode, mode);
-            }
-        });
+        viewModeProperty.addListener((obv, previousMode, mode) -> viewModeChanged(previousMode, mode));
 
         showModeProperty.setValue(ShowMode.ALL);
-        showModeProperty.addListener(new ChangeListener<ShowMode>() {
-            @Override
-            public void changed(ObservableValue<? extends ShowMode> arg0,
-                    ShowMode previousMode, ShowMode mode) {
-                showModeChanged();
-            }
-        });
+        showModeProperty.addListener((obv, previousMode, mode) -> showModeChanged());
 
         expandedSectionProperty.setValue(SectionId.PROPERTIES);
-        expandedSectionProperty.addListener(new ChangeListener<SectionId>() {
-            @Override
-            public void changed(ObservableValue<? extends SectionId> arg0,
-                    SectionId previousSectionId, SectionId sectionId) {
-                expandedSectionChanged();
-            }
-        });
+        expandedSectionProperty.addListener((obv, previousSectionId, sectionId) -> expandedSectionChanged());
 
         // Editor pools init
         editorPools.put(I18nStringEditor.class, i18nStringEditorPool);
@@ -295,6 +279,7 @@ public class InspectorPanelController extends AbstractFxmlPanelController {
         editorPools.put(ButtonTypeEditor.class, buttonTypeEditorPool);
         editorPools.put(IncludeFxmlEditor.class, includeFxmlEditorPool);
         editorPools.put(CharsetEditor.class, charsetEditorPool);
+        editorPools.put(ColorPopupEditor.class, colorEditorPool);
 
         // ...
     }
@@ -1473,6 +1458,8 @@ public class InspectorPanelController extends AbstractFxmlPanelController {
             propertyEditor = makePropertyEditor(ToggleGroupEditor.class, propMeta);
         } else if (propMeta instanceof DurationPropertyMetadata) {
             propertyEditor = makePropertyEditor(DurationEditor.class, propMeta);
+        } else if (propMeta instanceof ColorPropertyMetadata) {
+            propertyEditor = makePropertyEditor(ColorPopupEditor.class, propMeta);
         } else {
             // Generic editor
             propertyEditor = makePropertyEditor(GenericEditor.class, propMeta);
@@ -1966,6 +1953,12 @@ public class InspectorPanelController extends AbstractFxmlPanelController {
         }
         else if(editorClass == CharsetEditor.class) {
             createdPropertyEditor = createOrResetCharsetEditor(createdPropertyEditor, selectedClasses, propMeta);
+        } else if (editorClass == ColorPopupEditor.class) {
+            if (createdPropertyEditor != null) {
+                createdPropertyEditor.reset(propMeta, selectedClasses);
+            } else {
+                createdPropertyEditor = new ColorPopupEditor(propMeta, selectedClasses, getEditorController());
+            }
         }
         else {
             if (createdPropertyEditor != null) {

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/inspector/editors/ColorPopupEditor.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/inspector/editors/ColorPopupEditor.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2018, Gluon and/or its affiliates.
+ * All rights reserved. Use is subject to license terms.
+ *
+ * This file is available and licensed under the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the distribution.
+ *  - Neither the name of Oracle Corporation nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.javafx.scenebuilder.kit.editor.panel.inspector.editors;
+
+import com.oracle.javafx.scenebuilder.kit.editor.EditorController;
+import com.oracle.javafx.scenebuilder.kit.editor.panel.inspector.popupeditors.PaintPopupEditor;
+import com.oracle.javafx.scenebuilder.kit.metadata.property.ValuePropertyMetadata;
+import com.oracle.javafx.scenebuilder.kit.util.control.paintpicker.PaintPicker;
+
+import java.util.Set;
+
+/**
+ * The editor is shown as a MenuButton. This button then shows a popup
+ * to select a {@link javafx.scene.paint.Color}.
+ */
+public class ColorPopupEditor extends PaintPopupEditor {
+
+    private EditorController editorController;
+
+    public ColorPopupEditor(ValuePropertyMetadata propMeta, Set<Class<?>> selectedClasses, EditorController editorController) {
+        super(propMeta, selectedClasses, editorController);
+        this.editorController = editorController;
+    }
+
+    @Override
+    public void initializePopupContent() {
+        final PaintPicker.Delegate delegate = (warningKey, arguments) -> editorController.getMessageLog().logWarningMessage(warningKey, arguments);
+        paintPicker = new PaintPicker(delegate, PaintPicker.Mode.COLOR);
+    }
+}

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/inspector/popupeditors/PaintPopupEditor.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/inspector/popupeditors/PaintPopupEditor.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2018, Gluon and/or its affiliates.
  * Copyright (c) 2012, 2014, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
@@ -52,13 +53,13 @@ import javafx.scene.shape.Rectangle;
  */
 public class PaintPopupEditor extends PopupEditor {
 
-    private PaintPicker paintPicker;
     private final Rectangle graphic = new Rectangle(20, 10);
     private EditorController editorController;
+    protected PaintPicker paintPicker;
 
     private final ChangeListener<Paint> paintChangeListener = (ov, oldValue, newValue) -> {
         // If live update, do not commit the value
-        if (paintPicker.isLiveUpdate() == true) {
+        if (paintPicker.isLiveUpdate()) {
             userUpdateTransientValueProperty(newValue);
             popupMb.setText(getPreviewString(newValue));
         } else {
@@ -68,7 +69,7 @@ public class PaintPopupEditor extends PopupEditor {
     };
 
     private final ChangeListener<Boolean> liveUpdateListener = (ov, oldValue, newValue) -> {
-        if (paintPicker.isLiveUpdate() == false) {
+        if (!paintPicker.isLiveUpdate()) {
             commitValue(paintPicker.getPaintProperty());
         }
     };

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/fxom/glue/GlueSerializer.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/fxom/glue/GlueSerializer.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2018, Gluon and/or its affiliates.
  * Copyright (c) 2012, 2014, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
@@ -45,6 +46,9 @@ class GlueSerializer {
     
     private static final XMLAttrComparator attrComparator
             = new XMLAttrComparator();
+
+    private static final XMLAttrComparator colorAttrComparator =
+            new XMLColorAttrComparator();
     
     private final GlueDocument document;
     
@@ -143,8 +147,12 @@ class GlueSerializer {
         for (Map.Entry<String, String> entry : attributes.entrySet()) {
             attrNames.add(new SimpleEntry<>(entry.getKey(), entry.getValue()));
         }
-        Collections.sort(attrNames, attrComparator);
-        
+        if (element.getTagName().equals("Color")) {
+            Collections.sort(attrNames, colorAttrComparator);
+        } else {
+            Collections.sort(attrNames, attrComparator);
+        }
+
         for (Map.Entry<String,String> e : attrNames) {
             xmlBuffer.addAttribute(e.getKey(), e.getValue());
         }

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/fxom/glue/XMLAttrComparator.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/fxom/glue/XMLAttrComparator.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2018, Gluon and/or its affiliates.
  * Copyright (c) 2012, 2014, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
@@ -35,8 +36,10 @@ import java.util.Comparator;
 import java.util.Map;
 
 /**
+ * A Comparator for comparing the indices of the attributes of an element.
+ * These indices decides the location of each attribute in the FXML document.
  *
- * 
+ * This class can be extended to create a customized comparator for each attribute.
  */
 class XMLAttrComparator implements Comparator<Map.Entry<String,String>> {
 
@@ -59,19 +62,18 @@ class XMLAttrComparator implements Comparator<Map.Entry<String,String>> {
         
         return result;
     }
-    
-    
-    /*
-     * Private
+
+    /**
+     * Returns attribute index for a particular attribute
+     * @param attr Attribute of an element whose index is to be found out
+     * @return The index of the attribute in the FXML attribute list
      */
-    
-    private int getAttrOrderIndex(Map.Entry<String,String> attr) {
+    protected int getAttrOrderIndex(Map.Entry<String,String> attr) {
         assert attr != null;
         
         /*
          * fx:id < id < other-attr < fx:controller
          */
-        
         final int result;
         switch(attr.getKey()) {
             case "id": //NOI18N

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/fxom/glue/XMLColorAttrComparator.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/fxom/glue/XMLColorAttrComparator.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2018, Gluon and/or its affiliates.
+ * All rights reserved. Use is subject to license terms.
+ *
+ * This file is available and licensed under the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the distribution.
+ *  - Neither the name of Oracle Corporation nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.javafx.scenebuilder.kit.fxom.glue;
+
+import java.util.Map;
+
+/**
+ * Compares attributes of {@link javafx.scene.paint.Color} element.
+ *
+ * The comparator follows the following order:
+ * red < green < blue < opacity < other attributes
+ */
+class XMLColorAttrComparator extends XMLAttrComparator {
+
+    protected int getAttrOrderIndex(Map.Entry<String,String> attr) {
+        assert attr != null;
+
+        final int result;
+        switch (attr.getKey()) {
+            case "red"     : result = 0; break;
+            case "green"   : result = 1; break;
+            case "blue"    : result = 2; break;
+            case "opacity" : result = 3; break;
+            default        : result = 4; break;
+        }
+        return result;
+    }
+}

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/metadata/property/value/paint/ColorPropertyMetadata.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/metadata/property/value/paint/ColorPropertyMetadata.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2018, Gluon and/or its affiliates.
  * Copyright (c) 2012, 2014, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
@@ -31,35 +32,66 @@
  */
 package com.oracle.javafx.scenebuilder.kit.metadata.property.value.paint;
 
-import com.oracle.javafx.scenebuilder.kit.metadata.property.value.TextEncodablePropertyMetadata;
+import com.oracle.javafx.scenebuilder.kit.fxom.FXOMDocument;
+import com.oracle.javafx.scenebuilder.kit.fxom.FXOMInstance;
+import com.oracle.javafx.scenebuilder.kit.metadata.property.value.ComplexPropertyMetadata;
+import com.oracle.javafx.scenebuilder.kit.metadata.property.value.DoublePropertyMetadata;
 import com.oracle.javafx.scenebuilder.kit.metadata.util.ColorEncoder;
 import com.oracle.javafx.scenebuilder.kit.metadata.util.InspectorPath;
 import com.oracle.javafx.scenebuilder.kit.metadata.util.PropertyName;
 import javafx.scene.paint.Color;
 
 /**
- *
+ * ColorPropertyMetadata helps resolve Color as a combination of red, green, blue, opacity using
+ * the constructor {@link Color#Color(double, double, double, double)}.
+ * 
+ * The FXML representation of the same is:
+ * 
+ * <pre>
+ * {@code
+ * <Color blue="0.5" green="0.3" opacity="0.8" red="0.6" />
+ * }</pre>
  */
-public class ColorPropertyMetadata extends TextEncodablePropertyMetadata<Color> {
+public class ColorPropertyMetadata extends ComplexPropertyMetadata<Color> {
+
+    private final DoublePropertyMetadata redMetadata
+            = new DoublePropertyMetadata(new PropertyName("red"),
+            DoublePropertyMetadata.DoubleKind.OPACITY, true, 0.0, InspectorPath.UNUSED);
+    private final DoublePropertyMetadata greenMetadata
+            = new DoublePropertyMetadata(new PropertyName("green"),
+            DoublePropertyMetadata.DoubleKind.OPACITY, true, 0.0, InspectorPath.UNUSED);
+    private final DoublePropertyMetadata blueMetadata
+            = new DoublePropertyMetadata(new PropertyName("blue"),
+            DoublePropertyMetadata.DoubleKind.OPACITY, true, 0.0, InspectorPath.UNUSED);
+    private final DoublePropertyMetadata opacityMetadata
+            = new DoublePropertyMetadata(new PropertyName("opacity"),
+            DoublePropertyMetadata.DoubleKind.OPACITY, true, 1.0, InspectorPath.UNUSED);
 
     public ColorPropertyMetadata(PropertyName name, boolean readWrite, 
             Color defaultValue, InspectorPath inspectorPath) {
         super(name, Color.class, readWrite, defaultValue, inspectorPath);
     }
 
-    /*
-     * ValuePropertyMetadata
-     */
-    
+    @Override
+    public FXOMInstance makeFxomInstanceFromValue(Color value, FXOMDocument fxomDocument) {
+        final FXOMInstance result = new FXOMInstance(fxomDocument, Color.class);
+
+        redMetadata.setValue(result, value.getRed());
+        greenMetadata.setValue(result, value.getGreen());
+        blueMetadata.setValue(result, value.getBlue());
+        opacityMetadata.setValue(result, value.getOpacity());
+
+        return result;
+    }
+
     @Override
     public Color makeValueFromString(String string) {
         return Color.valueOf(string);
     }
-    
+
     @Override
     public String makeStringFromValue(Color value) {
         assert value != null;
         return ColorEncoder.encodeColor(value);
     }
-
 }


### PR DESCRIPTION
Scene Builder only supports Color as its web string representation. This largely limits what can be done with controls which have `Color` property like `ColorPicker`.

This PR enables SB to represent Color as a complex object comprising of RGBA.

With this PR, SB can represent the `ObjectProperty<Color> value` of the ColorPicker as a `PaintPicker` and can then store the FXML as:

```
<ColorPicker>
   <value>
      <Color red="0.5099999904632568" green="0.3949007987976074" blue="0.22439999878406525" opacity="0.6100000143051147" />
   </value>
</ColorPicker>
```