### PR TITLE
UserLibrary: feature for adding folders to library

### DIFF
--- a/app/src/main/java/com/oracle/javafx/scenebuilder/app/DocumentWindowController.java
+++ b/app/src/main/java/com/oracle/javafx/scenebuilder/app/DocumentWindowController.java
@@ -1147,9 +1147,9 @@ public class DocumentWindowController extends AbstractFxmlWindowController {
         });
         
         libraryLabel.textProperty().bind(Bindings.createStringBinding(() -> {
-        	
-        	return SceneBuilderApp.getSingleton().getUserLibrary().isExploring() ? I18N.getString("library.exploring") : I18N.getString("library");
-        	
+
+            return SceneBuilderApp.getSingleton().getUserLibrary().isExploring() ? I18N.getString("library.exploring") : I18N.getString("library");
+
         }, SceneBuilderApp.getSingleton().getUserLibrary().exploringProperty()));
     }
 
@@ -1364,7 +1364,7 @@ public class DocumentWindowController extends AbstractFxmlWindowController {
     }
     
     public void onImportFromFolder(Window owner) {
-    	libraryPanelController.performImportFromFolder(owner);
+        libraryPanelController.performImportFromFolder(owner);
     }
     
     @FXML

--- a/app/src/main/java/com/oracle/javafx/scenebuilder/app/DocumentWindowController.java
+++ b/app/src/main/java/com/oracle/javafx/scenebuilder/app/DocumentWindowController.java
@@ -32,49 +32,6 @@
  */
 package com.oracle.javafx.scenebuilder.app;
 
-import com.oracle.javafx.scenebuilder.app.i18n.I18N;
-import com.oracle.javafx.scenebuilder.app.info.InfoPanelController;
-import com.oracle.javafx.scenebuilder.app.menubar.MenuBarController;
-import com.oracle.javafx.scenebuilder.app.message.MessageBarController;
-import com.oracle.javafx.scenebuilder.app.preferences.PreferencesController;
-import com.oracle.javafx.scenebuilder.app.preferences.PreferencesRecordDocument;
-import com.oracle.javafx.scenebuilder.app.preferences.PreferencesRecordGlobal;
-import com.oracle.javafx.scenebuilder.app.util.AppSettings;
-import com.oracle.javafx.scenebuilder.kit.ResourceUtils;
-import com.oracle.javafx.scenebuilder.kit.preview.PreviewWindowController;
-import com.oracle.javafx.scenebuilder.app.report.JarAnalysisReportController;
-import com.oracle.javafx.scenebuilder.kit.selectionbar.SelectionBarController;
-import com.oracle.javafx.scenebuilder.kit.skeleton.SkeletonWindowController;
-import com.oracle.javafx.scenebuilder.kit.alert.WarnThemeAlert;
-import com.oracle.javafx.scenebuilder.kit.editor.EditorController;
-import com.oracle.javafx.scenebuilder.kit.editor.EditorController.ControlAction;
-import com.oracle.javafx.scenebuilder.kit.editor.EditorController.EditAction;
-import com.oracle.javafx.scenebuilder.kit.editor.EditorPlatform;
-import com.oracle.javafx.scenebuilder.kit.editor.job.Job;
-import com.oracle.javafx.scenebuilder.kit.editor.panel.content.ContentPanelController;
-import com.oracle.javafx.scenebuilder.kit.editor.panel.css.CssPanelController;
-import com.oracle.javafx.scenebuilder.kit.editor.panel.hierarchy.AbstractHierarchyPanelController;
-import com.oracle.javafx.scenebuilder.kit.editor.panel.hierarchy.AbstractHierarchyPanelController.DisplayOption;
-import com.oracle.javafx.scenebuilder.kit.editor.panel.hierarchy.HierarchyPanelController;
-import com.oracle.javafx.scenebuilder.kit.editor.panel.inspector.InspectorPanelController;
-import com.oracle.javafx.scenebuilder.kit.editor.panel.inspector.InspectorPanelController.SectionId;
-import com.oracle.javafx.scenebuilder.kit.editor.panel.library.manager.LibraryDialogController;
-import com.oracle.javafx.scenebuilder.kit.editor.panel.library.LibraryPanelController;
-import com.oracle.javafx.scenebuilder.kit.editor.panel.util.AbstractFxmlWindowController;
-import com.oracle.javafx.scenebuilder.kit.editor.panel.util.dialog.AbstractModalDialog;
-import com.oracle.javafx.scenebuilder.kit.editor.panel.util.dialog.AbstractModalDialog.ButtonID;
-import com.oracle.javafx.scenebuilder.kit.editor.panel.util.dialog.AlertDialog;
-import com.oracle.javafx.scenebuilder.kit.editor.panel.util.dialog.ErrorDialog;
-import com.oracle.javafx.scenebuilder.kit.editor.search.SearchController;
-import com.oracle.javafx.scenebuilder.kit.editor.selection.AbstractSelectionGroup;
-import com.oracle.javafx.scenebuilder.kit.editor.selection.ObjectSelectionGroup;
-import com.oracle.javafx.scenebuilder.kit.fxom.FXOMDocument;
-import com.oracle.javafx.scenebuilder.kit.fxom.FXOMNodes;
-import com.oracle.javafx.scenebuilder.kit.fxom.FXOMObject;
-import com.oracle.javafx.scenebuilder.kit.library.Library;
-import com.oracle.javafx.scenebuilder.kit.library.user.UserLibrary;
-import com.oracle.javafx.scenebuilder.kit.util.Utils;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -92,7 +49,51 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.oracle.javafx.scenebuilder.app.i18n.I18N;
+import com.oracle.javafx.scenebuilder.app.info.InfoPanelController;
+import com.oracle.javafx.scenebuilder.app.menubar.MenuBarController;
+import com.oracle.javafx.scenebuilder.app.message.MessageBarController;
+import com.oracle.javafx.scenebuilder.app.preferences.PreferencesController;
+import com.oracle.javafx.scenebuilder.app.preferences.PreferencesRecordDocument;
+import com.oracle.javafx.scenebuilder.app.preferences.PreferencesRecordGlobal;
+import com.oracle.javafx.scenebuilder.app.report.JarAnalysisReportController;
+import com.oracle.javafx.scenebuilder.app.util.AppSettings;
+import com.oracle.javafx.scenebuilder.kit.ResourceUtils;
+import com.oracle.javafx.scenebuilder.kit.alert.WarnThemeAlert;
+import com.oracle.javafx.scenebuilder.kit.editor.EditorController;
+import com.oracle.javafx.scenebuilder.kit.editor.EditorController.ControlAction;
+import com.oracle.javafx.scenebuilder.kit.editor.EditorController.EditAction;
+import com.oracle.javafx.scenebuilder.kit.editor.EditorPlatform;
+import com.oracle.javafx.scenebuilder.kit.editor.job.Job;
+import com.oracle.javafx.scenebuilder.kit.editor.panel.content.ContentPanelController;
+import com.oracle.javafx.scenebuilder.kit.editor.panel.css.CssPanelController;
+import com.oracle.javafx.scenebuilder.kit.editor.panel.hierarchy.AbstractHierarchyPanelController;
+import com.oracle.javafx.scenebuilder.kit.editor.panel.hierarchy.AbstractHierarchyPanelController.DisplayOption;
+import com.oracle.javafx.scenebuilder.kit.editor.panel.hierarchy.HierarchyPanelController;
+import com.oracle.javafx.scenebuilder.kit.editor.panel.inspector.InspectorPanelController;
+import com.oracle.javafx.scenebuilder.kit.editor.panel.inspector.InspectorPanelController.SectionId;
+import com.oracle.javafx.scenebuilder.kit.editor.panel.library.LibraryPanelController;
+import com.oracle.javafx.scenebuilder.kit.editor.panel.library.manager.LibraryDialogController;
+import com.oracle.javafx.scenebuilder.kit.editor.panel.util.AbstractFxmlWindowController;
+import com.oracle.javafx.scenebuilder.kit.editor.panel.util.dialog.AbstractModalDialog;
+import com.oracle.javafx.scenebuilder.kit.editor.panel.util.dialog.AbstractModalDialog.ButtonID;
+import com.oracle.javafx.scenebuilder.kit.editor.panel.util.dialog.AlertDialog;
+import com.oracle.javafx.scenebuilder.kit.editor.panel.util.dialog.ErrorDialog;
+import com.oracle.javafx.scenebuilder.kit.editor.search.SearchController;
+import com.oracle.javafx.scenebuilder.kit.editor.selection.AbstractSelectionGroup;
+import com.oracle.javafx.scenebuilder.kit.editor.selection.ObjectSelectionGroup;
+import com.oracle.javafx.scenebuilder.kit.fxom.FXOMDocument;
+import com.oracle.javafx.scenebuilder.kit.fxom.FXOMNodes;
+import com.oracle.javafx.scenebuilder.kit.fxom.FXOMObject;
+import com.oracle.javafx.scenebuilder.kit.library.Library;
+import com.oracle.javafx.scenebuilder.kit.library.user.UserLibrary;
+import com.oracle.javafx.scenebuilder.kit.preview.PreviewWindowController;
+import com.oracle.javafx.scenebuilder.kit.selectionbar.SelectionBarController;
+import com.oracle.javafx.scenebuilder.kit.skeleton.SkeletonWindowController;
+import com.oracle.javafx.scenebuilder.kit.util.Utils;
+
 import javafx.beans.InvalidationListener;
+import javafx.beans.binding.Bindings;
 import javafx.beans.value.ChangeListener;
 import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
@@ -102,6 +103,7 @@ import javafx.scene.Node;
 import javafx.scene.control.Accordion;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.DialogPane;
+import javafx.scene.control.Label;
 import javafx.scene.control.Menu;
 import javafx.scene.control.MenuButton;
 import javafx.scene.control.MenuItem;
@@ -214,6 +216,7 @@ public class DocumentWindowController extends AbstractFxmlWindowController {
     @FXML private SplitPane mainSplitPane;
     @FXML private SplitPane leftRightSplitPane;
     @FXML private SplitPane libraryDocumentSplitPane;
+    @FXML private Label libraryLabel;
     
     @FXML private MenuButton libraryMenuButton;
     @FXML private MenuItem libraryImportSelection;
@@ -1142,6 +1145,12 @@ public class DocumentWindowController extends AbstractFxmlWindowController {
                 }
             }
         });
+        
+        libraryLabel.textProperty().bind(Bindings.createStringBinding(() -> {
+        	
+        	return SceneBuilderApp.getSingleton().getUserLibrary().isExploring() ? I18N.getString("library.exploring") : I18N.getString("library");
+        	
+        }, SceneBuilderApp.getSingleton().getUserLibrary().exploringProperty()));
     }
 
     @Override
@@ -1344,6 +1353,7 @@ public class DocumentWindowController extends AbstractFxmlWindowController {
                     SceneBuilderApp.getSingleton().performOpenRecent(this,
                             fxmlPath.toFile());
             });
+            libraryDialogController.setOnAddFolder(() -> onImportFromFolder(libraryDialogController.getStage()));
         }
 
         libraryDialogController.openWindow();
@@ -1351,6 +1361,10 @@ public class DocumentWindowController extends AbstractFxmlWindowController {
     
     public void onImportJarFxml(Window owner) {
         libraryPanelController.performImportJarFxml(owner);
+    }
+    
+    public void onImportFromFolder(Window owner) {
+    	libraryPanelController.performImportFromFolder(owner);
     }
     
     @FXML

--- a/app/src/main/java/com/oracle/javafx/scenebuilder/app/DocumentWindowController.java
+++ b/app/src/main/java/com/oracle/javafx/scenebuilder/app/DocumentWindowController.java
@@ -32,23 +32,6 @@
  */
 package com.oracle.javafx.scenebuilder.app;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.net.MalformedURLException;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.NoSuchFileException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.attribute.FileTime;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import com.oracle.javafx.scenebuilder.app.i18n.I18N;
 import com.oracle.javafx.scenebuilder.app.info.InfoPanelController;
 import com.oracle.javafx.scenebuilder.app.menubar.MenuBarController;
@@ -91,6 +74,23 @@ import com.oracle.javafx.scenebuilder.kit.preview.PreviewWindowController;
 import com.oracle.javafx.scenebuilder.kit.selectionbar.SelectionBarController;
 import com.oracle.javafx.scenebuilder.kit.skeleton.SkeletonWindowController;
 import com.oracle.javafx.scenebuilder.kit.util.Utils;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.FileTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import javafx.beans.InvalidationListener;
 import javafx.beans.binding.Bindings;

--- a/app/src/main/resources/com/oracle/javafx/scenebuilder/app/DocumentWindow.fxml
+++ b/app/src/main/resources/com/oracle/javafx/scenebuilder/app/DocumentWindow.fxml
@@ -62,7 +62,7 @@
                   <children>
                     <HBox id="HBox" alignment="CENTER" spacing="0.0" styleClass="panel-header">
                       <children>
-                        <Label maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" text="%library" HBox.hgrow="NEVER" />
+                        <Label fx:id="libraryLabel" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" text="%library" HBox.hgrow="NEVER" />
                         <StackPane fx:id="librarySearchPanelHost" maxHeight="-1.0" maxWidth="-1.0" minHeight="-1.0" minWidth="-1.0" prefHeight="-1.0" prefWidth="-1.0" style="" HBox.hgrow="ALWAYS" />
                         <MenuButton fx:id="libraryMenuButton" mnemonicParsing="false" text="" HBox.hgrow="NEVER">
                           <items>

--- a/app/src/main/resources/com/oracle/javafx/scenebuilder/app/i18n/SceneBuilderApp.properties
+++ b/app/src/main/resources/com/oracle/javafx/scenebuilder/app/i18n/SceneBuilderApp.properties
@@ -262,6 +262,7 @@ template.cannot.save.file = Can''t save file: {0}
 # Library Menu within Library panel
 # -----------------------------------------------------------------------------
 library = Library
+library.exploring = Exploring Library..
 library.panel.menu.manage.jar.fxml = JAR/FXML Manager
 library.panel.menu.import.selection = Import Selection
 # Messages below are temporarily unused

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/ImportWindowController.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/ImportWindowController.java
@@ -595,7 +595,13 @@ public class ImportWindowController extends AbstractModalDialog {
         try {
             int index = 0;
             for (File file : files) {
-                result[index] = new URL("jar","",file.toURI().toURL()+"!/");
+            	URL url = file.toURI().toURL();
+                if (url.toString().endsWith(".jar")) {
+                    result[index] = new URL("jar", "", url + "!/"); // <-- jar:file/path/to/jar!/
+                } else {
+                    result[index] = url; // <-- file:/path/to/folder/
+                }
+                
                 index++;
             }
         } catch (MalformedURLException x) {

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/ImportWindowController.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/ImportWindowController.java
@@ -595,13 +595,13 @@ public class ImportWindowController extends AbstractModalDialog {
         try {
             int index = 0;
             for (File file : files) {
-            	URL url = file.toURI().toURL();
+                URL url = file.toURI().toURL();
                 if (url.toString().endsWith(".jar")) {
                     result[index] = new URL("jar", "", url + "!/"); // <-- jar:file/path/to/jar!/
                 } else {
                     result[index] = url; // <-- file:/path/to/folder/
                 }
-                
+
                 index++;
             }
         } catch (MalformedURLException x) {

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/ImportWindowController.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/ImportWindowController.java
@@ -32,16 +32,6 @@
  */
 package com.oracle.javafx.scenebuilder.kit.editor.panel.library;
 
-import com.oracle.javafx.scenebuilder.kit.alert.ImportingGluonControlsAlert;
-import com.oracle.javafx.scenebuilder.kit.i18n.I18N;
-import com.oracle.javafx.scenebuilder.kit.editor.panel.util.dialog.AbstractModalDialog;
-import com.oracle.javafx.scenebuilder.kit.editor.panel.util.dialog.ErrorDialog;
-import com.oracle.javafx.scenebuilder.kit.fxom.FXOMDocument;
-import com.oracle.javafx.scenebuilder.kit.library.user.UserLibrary;
-import com.oracle.javafx.scenebuilder.kit.library.util.JarExplorer;
-import com.oracle.javafx.scenebuilder.kit.library.util.JarReport;
-import com.oracle.javafx.scenebuilder.kit.library.util.JarReportEntry;
-
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -54,10 +44,23 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
+import com.oracle.javafx.scenebuilder.kit.alert.ImportingGluonControlsAlert;
+import com.oracle.javafx.scenebuilder.kit.editor.panel.util.dialog.AbstractModalDialog;
+import com.oracle.javafx.scenebuilder.kit.editor.panel.util.dialog.ErrorDialog;
+import com.oracle.javafx.scenebuilder.kit.fxom.FXOMDocument;
+import com.oracle.javafx.scenebuilder.kit.i18n.I18N;
+import com.oracle.javafx.scenebuilder.kit.library.user.UserLibrary;
+import com.oracle.javafx.scenebuilder.kit.library.util.FolderExplorer;
+import com.oracle.javafx.scenebuilder.kit.library.util.JarExplorer;
+import com.oracle.javafx.scenebuilder.kit.library.util.JarReport;
+import com.oracle.javafx.scenebuilder.kit.library.util.JarReportEntry;
 import com.oracle.javafx.scenebuilder.kit.preferences.MavenPreferences;
+
 import javafx.application.Platform;
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
@@ -228,10 +231,36 @@ public class ImportWindowController extends AbstractModalDialog {
         
         try {
             closeClassLoader();
-            if (copyFilesToUserLibraryDir) {
-                libPanelController.copyFilesToUserLibraryDir(importFiles);
-            }
+            
             UserLibrary userLib = ((UserLibrary) libPanelController.getEditorController().getLibrary());
+            
+            if (copyFilesToUserLibraryDir) {
+            	// collect directories from importFiles and add to library.folders file
+            	// for other filex (jar, fxml) copy them directly
+            	List<File> folders = new ArrayList<>(importFiles.size());
+            	List<File> files = new ArrayList<>(importFiles.size());
+            	
+            	for (File file : importFiles) {
+					if (file.isDirectory())
+						folders.add(file);
+					else
+						files.add(file);
+				}
+            	
+            	if (!files.isEmpty())
+            		libPanelController.copyFilesToUserLibraryDir(files);
+                
+                Path foldersMarkerPath = Paths.get(userLib.getPath().toString(), LibraryUtil.FOLDERS_LIBRARY_FILENAME);
+            	
+				if (!Files.exists(foldersMarkerPath))
+					Files.createFile(foldersMarkerPath);
+				
+				Set<String> lines = new TreeSet<>(Files.readAllLines(foldersMarkerPath));
+				lines.addAll(folders.stream().map(f -> f.getAbsolutePath()).collect(Collectors.toList()));
+				
+				Files.write(foldersMarkerPath, lines);
+            }
+            
             if (copyFilesToUserLibraryDir) {
                 userLib.setFilter(getExcludedItems());
             }
@@ -373,9 +402,16 @@ public class ImportWindowController extends AbstractModalDialog {
                     }
                     updateMessage(I18N.getString("import.work.exploring", file.getName()));
 //                    System.out.println("[" + index + "/" + max + "] Exploring file " + file.getName()); //NOI18N
-                    final JarExplorer explorer = new JarExplorer(Paths.get(file.getAbsolutePath()));
-                    final JarReport jarReport = explorer.explore(classLoader);
-                    res.add(jarReport);
+                    if (file.isDirectory()) {
+                   		final FolderExplorer explorer = new FolderExplorer(file.toPath());
+                   		final JarReport jarReport = explorer.explore(classLoader);
+                   		res.add(jarReport);
+                    }
+                    else {
+                    	final JarExplorer explorer = new JarExplorer(Paths.get(file.getAbsolutePath()));
+                    	final JarReport jarReport = explorer.explore(classLoader);
+                    	res.add(jarReport);
+                    }
                     updateProgress(index, numOfImportedJar);
                     index++;
                 }
@@ -530,9 +566,11 @@ public class ImportWindowController extends AbstractModalDialog {
             }
             
             if (builtinPrefWidth == 0 || builtinPrefHeight == 0) {
-                ((Region) zeNode).setPrefSize(200, 200);
-                setSizeLabel(PrefSize.TWO_HUNDRED_BY_TWO_HUNDRED);
-                defSizeChoice.getSelectionModel().select(2);
+            	if (zeNode instanceof Region) { // must check instanceof: custom components are not necessarily regions..
+            		((Region) zeNode).setPrefSize(200, 200);
+            		setSizeLabel(PrefSize.TWO_HUNDRED_BY_TWO_HUNDRED);
+            		defSizeChoice.getSelectionModel().select(2);
+            	}
             } else {
                 setSizeLabel(PrefSize.DEFAULT);
                 defSizeChoice.getSelectionModel().selectFirst();

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/ImportWindowController.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/ImportWindowController.java
@@ -233,34 +233,34 @@ public class ImportWindowController extends AbstractModalDialog {
             closeClassLoader();
             
             UserLibrary userLib = ((UserLibrary) libPanelController.getEditorController().getLibrary());
-            
+
             if (copyFilesToUserLibraryDir) {
-            	// collect directories from importFiles and add to library.folders file
-            	// for other filex (jar, fxml) copy them directly
-            	List<File> folders = new ArrayList<>(importFiles.size());
-            	List<File> files = new ArrayList<>(importFiles.size());
-            	
-            	for (File file : importFiles) {
-					if (file.isDirectory())
-						folders.add(file);
-					else
-						files.add(file);
-				}
-            	
-            	if (!files.isEmpty())
-            		libPanelController.copyFilesToUserLibraryDir(files);
-                
+                // collect directories from importFiles and add to library.folders file
+                // for other filex (jar, fxml) copy them directly
+                List<File> folders = new ArrayList<>(importFiles.size());
+                List<File> files = new ArrayList<>(importFiles.size());
+
+                for (File file : importFiles) {
+                    if (file.isDirectory())
+                        folders.add(file);
+                    else
+                        files.add(file);
+                }
+
+                if (!files.isEmpty())
+                    libPanelController.copyFilesToUserLibraryDir(files);
+
                 Path foldersMarkerPath = Paths.get(userLib.getPath().toString(), LibraryUtil.FOLDERS_LIBRARY_FILENAME);
-            	
-				if (!Files.exists(foldersMarkerPath))
-					Files.createFile(foldersMarkerPath);
-				
-				Set<String> lines = new TreeSet<>(Files.readAllLines(foldersMarkerPath));
-				lines.addAll(folders.stream().map(f -> f.getAbsolutePath()).collect(Collectors.toList()));
-				
-				Files.write(foldersMarkerPath, lines);
+
+                if (!Files.exists(foldersMarkerPath))
+                    Files.createFile(foldersMarkerPath);
+
+                Set<String> lines = new TreeSet<>(Files.readAllLines(foldersMarkerPath));
+                lines.addAll(folders.stream().map(f -> f.getAbsolutePath()).collect(Collectors.toList()));
+
+                Files.write(foldersMarkerPath, lines);
             }
-            
+
             if (copyFilesToUserLibraryDir) {
                 userLib.setFilter(getExcludedItems());
             }
@@ -403,14 +403,14 @@ public class ImportWindowController extends AbstractModalDialog {
                     updateMessage(I18N.getString("import.work.exploring", file.getName()));
 //                    System.out.println("[" + index + "/" + max + "] Exploring file " + file.getName()); //NOI18N
                     if (file.isDirectory()) {
-                   		final FolderExplorer explorer = new FolderExplorer(file.toPath());
-                   		final JarReport jarReport = explorer.explore(classLoader);
-                   		res.add(jarReport);
+                        final FolderExplorer explorer = new FolderExplorer(file.toPath());
+                        final JarReport jarReport = explorer.explore(classLoader);
+                        res.add(jarReport);
                     }
                     else {
-                    	final JarExplorer explorer = new JarExplorer(Paths.get(file.getAbsolutePath()));
-                    	final JarReport jarReport = explorer.explore(classLoader);
-                    	res.add(jarReport);
+                        final JarExplorer explorer = new JarExplorer(Paths.get(file.getAbsolutePath()));
+                        final JarReport jarReport = explorer.explore(classLoader);
+                        res.add(jarReport);
                     }
                     updateProgress(index, numOfImportedJar);
                     index++;
@@ -566,11 +566,11 @@ public class ImportWindowController extends AbstractModalDialog {
             }
             
             if (builtinPrefWidth == 0 || builtinPrefHeight == 0) {
-            	if (zeNode instanceof Region) { // must check instanceof: custom components are not necessarily regions..
-            		((Region) zeNode).setPrefSize(200, 200);
-            		setSizeLabel(PrefSize.TWO_HUNDRED_BY_TWO_HUNDRED);
-            		defSizeChoice.getSelectionModel().select(2);
-            	}
+                if (zeNode instanceof Region) { // must check instanceof: custom components are not necessarily regions..
+                    ((Region) zeNode).setPrefSize(200, 200);
+                    setSizeLabel(PrefSize.TWO_HUNDRED_BY_TWO_HUNDRED);
+                    defSizeChoice.getSelectionModel().select(2);
+                }
             } else {
                 setSizeLabel(PrefSize.DEFAULT);
                 defSizeChoice.getSelectionModel().selectFirst();

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/LibraryPanelController.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/LibraryPanelController.java
@@ -181,9 +181,9 @@ public class LibraryPanelController extends AbstractFxmlPanelController {
      * @treatAsPrivate Perform the import jar action.
      */
     public void performImportFromFolder(Window owner) {
-    	File folder = performSelectFolder(owner);
-    	processImportFolder(folder);
-	}
+        File folder = performSelectFolder(owner);
+        processImportFolder(folder);
+    }
     
 	/**
      * @treatAsPrivate Perform the import of the selection

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/LibraryPanelController.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/LibraryPanelController.java
@@ -788,9 +788,9 @@ public class LibraryPanelController extends AbstractFxmlPanelController {
     }
     
     private void processImportFolder(File folder) {
-		if (folder != null && folder.exists() && folder.isDirectory()) {
-			Path libPath = Paths.get(((UserLibrary)getEditorController().getLibrary()).getPath());
-			if (createUserLibraryDir(libPath)) {
+        if (folder != null && folder.exists() && folder.isDirectory()) {
+            Path libPath = Paths.get(((UserLibrary)getEditorController().getLibrary()).getPath());
+            if (createUserLibraryDir(libPath)) {
                 // From here we know we will initiate the import dialog.
                 // This is why we put application window on the front.
                 // From there the import dialog window, which is application modal,
@@ -801,8 +801,7 @@ public class LibraryPanelController extends AbstractFxmlPanelController {
                     stage.toFront();
                 }
 
-                final ImportWindowController iwc
-                        = new ImportWindowController(this, Arrays.asList(folder), mavenPreferences, (Stage) window);
+                final ImportWindowController iwc = new ImportWindowController(this, Arrays.asList(folder), mavenPreferences, (Stage) window);
                 iwc.setToolStylesheet(getEditorController().getToolStylesheet());
                 // See comment in OnDragDropped handle set in method startListeningToDrop.
                 ButtonID userChoice = iwc.showAndWait();
@@ -810,9 +809,9 @@ public class LibraryPanelController extends AbstractFxmlPanelController {
                 if (userChoice.equals(ButtonID.OK) && currentDisplayMode.equals(DISPLAY_MODE.SECTIONS)) {
                     sectionNameToKeepOpened = UserLibrary.TAG_USER_DEFINED;
                 }
-			}
-		}
-	}
+            }
+        }
+    }
     
     private List<File> getSubsetOfFiles(String pattern, List<File> files) {
         final List<File> res = new ArrayList<>();
@@ -940,17 +939,17 @@ public class LibraryPanelController extends AbstractFxmlPanelController {
      * @return the selected folder or null
      */
     private File performSelectFolder(Window owner) {
-    	DirectoryChooser dirChooser = new DirectoryChooser();
-    	dirChooser.setInitialDirectory(EditorController.getNextInitialDirectory());
-    	
-    	File folder = dirChooser.showDialog(owner);
-    	if (folder != null) {
-    		// Keep track of the user choice for next time
-    		EditorController.updateNextInitialDirectory(folder);
-    	}
-    	
-		return folder;
-	}
+        DirectoryChooser dirChooser = new DirectoryChooser();
+        dirChooser.setInitialDirectory(EditorController.getNextInitialDirectory());
+
+        File folder = dirChooser.showDialog(owner);
+        if (folder != null) {
+            // Keep track of the user choice for next time
+            EditorController.updateNextInitialDirectory(folder);
+        }
+
+        return folder;
+    }
     
     private void userLibraryUpdateRejected() {
         final AlertDialog dialog = new AlertDialog(null);

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/LibraryPanelController.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/LibraryPanelController.java
@@ -32,28 +32,6 @@
  */
 package com.oracle.javafx.scenebuilder.kit.editor.panel.library;
 
-import com.oracle.javafx.scenebuilder.kit.editor.EditorController;
-import com.oracle.javafx.scenebuilder.kit.editor.drag.source.AbstractDragSource;
-import com.oracle.javafx.scenebuilder.kit.editor.drag.source.DocumentDragSource;
-import com.oracle.javafx.scenebuilder.kit.i18n.I18N;
-import com.oracle.javafx.scenebuilder.kit.editor.panel.util.AbstractFxmlPanelController;
-import com.oracle.javafx.scenebuilder.kit.editor.panel.util.dialog.AbstractModalDialog.ButtonID;
-import com.oracle.javafx.scenebuilder.kit.editor.panel.util.dialog.AlertDialog;
-import com.oracle.javafx.scenebuilder.kit.editor.panel.util.dialog.ErrorDialog;
-import com.oracle.javafx.scenebuilder.kit.fxom.FXOMArchive;
-import com.oracle.javafx.scenebuilder.kit.fxom.FXOMDocument;
-import com.oracle.javafx.scenebuilder.kit.fxom.FXOMInstance;
-import com.oracle.javafx.scenebuilder.kit.fxom.FXOMObject;
-import com.oracle.javafx.scenebuilder.kit.fxom.FXOMProperty;
-import com.oracle.javafx.scenebuilder.kit.fxom.FXOMPropertyT;
-import com.oracle.javafx.scenebuilder.kit.library.BuiltinLibrary;
-import com.oracle.javafx.scenebuilder.kit.library.Library;
-import com.oracle.javafx.scenebuilder.kit.library.LibraryItem;
-import com.oracle.javafx.scenebuilder.kit.library.LibraryItemNameComparator;
-import com.oracle.javafx.scenebuilder.kit.library.user.UserLibrary;
-import com.oracle.javafx.scenebuilder.kit.metadata.util.PrefixedValue;
-import com.oracle.javafx.scenebuilder.kit.metadata.util.PropertyName;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -67,6 +45,7 @@ import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.FileAttribute;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -75,7 +54,29 @@ import java.util.Timer;
 import java.util.TimerTask;
 import java.util.TreeSet;
 
+import com.oracle.javafx.scenebuilder.kit.editor.EditorController;
+import com.oracle.javafx.scenebuilder.kit.editor.drag.source.AbstractDragSource;
+import com.oracle.javafx.scenebuilder.kit.editor.drag.source.DocumentDragSource;
+import com.oracle.javafx.scenebuilder.kit.editor.panel.util.AbstractFxmlPanelController;
+import com.oracle.javafx.scenebuilder.kit.editor.panel.util.dialog.AbstractModalDialog.ButtonID;
+import com.oracle.javafx.scenebuilder.kit.editor.panel.util.dialog.AlertDialog;
+import com.oracle.javafx.scenebuilder.kit.editor.panel.util.dialog.ErrorDialog;
+import com.oracle.javafx.scenebuilder.kit.fxom.FXOMArchive;
+import com.oracle.javafx.scenebuilder.kit.fxom.FXOMDocument;
+import com.oracle.javafx.scenebuilder.kit.fxom.FXOMInstance;
+import com.oracle.javafx.scenebuilder.kit.fxom.FXOMObject;
+import com.oracle.javafx.scenebuilder.kit.fxom.FXOMProperty;
+import com.oracle.javafx.scenebuilder.kit.fxom.FXOMPropertyT;
+import com.oracle.javafx.scenebuilder.kit.i18n.I18N;
+import com.oracle.javafx.scenebuilder.kit.library.BuiltinLibrary;
+import com.oracle.javafx.scenebuilder.kit.library.Library;
+import com.oracle.javafx.scenebuilder.kit.library.LibraryItem;
+import com.oracle.javafx.scenebuilder.kit.library.LibraryItemNameComparator;
+import com.oracle.javafx.scenebuilder.kit.library.user.UserLibrary;
+import com.oracle.javafx.scenebuilder.kit.metadata.util.PrefixedValue;
+import com.oracle.javafx.scenebuilder.kit.metadata.util.PropertyName;
 import com.oracle.javafx.scenebuilder.kit.preferences.MavenPreferences;
+
 import javafx.application.Platform;
 import javafx.beans.value.ChangeListener;
 import javafx.collections.ListChangeListener;
@@ -91,6 +92,7 @@ import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.input.TransferMode;
 import javafx.scene.layout.StackPane;
+import javafx.stage.DirectoryChooser;
 import javafx.stage.FileChooser;
 import javafx.stage.Stage;
 import javafx.stage.Window;
@@ -175,6 +177,15 @@ public class LibraryPanelController extends AbstractFxmlPanelController {
     }
     
     /**
+     * @param owner
+     * @treatAsPrivate Perform the import jar action.
+     */
+    public void performImportFromFolder(Window owner) {
+    	File folder = performSelectFolder(owner);
+    	processImportFolder(folder);
+	}
+    
+	/**
      * @treatAsPrivate Perform the import of the selection
      * @param objects the FXOM objects to import to customize the Library content.
      */
@@ -776,6 +787,33 @@ public class LibraryPanelController extends AbstractFxmlPanelController {
         }
     }
     
+    private void processImportFolder(File folder) {
+		if (folder != null && folder.exists() && folder.isDirectory()) {
+			Path libPath = Paths.get(((UserLibrary)getEditorController().getLibrary()).getPath());
+			if (createUserLibraryDir(libPath)) {
+                // From here we know we will initiate the import dialog.
+                // This is why we put application window on the front.
+                // From there the import dialog window, which is application modal,
+                // should come on top of it.
+                final Window window = getPanelRoot().getScene().getWindow();
+                if (window instanceof Stage) {
+                    final Stage stage = (Stage) window;
+                    stage.toFront();
+                }
+
+                final ImportWindowController iwc
+                        = new ImportWindowController(this, Arrays.asList(folder), mavenPreferences, (Stage) window);
+                iwc.setToolStylesheet(getEditorController().getToolStylesheet());
+                // See comment in OnDragDropped handle set in method startListeningToDrop.
+                ButtonID userChoice = iwc.showAndWait();
+
+                if (userChoice.equals(ButtonID.OK) && currentDisplayMode.equals(DISPLAY_MODE.SECTIONS)) {
+                    sectionNameToKeepOpened = UserLibrary.TAG_USER_DEFINED;
+                }
+			}
+		}
+	}
+    
     private List<File> getSubsetOfFiles(String pattern, List<File> files) {
         final List<File> res = new ArrayList<>();
         
@@ -897,6 +935,23 @@ public class LibraryPanelController extends AbstractFxmlPanelController {
         return selectedFiles;
     }
 
+    /**
+     * Open a file chooser that allows to select one folder
+     * @return the selected folder or null
+     */
+    private File performSelectFolder(Window owner) {
+    	DirectoryChooser dirChooser = new DirectoryChooser();
+    	dirChooser.setInitialDirectory(EditorController.getNextInitialDirectory());
+    	
+    	File folder = dirChooser.showDialog(owner);
+    	if (folder != null) {
+    		// Keep track of the user choice for next time
+    		EditorController.updateNextInitialDirectory(folder);
+    	}
+    	
+		return folder;
+	}
+    
     private void userLibraryUpdateRejected() {
         final AlertDialog dialog = new AlertDialog(null);
         dialog.setTitle(I18N.getString("alert.import.reject.dependencies.title"));

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/LibraryUtil.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/LibraryUtil.java
@@ -1,3 +1,35 @@
+/*
+ * Copyright (c) 2016, 2019 Gluon and/or its affiliates.
+ * Copyright (c) 2012, 2014, Oracle and/or its affiliates.
+ * All rights reserved. Use is subject to license terms.
+ *
+ * This file is available and licensed under the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the distribution.
+ *  - Neither the name of Oracle Corporation nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.oracle.javafx.scenebuilder.kit.editor.panel.library;
 
 import java.io.File;
@@ -10,34 +42,34 @@ import java.util.Locale;
 import java.util.stream.Collectors;
 
 public class LibraryUtil {
-	
-	public static final String FOLDERS_LIBRARY_FILENAME = "library.folders"; //NOI18N
 
-	public static boolean isJarPath(Path path) {
+    public static final String FOLDERS_LIBRARY_FILENAME = "library.folders"; //NOI18N
+
+    public static boolean isJarPath(Path path) {
         final String pathString = path.toString().toLowerCase(Locale.ROOT);
         return pathString.endsWith(".jar"); //NOI18N
     }
 
-	public static boolean isFxmlPath(Path path) {
+    public static boolean isFxmlPath(Path path) {
         final String pathString = path.toString().toLowerCase(Locale.ROOT);
         return pathString.endsWith(".fxml"); //NOI18N
     }
-    
-	public static boolean isFolderMarkerPath(Path path) {
-    	final String pathString = path.toString().toLowerCase(Locale.ROOT);
-    	return pathString.endsWith(".folders"); //NOI18N
+
+    public static boolean isFolderMarkerPath(Path path) {
+        final String pathString = path.toString().toLowerCase(Locale.ROOT);
+        return pathString.endsWith(".folders"); //NOI18N
     }
-	
-	public static List<Path> getFolderPaths(Path libraryFile) throws FileNotFoundException, IOException {
-		return Files.readAllLines(libraryFile).stream()
-				.map(line -> {
-					File f = new File(line);
-					if (f.exists() && f.isDirectory())
-						return f.toPath();
-					else
-						return null;
-				})
-				.filter(p -> p != null)
-				.collect(Collectors.toList());
-	}
+
+    public static List<Path> getFolderPaths(Path libraryFile) throws FileNotFoundException, IOException {
+        return Files.readAllLines(libraryFile).stream()
+                .map(line -> {
+                    File f = new File(line);
+                    if (f.exists() && f.isDirectory())
+                        return f.toPath();
+                    else
+                        return null;
+                })
+                .filter(p -> p != null)
+                .collect(Collectors.toList());
+    }
 }

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/LibraryUtil.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/LibraryUtil.java
@@ -1,0 +1,43 @@
+package com.oracle.javafx.scenebuilder.kit.editor.panel.library;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+
+public class LibraryUtil {
+	
+	public static final String FOLDERS_LIBRARY_FILENAME = "library.folders"; //NOI18N
+
+	public static boolean isJarPath(Path path) {
+        final String pathString = path.toString().toLowerCase(Locale.ROOT);
+        return pathString.endsWith(".jar"); //NOI18N
+    }
+
+	public static boolean isFxmlPath(Path path) {
+        final String pathString = path.toString().toLowerCase(Locale.ROOT);
+        return pathString.endsWith(".fxml"); //NOI18N
+    }
+    
+	public static boolean isFolderMarkerPath(Path path) {
+    	final String pathString = path.toString().toLowerCase(Locale.ROOT);
+    	return pathString.endsWith(".folders"); //NOI18N
+    }
+	
+	public static List<Path> getFolderPaths(Path libraryFile) throws FileNotFoundException, IOException {
+		return Files.readAllLines(libraryFile).stream()
+				.map(line -> {
+					File f = new File(line);
+					if (f.exists() && f.isDirectory())
+						return f.toPath();
+					else
+						return null;
+				})
+				.filter(p -> p != null)
+				.collect(Collectors.toList());
+	}
+}

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/manager/LibraryDialogController.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/manager/LibraryDialogController.java
@@ -112,9 +112,9 @@ public class LibraryDialogController extends AbstractFxmlWindowController {
 
     @Override
     protected void controllerDidLoadFxml() {
-    	super.controllerDidLoadFxml();
-    	
-    	this.classesLink.setTooltip(new Tooltip(I18N.getString("library.dialog.hyperlink.tooltip")));
+        super.controllerDidLoadFxml();
+
+        this.classesLink.setTooltip(new Tooltip(I18N.getString("library.dialog.hyperlink.tooltip")));
     }
     
     @Override
@@ -157,12 +157,12 @@ public class LibraryDialogController extends AbstractFxmlWindowController {
                     if (LibraryUtil.isJarPath(entry) || LibraryUtil.isFxmlPath(entry)) {
                         listItems.add(new LibraryDialogListItem(this, entry));
                     } else if (LibraryUtil.isFolderMarkerPath(entry)) {
-                    	// open folders marker file: every line should be a single folder entry
-                    	// we scan the file and add the path to currentJarsOrFolders
-                    	List<Path> folderPaths = LibraryUtil.getFolderPaths(entry);
-                    	for (Path f : folderPaths) {
-                    		listItems.add(new LibraryDialogListItem(this, f));
-						}
+                        // open folders marker file: every line should be a single folder entry
+                        // we scan the file and add the path to currentJarsOrFolders
+                        List<Path> folderPaths = LibraryUtil.getFolderPaths(entry);
+                        for (Path f : folderPaths) {
+                            listItems.add(new LibraryDialogListItem(this, f));
+                        }
                     }
                 }
             } catch (IOException x) {
@@ -201,10 +201,10 @@ public class LibraryDialogController extends AbstractFxmlWindowController {
     
     @FXML
     private void addFolder() {
-    	if (onAddFolder != null) {
-    		onAddFolder.run();
-    	}
-    	loadLibraryList();
+        if (onAddFolder != null) {
+            onAddFolder.run();
+        }
+        loadLibraryList();
     }
 
     @FXML
@@ -267,30 +267,30 @@ public class LibraryDialogController extends AbstractFxmlWindowController {
             if (dialogListItem instanceof LibraryDialogListItem) {
                 LibraryDialogListItem item = (LibraryDialogListItem) dialogListItem;
                 Path path = item.getFilePath();
-                
-				if (Files.exists(path)) {
-                	if (Files.isDirectory(path)) {
-                		// we need to remove the entry from the folder list in the placeholder marker
-                		String libraryPath = ((UserLibrary) editorController.getLibrary()).getPath();
-                		
-                		Path foldersPath = Paths.get(libraryPath, LibraryUtil.FOLDERS_LIBRARY_FILENAME);
-                		if (Files.exists(foldersPath)) {
-                			
-                			List<String> lines = Files.readAllLines(foldersPath);
-                			
-                			for (Iterator<String> it = lines.iterator(); it.hasNext();) {
-								String line = (String) it.next();
-								if (line.equals(path.toString()))
-									it.remove();
-							}
-                			
-                			Files.write(foldersPath, lines);
-                		}
-                	}
-                	else {
-                		Files.delete(path);
-                		listItems.remove(item);
-                	}
+
+                if (Files.exists(path)) {
+                    if (Files.isDirectory(path)) {
+                        // we need to remove the entry from the folder list in the placeholder marker
+                        String libraryPath = ((UserLibrary) editorController.getLibrary()).getPath();
+
+                        Path foldersPath = Paths.get(libraryPath, LibraryUtil.FOLDERS_LIBRARY_FILENAME);
+                        if (Files.exists(foldersPath)) {
+
+                            List<String> lines = Files.readAllLines(foldersPath);
+
+                            for (Iterator<String> it = lines.iterator(); it.hasNext();) {
+                                String line = (String) it.next();
+                                if (line.equals(path.toString()))
+                                    it.remove();
+                            }
+
+                            Files.write(foldersPath, lines);
+                        }
+                    }
+                    else {
+                        Files.delete(path);
+                        listItems.remove(item);
+                    }
                 }
             } else if (dialogListItem instanceof ArtifactDialogListItem) {
                 preferencesControllerBase.removeArtifact(((ArtifactDialogListItem) dialogListItem).getCoordinates());
@@ -379,6 +379,6 @@ public class LibraryDialogController extends AbstractFxmlWindowController {
     }
     
     public void setOnAddFolder(Runnable onAddFolder) {
-    	this.onAddFolder = onAddFolder;
+        this.onAddFolder = onAddFolder;
     }
 }

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/manager/LibraryDialogController.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/manager/LibraryDialogController.java
@@ -32,27 +32,6 @@
 
 package com.oracle.javafx.scenebuilder.kit.editor.panel.library.manager;
 
-import com.oracle.javafx.scenebuilder.kit.preferences.PreferencesRecordArtifact;
-import com.oracle.javafx.scenebuilder.kit.editor.EditorController;
-import com.oracle.javafx.scenebuilder.kit.i18n.I18N;
-import com.oracle.javafx.scenebuilder.kit.editor.panel.library.maven.MavenArtifact;
-import com.oracle.javafx.scenebuilder.kit.preferences.MavenPreferences;
-import com.oracle.javafx.scenebuilder.kit.editor.panel.library.ImportWindowController;
-import com.oracle.javafx.scenebuilder.kit.editor.panel.library.LibraryPanelController;
-import com.oracle.javafx.scenebuilder.kit.editor.panel.library.maven.MavenDialogController;
-import com.oracle.javafx.scenebuilder.kit.editor.panel.library.maven.search.SearchMavenDialogController;
-import com.oracle.javafx.scenebuilder.kit.editor.panel.library.maven.repository.RepositoryManagerController;
-import com.oracle.javafx.scenebuilder.kit.editor.panel.util.AbstractFxmlWindowController;
-import com.oracle.javafx.scenebuilder.kit.editor.panel.util.dialog.AbstractModalDialog;
-import com.oracle.javafx.scenebuilder.kit.library.user.UserLibrary;
-import com.oracle.javafx.scenebuilder.kit.preferences.PreferencesControllerBase;
-import javafx.collections.FXCollections;
-import javafx.collections.ObservableList;
-import javafx.fxml.FXML;
-import javafx.scene.control.ListView;
-import javafx.stage.Stage;
-import javafx.stage.WindowEvent;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.DirectoryStream;
@@ -60,16 +39,39 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
-import java.util.Locale;
 import java.util.function.Consumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+
+import com.oracle.javafx.scenebuilder.kit.editor.EditorController;
+import com.oracle.javafx.scenebuilder.kit.editor.panel.library.ImportWindowController;
+import com.oracle.javafx.scenebuilder.kit.editor.panel.library.LibraryPanelController;
+import com.oracle.javafx.scenebuilder.kit.editor.panel.library.LibraryUtil;
+import com.oracle.javafx.scenebuilder.kit.editor.panel.library.maven.MavenArtifact;
+import com.oracle.javafx.scenebuilder.kit.editor.panel.library.maven.MavenDialogController;
+import com.oracle.javafx.scenebuilder.kit.editor.panel.library.maven.repository.RepositoryManagerController;
+import com.oracle.javafx.scenebuilder.kit.editor.panel.library.maven.search.SearchMavenDialogController;
+import com.oracle.javafx.scenebuilder.kit.editor.panel.util.AbstractFxmlWindowController;
+import com.oracle.javafx.scenebuilder.kit.editor.panel.util.dialog.AbstractModalDialog;
+import com.oracle.javafx.scenebuilder.kit.i18n.I18N;
+import com.oracle.javafx.scenebuilder.kit.library.user.UserLibrary;
+import com.oracle.javafx.scenebuilder.kit.preferences.MavenPreferences;
+import com.oracle.javafx.scenebuilder.kit.preferences.PreferencesControllerBase;
+import com.oracle.javafx.scenebuilder.kit.preferences.PreferencesRecordArtifact;
+
 import javafx.beans.InvalidationListener;
 import javafx.beans.Observable;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.fxml.FXML;
 import javafx.scene.control.Button;
+import javafx.scene.control.ListView;
 import javafx.stage.Modality;
+import javafx.stage.Stage;
+import javafx.stage.WindowEvent;
 
 /**
  * Controller for the JAR/FXML Library dialog.
@@ -89,6 +91,7 @@ public class LibraryDialogController extends AbstractFxmlWindowController {
     private ObservableList<DialogListItem> listItems;
 
     private Runnable onAddJar;
+    private Runnable onAddFolder;
     private Consumer<Path> onEditFXML;
 
     private String userM2Repository;
@@ -144,8 +147,15 @@ public class LibraryDialogController extends AbstractFxmlWindowController {
         if (folder != null && folder.toFile().exists()) {
             try (DirectoryStream<Path> stream = Files.newDirectoryStream(folder)) {
                 for (Path entry : stream) {
-                    if (isJarPath(entry) || isFxmlPath(entry)) {
+                    if (LibraryUtil.isJarPath(entry) || LibraryUtil.isFxmlPath(entry)) {
                         listItems.add(new LibraryDialogListItem(this, entry));
+                    } else if (LibraryUtil.isFolderMarkerPath(entry)) {
+                    	// open folders marker file: every line should be a single folder entry
+                    	// we scan the file and add the path to currentJarsOrFolders
+                    	List<Path> folderPaths = LibraryUtil.getFolderPaths(entry);
+                    	for (Path f : folderPaths) {
+                    		listItems.add(new LibraryDialogListItem(this, f));
+						}
                     }
                 }
             } catch (IOException x) {
@@ -158,16 +168,6 @@ public class LibraryDialogController extends AbstractFxmlWindowController {
                 .stream()
                 .map(c -> new ArtifactDialogListItem(this, c))
                 .collect(Collectors.toList()));
-    }
-
-    private static boolean isJarPath(Path path) {
-        final String pathString = path.toString().toLowerCase(Locale.ROOT);
-        return pathString.endsWith(".jar"); //NOI18N
-    }
-
-    private static boolean isFxmlPath(Path path) {
-        final String pathString = path.toString().toLowerCase(Locale.ROOT);
-        return pathString.endsWith(".fxml"); //NOI18N
     }
 
     @FXML
@@ -194,7 +194,10 @@ public class LibraryDialogController extends AbstractFxmlWindowController {
     
     @FXML
     private void addFolder() {
-    	
+    	if (onAddFolder != null) {
+    		onAddFolder.run();
+    	}
+    	loadLibraryList();
     }
 
     @FXML
@@ -236,9 +239,9 @@ public class LibraryDialogController extends AbstractFxmlWindowController {
     2) Then, if the file exists, the jar or fxml file will be deleted from the library.
     3) After the jar or fxml is removed, the library watcher is started again.
      */
-    public void processJarFXMLDelete(DialogListItem dialogListItem) {
+    public void processJarFXMLFolderDelete(DialogListItem dialogListItem) {
         if (dialogListItem instanceof LibraryDialogListItem &&
-            isFxmlPath(((LibraryDialogListItem) dialogListItem).getFilePath())) {
+            LibraryUtil.isFxmlPath(((LibraryDialogListItem) dialogListItem).getFilePath())) {
             deleteFile(dialogListItem);
         } else {
             //1)
@@ -256,9 +259,31 @@ public class LibraryDialogController extends AbstractFxmlWindowController {
         try {
             if (dialogListItem instanceof LibraryDialogListItem) {
                 LibraryDialogListItem item = (LibraryDialogListItem) dialogListItem;
-                if (Files.exists(item.getFilePath())) {
-                    Files.delete(item.getFilePath());
-                    listItems.remove(item);
+                Path path = item.getFilePath();
+                
+				if (Files.exists(path)) {
+                	if (Files.isDirectory(path)) {
+                		// we need to remove the entry from the folder list in the placeholder marker
+                		String libraryPath = ((UserLibrary) editorController.getLibrary()).getPath();
+                		
+                		Path foldersPath = Paths.get(libraryPath, LibraryUtil.FOLDERS_LIBRARY_FILENAME);
+                		if (Files.exists(foldersPath)) {
+                			
+                			List<String> lines = Files.readAllLines(foldersPath);
+                			
+                			for (Iterator<String> it = lines.iterator(); it.hasNext();) {
+								String line = (String) it.next();
+								if (line.equals(path.toString()))
+									it.remove();
+							}
+                			
+                			Files.write(foldersPath, lines);
+                		}
+                	}
+                	else {
+                		Files.delete(path);
+                		listItems.remove(item);
+                	}
                 }
             } else if (dialogListItem instanceof ArtifactDialogListItem) {
                 preferencesControllerBase.removeArtifact(((ArtifactDialogListItem) dialogListItem).getCoordinates());
@@ -270,11 +295,11 @@ public class LibraryDialogController extends AbstractFxmlWindowController {
         loadLibraryList();
     }
     
-    public void processJarFXMLEdit(DialogListItem dialogListItem) {
+    public void processJarFXMLFolderEdit(DialogListItem dialogListItem) {
         if (dialogListItem instanceof LibraryDialogListItem) {
             LibraryDialogListItem item = (LibraryDialogListItem) dialogListItem;
             if (Files.exists(item.getFilePath())) {
-                if (isJarPath(item.getFilePath())) {
+                if (LibraryUtil.isJarPath(item.getFilePath()) || Files.isDirectory(item.getFilePath())) {
                     final ImportWindowController iwc = new ImportWindowController(
                             new LibraryPanelController(editorController, preferencesControllerBase.getMavenPreferences()),
                             Arrays.asList(item.getFilePath().toFile()), preferencesControllerBase.getMavenPreferences(),
@@ -344,5 +369,9 @@ public class LibraryDialogController extends AbstractFxmlWindowController {
 
     public void setOnEditFXML(Consumer<Path> onEditFXML) {
         this.onEditFXML = onEditFXML;
+    }
+    
+    public void setOnAddFolder(Runnable onAddFolder) {
+    	this.onAddFolder = onAddFolder;
     }
 }

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/manager/LibraryDialogController.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/manager/LibraryDialogController.java
@@ -191,6 +191,11 @@ public class LibraryDialogController extends AbstractFxmlWindowController {
         }
         loadLibraryList();
     }
+    
+    @FXML
+    private void addFolder() {
+    	
+    }
 
     @FXML
     private void addRelease() {

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/manager/LibraryDialogController.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/manager/LibraryDialogController.java
@@ -67,8 +67,9 @@ import javafx.beans.Observable;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
-import javafx.scene.control.Button;
+import javafx.scene.control.Hyperlink;
 import javafx.scene.control.ListView;
+import javafx.scene.control.Tooltip;
 import javafx.stage.Modality;
 import javafx.stage.Stage;
 import javafx.stage.WindowEvent;
@@ -80,10 +81,9 @@ public class LibraryDialogController extends AbstractFxmlWindowController {
 
     @FXML
     private ListView<DialogListItem> libraryListView;
-    
     @FXML
-    private Button manageButton;
-
+    private Hyperlink classesLink;
+    
     private final EditorController editorController;
     private final UserLibrary userLibrary;
     private final Stage owner;
@@ -110,6 +110,13 @@ public class LibraryDialogController extends AbstractFxmlWindowController {
         this.preferencesControllerBase = preferencesController;
     }
 
+    @Override
+    protected void controllerDidLoadFxml() {
+    	super.controllerDidLoadFxml();
+    	
+    	this.classesLink.setTooltip(new Tooltip(I18N.getString("library.dialog.hyperlink.tooltip")));
+    }
+    
     @Override
     protected void controllerDidCreateStage() {
         if (this.owner == null) {

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/manager/LibraryDialogListCell.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/manager/LibraryDialogListCell.java
@@ -33,6 +33,10 @@
 package com.oracle.javafx.scenebuilder.kit.editor.panel.library.manager;
 
 import com.oracle.javafx.scenebuilder.kit.i18n.I18N;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
 import com.oracle.javafx.scenebuilder.kit.editor.images.ImageUtils;
 import javafx.geometry.Pos;
 import javafx.scene.control.Button;
@@ -72,7 +76,7 @@ public class LibraryDialogListCell extends ListCell<DialogListItem> {
         cellContent.setAlignment(Pos.CENTER_LEFT);
         String name;
         if (dialogListItem instanceof LibraryDialogListItem) {
-            name = ((LibraryDialogListItem) dialogListItem).getFilePath().getFileName().toString();
+            name = ((LibraryDialogListItem) dialogListItem).toString();
         } else {
             name = ((ArtifactDialogListItem) dialogListItem).getCoordinates();
         }
@@ -90,10 +94,10 @@ public class LibraryDialogListCell extends ListCell<DialogListItem> {
         buttonContent.setSpacing(5);
         Button editButton = new Button("", new ImageView(ImageUtils.getEditIconImage()));
         editButton.getStyleClass().add("image-view-button");
-        editButton.setOnMouseClicked(event -> dialogListItem.getLibraryDialogController().processJarFXMLEdit(dialogListItem));
+        editButton.setOnMouseClicked(event -> dialogListItem.getLibraryDialogController().processJarFXMLFolderEdit(dialogListItem));
         editButton.setTooltip(new Tooltip(I18N.getString("library.dialog.button.edit.tooltip")));
         Button deleteButton = new Button("", new ImageView(ImageUtils.getDeleteIconImage()));
-        deleteButton.setOnMouseClicked(event -> dialogListItem.getLibraryDialogController().processJarFXMLDelete(dialogListItem));
+        deleteButton.setOnMouseClicked(event -> dialogListItem.getLibraryDialogController().processJarFXMLFolderDelete(dialogListItem));
         deleteButton.getStyleClass().add("image-view-button");
         deleteButton.setTooltip(new Tooltip(I18N.getString("library.dialog.button.delete.tooltip")));
         buttonContent.getChildren().addAll(editButton, deleteButton);

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/manager/LibraryDialogListItem.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/manager/LibraryDialogListItem.java
@@ -32,6 +32,7 @@
 
 package com.oracle.javafx.scenebuilder.kit.editor.panel.library.manager;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 /**
@@ -54,5 +55,13 @@ public class LibraryDialogListItem implements DialogListItem {
 
     public Path getFilePath() {
         return filePath;
+    }
+    
+    @Override
+    public String toString() {
+    	if (Files.isDirectory(filePath))
+    		return filePath.toAbsolutePath().toString();
+    	else
+    		return filePath.getFileName().toString();
     }
 }

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/manager/LibraryDialogListItem.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/manager/LibraryDialogListItem.java
@@ -59,9 +59,9 @@ public class LibraryDialogListItem implements DialogListItem {
     
     @Override
     public String toString() {
-    	if (Files.isDirectory(filePath))
-    		return filePath.toAbsolutePath().toString();
-    	else
-    		return filePath.getFileName().toString();
+        if (Files.isDirectory(filePath))
+            return filePath.toAbsolutePath().toString();
+        else
+            return filePath.getFileName().toString();
     }
 }

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/library/user/LibraryFolderWatcher.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/library/user/LibraryFolderWatcher.java
@@ -123,12 +123,12 @@ class LibraryFolderWatcher implements Runnable {
                         } else if (LibraryUtil.isFxmlPath(entry)) {
                             currentFxmls.add(entry);
                         } else if (LibraryUtil.isFolderMarkerPath(entry)) {
-                        	// open folders marker file: every line should be a single folder entry
-                        	// we scan the file and add the path to currentJarsOrFolders
-                        	List<Path> folderPaths = LibraryUtil.getFolderPaths(entry);
-                        	for (Path f : folderPaths) {
-                        		currentJarsOrFolders.add(f);
-							}
+                            // open folders marker file: every line should be a single folder entry
+                            // we scan the file and add the path to currentJarsOrFolders
+                            List<Path> folderPaths = LibraryUtil.getFolderPaths(entry);
+                            for (Path f : folderPaths) {
+                                currentJarsOrFolders.add(f);
+                            }
                         }
                     }
                     retry = false;
@@ -142,14 +142,14 @@ class LibraryFolderWatcher implements Runnable {
             while (retry && library.getExplorationCount() < 10);
         }
         try {
-        	library.setExploring(true);
-        	try {
-	            updateLibrary(currentFxmls);
-	            exploreAndUpdateLibrary(currentJarsOrFolders);
-        	}
-        	finally {
-        		library.setExploring(false);
-        	}
+            library.setExploring(true);
+            try {
+                updateLibrary(currentFxmls);
+                exploreAndUpdateLibrary(currentJarsOrFolders);
+            }
+            finally {
+                library.setExploring(false);
+            }
         } catch(IOException x) { }
     }
     
@@ -210,31 +210,31 @@ class LibraryFolderWatcher implements Runnable {
                             // First put the builtin items in the library
                         	library.setExploring(true);
                         	try {
-	                            library.setItems(BuiltinLibrary.getLibrary().getItems());
-	                            
-	                            // Now attempts to add the maven jars
-	                            List<Path> currentMavenJars = library.getAdditionalJarPaths().get();
-	                            
-	                            final Set<Path> fxmls = new HashSet<>();
-	                            fxmls.addAll(getAllFiles(FILE_TYPE.FXML));
-	                            updateLibrary(fxmls);
-	                            
-	                            final Set<Path> jarsAndFolders = new HashSet<>(currentMavenJars);
-	                            jarsAndFolders.addAll(getAllFiles(FILE_TYPE.JAR));
-	                            
-	                            Set<Path> foldersMarkers = getAllFiles(FILE_TYPE.FOLDER_MARKER);
-	                            for (Path path : foldersMarkers) {
-	                            	// open folders marker file: every line should be a single folder entry
-	                            	// we scan the file and add the path to currentJarsOrFolders
-	                            	List<Path> folderPaths = LibraryUtil.getFolderPaths(path);
-	                            	for (Path f : folderPaths) {
-	                            		jarsAndFolders.add(f);
-									}
-								}
-	                            
-	                            exploreAndUpdateLibrary(jarsAndFolders);
-	                            
-	                            library.updateExplorationCount(library.getExplorationCount()+1);
+                        	    library.setItems(BuiltinLibrary.getLibrary().getItems());
+
+                        	    // Now attempts to add the maven jars
+                        	    List<Path> currentMavenJars = library.getAdditionalJarPaths().get();
+
+                        	    final Set<Path> fxmls = new HashSet<>();
+                        	    fxmls.addAll(getAllFiles(FILE_TYPE.FXML));
+                        	    updateLibrary(fxmls);
+
+                        	    final Set<Path> jarsAndFolders = new HashSet<>(currentMavenJars);
+                        	    jarsAndFolders.addAll(getAllFiles(FILE_TYPE.JAR));
+
+                        	    Set<Path> foldersMarkers = getAllFiles(FILE_TYPE.FOLDER_MARKER);
+                        	    for (Path path : foldersMarkers) {
+                        	        // open folders marker file: every line should be a single folder entry
+                        	        // we scan the file and add the path to currentJarsOrFolders
+                        	        List<Path> folderPaths = LibraryUtil.getFolderPaths(path);
+                        	        for (Path f : folderPaths) {
+                        	            jarsAndFolders.add(f);
+                        	        }
+                        	    }
+
+                        	    exploreAndUpdateLibrary(jarsAndFolders);
+
+                        	    library.updateExplorationCount(library.getExplorationCount()+1);
                         	}
                         	finally {
                         		library.setExploring(false);
@@ -267,10 +267,10 @@ class LibraryFolderWatcher implements Runnable {
                         }
                         break;
                     case FOLDER_MARKER:
-                    	if (LibraryUtil.isFolderMarkerPath(p)) {
-                    		res.add(p);
-                    	}
-                    	break;
+                        if (LibraryUtil.isFolderMarkerPath(p)) {
+                            res.add(p);
+                        }
+                        break;
                     default:
                         break;
                 }
@@ -348,20 +348,20 @@ class LibraryFolderWatcher implements Runnable {
 //        boolean shouldShowImportGluonJarAlert = false;
         for (Path currentJarOrFolder : jarsOrFolders) {
             if (LibraryUtil.isJarPath(currentJarOrFolder)) {
-            	Logger.getLogger(this.getClass().getSimpleName()).info(I18N.getString("log.info.explore.jar", currentJarOrFolder));
-	            final JarExplorer explorer = new JarExplorer(currentJarOrFolder);
-	            JarReport jarReport = explorer.explore(classLoader);
-	            jarOrFolderReports.add(jarReport);
+                Logger.getLogger(this.getClass().getSimpleName()).info(I18N.getString("log.info.explore.jar", currentJarOrFolder));
+                final JarExplorer explorer = new JarExplorer(currentJarOrFolder);
+                JarReport jarReport = explorer.explore(classLoader);
+                jarOrFolderReports.add(jarReport);
             }
             else if (Files.isDirectory(currentJarOrFolder)) {
-            	Logger.getLogger(this.getClass().getSimpleName()).info(I18N.getString("log.info.explore.folder", currentJarOrFolder));
-	            final FolderExplorer explorer = new FolderExplorer(currentJarOrFolder);
-	            JarReport jarReport = explorer.explore(classLoader);
-	            jarOrFolderReports.add(jarReport);
+                Logger.getLogger(this.getClass().getSimpleName()).info(I18N.getString("log.info.explore.folder", currentJarOrFolder));
+                final FolderExplorer explorer = new FolderExplorer(currentJarOrFolder);
+                JarReport jarReport = explorer.explore(classLoader);
+                jarOrFolderReports.add(jarReport);
             }
-            
-            Logger.getLogger(this.getClass().getSimpleName()).info(I18N.getString("log.info.explore.end", currentJarOrFolder));
 
+            Logger.getLogger(this.getClass().getSimpleName()).info(I18N.getString("log.info.explore.end", currentJarOrFolder));
+            
             //            if (jarReport.hasGluonControls()) {
 //                // We check if the jar has already been imported to avoid showing the import gluon jar
 //                // alert every time Scene Builder starts for jars that have already been imported
@@ -427,7 +427,7 @@ class LibraryFolderWatcher implements Runnable {
         int i = 0;
         for (Path p : paths) {
             try {
-            	URL url = p.toUri().toURL();
+                URL url = p.toUri().toURL();
                 if (url.toString().endsWith(".jar")) {
                     result[i++] = new URL("jar", "", url + "!/"); // <-- jar:file/path/to/jar!/
                 } else {

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/library/user/LibraryFolderWatcher.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/library/user/LibraryFolderWatcher.java
@@ -427,7 +427,12 @@ class LibraryFolderWatcher implements Runnable {
         int i = 0;
         for (Path p : paths) {
             try {
-                result[i++] = new URL("jar","",p.toUri().toURL()+"!/");
+            	URL url = p.toUri().toURL();
+                if (url.toString().endsWith(".jar")) {
+                    result[i++] = new URL("jar", "", url + "!/"); // <-- jar:file/path/to/jar!/
+                } else {
+                    result[i++] = url; // <-- file:/path/to/folder/
+                }
             } catch(MalformedURLException x) {
                 throw new RuntimeException("Bug in " + getClass().getSimpleName(), x); //NOI18N
             }

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/library/user/UserLibrary.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/library/user/UserLibrary.java
@@ -32,10 +32,6 @@
  */
 package com.oracle.javafx.scenebuilder.kit.library.user;
 
-import com.oracle.javafx.scenebuilder.kit.library.BuiltinSectionComparator;
-import com.oracle.javafx.scenebuilder.kit.library.Library;
-import com.oracle.javafx.scenebuilder.kit.library.LibraryItem;
-import com.oracle.javafx.scenebuilder.kit.library.util.JarReport;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -57,11 +53,17 @@ import java.util.TreeSet;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
+import com.oracle.javafx.scenebuilder.kit.library.BuiltinSectionComparator;
+import com.oracle.javafx.scenebuilder.kit.library.Library;
+import com.oracle.javafx.scenebuilder.kit.library.LibraryItem;
+import com.oracle.javafx.scenebuilder.kit.library.util.JarReport;
+
 import javafx.application.Platform;
 import javafx.beans.property.ReadOnlyBooleanProperty;
 import javafx.beans.property.ReadOnlyBooleanWrapper;
 import javafx.beans.property.ReadOnlyIntegerProperty;
 import javafx.beans.property.ReadOnlyObjectProperty;
+import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleIntegerProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.FXCollections;
@@ -88,7 +90,8 @@ public class UserLibrary extends Library {
     private final SimpleIntegerProperty explorationCountProperty = new SimpleIntegerProperty();
     private final SimpleObjectProperty<Date> explorationDateProperty = new SimpleObjectProperty<>();
     private final ReadOnlyBooleanWrapper firstExplorationCompleted = new ReadOnlyBooleanWrapper(false);
-    
+    private SimpleBooleanProperty exploring = new SimpleBooleanProperty();
+
     private State state = State.READY;
     private Exception exception;
     private LibraryFolderWatcher watcher;
@@ -209,7 +212,7 @@ public class UserLibrary extends Library {
     }
     
     public void setFilter(List<String> classnames) throws FileNotFoundException, IOException {
-        if (classnames != null && classnames.size() > 0) {
+//        if (classnames != null && classnames.size() > 0) { // empty classnames means "no filter", so we need to clear filters.txt file
             File filterFile = new File(getFilterFileName());
             // TreeSet to get natural order sorting and no duplicates
             TreeSet<String> allClassnames = new TreeSet<>();
@@ -249,7 +252,7 @@ public class UserLibrary extends Library {
                 }
                 throw (ioe);
             }
-        }
+//        }
     }
     
     public List<String> getFilter() throws FileNotFoundException, IOException {
@@ -279,6 +282,22 @@ public class UserLibrary extends Library {
     public final boolean isFirstExplorationCompleted() {
         return firstExplorationCompleted.get();
     }
+
+	public SimpleBooleanProperty exploringProperty() {
+		return exploring;
+	}
+
+	public boolean isExploring() {
+		return exploringProperty().get();
+	}
+
+	public void setExploring(boolean value) {
+		if (Platform.isFxApplicationThread())
+			exploringProperty().set(value);
+		else
+			Platform.runLater(() -> setExploring(value));
+	}
+
 
     /*
      * Package

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/library/user/UserLibrary.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/library/user/UserLibrary.java
@@ -283,20 +283,20 @@ public class UserLibrary extends Library {
         return firstExplorationCompleted.get();
     }
 
-	public SimpleBooleanProperty exploringProperty() {
-		return exploring;
-	}
+    public SimpleBooleanProperty exploringProperty() {
+        return exploring;
+    }
 
-	public boolean isExploring() {
-		return exploringProperty().get();
-	}
+    public boolean isExploring() {
+        return exploringProperty().get();
+    }
 
-	public void setExploring(boolean value) {
-		if (Platform.isFxApplicationThread())
-			exploringProperty().set(value);
-		else
-			Platform.runLater(() -> setExploring(value));
-	}
+    public void setExploring(boolean value) {
+        if (Platform.isFxApplicationThread())
+            exploringProperty().set(value);
+        else
+            Platform.runLater(() -> setExploring(value));
+    }
 
 
     /*

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/library/util/FolderExplorer.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/library/util/FolderExplorer.java
@@ -47,38 +47,34 @@ import com.oracle.javafx.scenebuilder.kit.library.util.JarReportEntry.Status;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Node;
 
-/**
- *
- * 
- */
 public class FolderExplorer {
-    
+
     private final Path rootFolderPath;
-    
+
     public FolderExplorer(Path folderPath) {
         assert folderPath != null;
         assert folderPath.isAbsolute();
-        
+
         this.rootFolderPath = folderPath;
     }
-    
+
     public JarReport explore(ClassLoader classLoader) throws IOException {
         final JarReport result = new JarReport(rootFolderPath);
-        
+
         try (Stream<Path> stream = Files.walk(rootFolderPath).filter(p -> !p.toFile().isDirectory())) {
-        	stream.forEach(p -> {
-        		JarReportEntry explored = exploreEntry(rootFolderPath, p, classLoader);
-        		if (explored.getStatus() != Status.IGNORED)
-        			result.getEntries().add(explored);
-        	});
+            stream.forEach(p -> {
+                JarReportEntry explored = exploreEntry(rootFolderPath, p, classLoader);
+                if (explored.getStatus() != Status.IGNORED)
+                    result.getEntries().add(explored);
+            });
         };
-        
+
         return result;
     }
-    
+
     public static String makeFxmlText(Class<?> klass) {
         final StringBuilder result = new StringBuilder();
-        
+
         /*
          * <?xml version="1.0" encoding="UTF-8"?> //NOI18N
          * 
@@ -86,23 +82,23 @@ public class FolderExplorer {
          * 
          * <C/>
          */
-        
+
         result.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"); //NOI18N
-        
+
         result.append("<?import "); //NOI18N
         result.append(klass.getCanonicalName());
         result.append("?>"); //NOI18N
         result.append("<"); //NOI18N
         result.append(klass.getSimpleName());
         result.append("/>\n"); //NOI18N
-        
+
         return result.toString();
     }
-    
-    
+
+
     public static Object instantiateWithFXMLLoader(Class<?> klass, ClassLoader classLoader) throws IOException {
         Object result;
-        
+
         final String fxmlText = makeFxmlText(klass);
         final byte[] fxmlBytes = fxmlText.getBytes(Charset.forName("UTF-8")); //NOI18N
 
@@ -115,30 +111,30 @@ public class FolderExplorer {
         } catch(RuntimeException|Error x) {
             throw new IOException(x);
         }
-        
+
         return result;
     }
-    
+
     /*
      * Private
      */
-    
+
     private JarReportEntry exploreEntry(Path rootpath, Path path, ClassLoader classLoader) {
         JarReportEntry.Status status;
         Throwable entryException;
         Class<?> entryClass = null;
         String className;
-        
+
         File file = path.toFile();
-        
+
         if (file.isDirectory()) {
             status = JarReportEntry.Status.IGNORED;
             entryClass = null;
             entryException = null;
             className = null;
         } else {
-        	Path relativepath = rootpath.relativize(path);
-        	
+            Path relativepath = rootpath.relativize(path);
+
             className = makeClassName(relativepath.toString());
             // Filtering out what starts with com.javafx. is bound to DTL-6378.
             if (className == null || className.startsWith("java.") //NOI18N
@@ -177,14 +173,14 @@ public class FolderExplorer {
                 }
             }
         }
-        
+
         return new JarReportEntry(file.getName(), status, entryException, entryClass, className);
     }
-    
-    
+
+
     private String makeClassName(String filename) {
         final String result;
-        
+
         if (filename.endsWith(".class") == false) { //NOI18N
             result = null;
         } else if (filename.contains("$")) { //NOI18N
@@ -194,7 +190,7 @@ public class FolderExplorer {
             final int endIndex = filename.length()-6; // ".class" -> 6 //NOI18N
             result = filename.substring(0, endIndex).replace(File.separator, "."); //NOI18N
         }
-        
+
         return result;
     }
 }

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/library/util/FolderExplorer.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/library/util/FolderExplorer.java
@@ -42,6 +42,7 @@ import java.nio.file.Path;
 import java.util.stream.Stream;
 
 import com.oracle.javafx.scenebuilder.kit.editor.EditorPlatform;
+import com.oracle.javafx.scenebuilder.kit.library.util.JarReportEntry.Status;
 
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Node;
@@ -66,7 +67,9 @@ public class FolderExplorer {
         
         try (Stream<Path> stream = Files.walk(rootFolderPath).filter(p -> !p.toFile().isDirectory())) {
         	stream.forEach(p -> {
-        		result.getEntries().add(exploreEntry(rootFolderPath, p, classLoader));
+        		JarReportEntry explored = exploreEntry(rootFolderPath, p, classLoader);
+        		if (explored.getStatus() != Status.IGNORED)
+        			result.getEntries().add(explored);
         	});
         };
         

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/library/util/FolderExplorer.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/library/util/FolderExplorer.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2017, Gluon and/or its affiliates.
+ * Copyright (c) 2012, 2014, Oracle and/or its affiliates.
+ * All rights reserved. Use is subject to license terms.
+ *
+ * This file is available and licensed under the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the distribution.
+ *  - Neither the name of Oracle Corporation nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.javafx.scenebuilder.kit.library.util;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Modifier;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+import com.oracle.javafx.scenebuilder.kit.editor.EditorPlatform;
+
+import javafx.fxml.FXMLLoader;
+import javafx.scene.Node;
+
+/**
+ *
+ * 
+ */
+public class FolderExplorer {
+    
+    private final Path rootFolderPath;
+    
+    public FolderExplorer(Path folderPath) {
+        assert folderPath != null;
+        assert folderPath.isAbsolute();
+        
+        this.rootFolderPath = folderPath;
+    }
+    
+    public JarReport explore(ClassLoader classLoader) throws IOException {
+        final JarReport result = new JarReport(rootFolderPath);
+        
+        try (Stream<Path> stream = Files.walk(rootFolderPath).filter(p -> !p.toFile().isDirectory())) {
+        	stream.forEach(p -> {
+        		result.getEntries().add(exploreEntry(rootFolderPath, p, classLoader));
+        	});
+        };
+        
+        return result;
+    }
+    
+    public static String makeFxmlText(Class<?> klass) {
+        final StringBuilder result = new StringBuilder();
+        
+        /*
+         * <?xml version="1.0" encoding="UTF-8"?> //NOI18N
+         * 
+         * <?import a.b.C?>
+         * 
+         * <C/>
+         */
+        
+        result.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"); //NOI18N
+        
+        result.append("<?import "); //NOI18N
+        result.append(klass.getCanonicalName());
+        result.append("?>"); //NOI18N
+        result.append("<"); //NOI18N
+        result.append(klass.getSimpleName());
+        result.append("/>\n"); //NOI18N
+        
+        return result.toString();
+    }
+    
+    
+    public static Object instantiateWithFXMLLoader(Class<?> klass, ClassLoader classLoader) throws IOException {
+        Object result;
+        
+        final String fxmlText = makeFxmlText(klass);
+        final byte[] fxmlBytes = fxmlText.getBytes(Charset.forName("UTF-8")); //NOI18N
+
+        final FXMLLoader fxmlLoader = new FXMLLoader();
+        try {
+            fxmlLoader.setClassLoader(classLoader);
+            result = fxmlLoader.load(new ByteArrayInputStream(fxmlBytes));
+        } catch(IOException x) {
+            throw x;
+        } catch(RuntimeException|Error x) {
+            throw new IOException(x);
+        }
+        
+        return result;
+    }
+    
+    /*
+     * Private
+     */
+    
+    private JarReportEntry exploreEntry(Path rootpath, Path path, ClassLoader classLoader) {
+        JarReportEntry.Status status;
+        Throwable entryException;
+        Class<?> entryClass = null;
+        String className;
+        
+        File file = path.toFile();
+        
+        if (file.isDirectory()) {
+            status = JarReportEntry.Status.IGNORED;
+            entryClass = null;
+            entryException = null;
+            className = null;
+        } else {
+        	Path relativepath = rootpath.relativize(path);
+        	
+            className = makeClassName(relativepath.toString());
+            // Filtering out what starts with com.javafx. is bound to DTL-6378.
+            if (className == null || className.startsWith("java.") //NOI18N
+                    || className.startsWith("javax.") || className.startsWith("javafx.") //NOI18N
+                    || className.startsWith("com.oracle.javafx.scenebuilder.") //NOI18N
+                    || className.startsWith("com.javafx.")
+                    || className.startsWith(EditorPlatform.GLUON_PACKAGE)) { //NOI18N
+                status = JarReportEntry.Status.IGNORED;
+                entryClass = null;
+                entryException = null;
+            } else {
+                try {
+                    // Some reading explaining why using Class.forName is not appropriate:
+                    // http://blog.osgi.org/2011/05/what-you-should-know-about-class.html
+                    // http://blog.bjhargrave.com/2007/09/classforname-caches-defined-class-in.html
+                    // http://stackoverflow.com/questions/8100376/class-forname-vs-classloader-loadclass-which-to-use-for-dynamic-loading
+                    entryClass = classLoader.loadClass(className); // Note: static intializers of entryClass are not run, this doesn't seem to be an issue
+
+                    if (Modifier.isAbstract(entryClass.getModifiers())
+                            || !Node.class.isAssignableFrom(entryClass)) {
+                        status = JarReportEntry.Status.IGNORED;
+                        entryClass = null;
+                        entryException = null;
+                    } else {
+                        instantiateWithFXMLLoader(entryClass, classLoader);
+                        status = JarReportEntry.Status.OK;
+                        entryException = null;
+                    }
+                } catch (RuntimeException | IOException x) {
+                    status = JarReportEntry.Status.CANNOT_INSTANTIATE;
+                    entryException = x;
+                } catch (Error | ClassNotFoundException x) {
+                    status = JarReportEntry.Status.CANNOT_LOAD;
+                    entryClass = null;
+                    entryException = x;
+                }
+            }
+        }
+        
+        return new JarReportEntry(file.getName(), status, entryException, entryClass, className);
+    }
+    
+    
+    private String makeClassName(String filename) {
+        final String result;
+        
+        if (filename.endsWith(".class") == false) { //NOI18N
+            result = null;
+        } else if (filename.contains("$")) { //NOI18N
+            // We skip inner classes for now
+            result = null;
+        } else {
+            final int endIndex = filename.length()-6; // ".class" -> 6 //NOI18N
+            result = filename.substring(0, endIndex).replace(File.separator, "."); //NOI18N
+        }
+        
+        return result;
+    }
+}

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/library/util/JarExplorer.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/library/util/JarExplorer.java
@@ -42,6 +42,8 @@ import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
 import com.oracle.javafx.scenebuilder.kit.editor.EditorPlatform;
+import com.oracle.javafx.scenebuilder.kit.library.util.JarReportEntry.Status;
+
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Node;
 
@@ -67,7 +69,9 @@ public class JarExplorer {
             final Enumeration<JarEntry> e = jarFile.entries();
             while (e.hasMoreElements()) {
                 final JarEntry entry = e.nextElement();
-                result.getEntries().add(exploreEntry(entry, classLoader));
+                JarReportEntry explored = exploreEntry(entry, classLoader);
+                if (explored.getStatus() != Status.IGNORED)
+                	result.getEntries().add(explored);
             }
         }
         

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/library/util/JarExplorer.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/library/util/JarExplorer.java
@@ -71,7 +71,7 @@ public class JarExplorer {
                 final JarEntry entry = e.nextElement();
                 JarReportEntry explored = exploreEntry(entry, classLoader);
                 if (explored.getStatus() != Status.IGNORED)
-                	result.getEntries().add(explored);
+                    result.getEntries().add(explored);
             }
         }
         

--- a/kit/src/main/resources/com/oracle/javafx/scenebuilder/kit/editor/panel/library/LibraryDialog.fxml
+++ b/kit/src/main/resources/com/oracle/javafx/scenebuilder/kit/editor/panel/library/LibraryDialog.fxml
@@ -45,7 +45,7 @@
 <?import javafx.scene.layout.Pane?>
 <?import javafx.scene.layout.RowConstraints?>
 
-<AnchorPane fx:id="LibraryDialog" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="300.0" minWidth="300.0" prefHeight="420.0" prefWidth="500.0" styleClass="theme-presets" xmlns="http://javafx.com/javafx/8.0.65" xmlns:fx="http://javafx.com/fxml/1">
+<AnchorPane fx:id="LibraryDialog" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="300.0" minWidth="300.0" prefHeight="468.0" prefWidth="500.0" styleClass="theme-presets" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1">
    <children>
       <GridPane hgap="5.0" prefHeight="380.0" prefWidth="520.0" vgap="5.0" AnchorPane.bottomAnchor="10.0" AnchorPane.leftAnchor="10.0" AnchorPane.rightAnchor="10.0" AnchorPane.topAnchor="10.0">
          <columnConstraints>
@@ -60,6 +60,7 @@
             <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
             <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
             <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+            <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
             <RowConstraints minHeight="40.0" prefHeight="40.0" vgrow="SOMETIMES" />
          </rowConstraints>
          <children>
@@ -70,7 +71,7 @@
                  </placeholder>
             </ListView>
             <Label prefHeight="17.0" prefWidth="577.0" text="%library.dialog.label.install" GridPane.columnSpan="2" GridPane.rowIndex="2" />
-            <HBox alignment="CENTER_RIGHT" spacing="10.0" GridPane.columnSpan="2" GridPane.rowIndex="7">
+            <HBox alignment="CENTER_RIGHT" spacing="10.0" GridPane.columnSpan="2" GridPane.rowIndex="8">
                <children>
                   <Pane prefHeight="15.0" prefWidth="324.0" HBox.hgrow="ALWAYS" />
                   <Button fx:id="closeButton" layoutX="317.0" layoutY="17.0" minWidth="70.0" mnemonicParsing="false" onAction="#close" text="%library.dialog.button.close" />
@@ -82,7 +83,8 @@
                </GridPane.margin></Hyperlink>
             <Hyperlink layoutX="15.0" layoutY="298.0" onAction="#addManually" prefHeight="25.0" prefWidth="477.0" styleClass="dialog-hyperlink" text="%library.dialog.hyperlink.manually" GridPane.columnIndex="1" GridPane.rowIndex="4" />
             <Hyperlink layoutX="15.0" layoutY="298.0" onAction="#addJar" prefHeight="25.0" prefWidth="477.0" styleClass="dialog-hyperlink" text="%library.dialog.hyperlink.jar" GridPane.columnIndex="1" GridPane.rowIndex="5" />
-            <Hyperlink layoutX="30.0" layoutY="316.0" onAction="#manage" prefHeight="25.0" prefWidth="477.0" styleClass="dialog-hyperlink" text="%library.dialog.hyperlink.repositories" GridPane.columnIndex="1" GridPane.rowIndex="6" />
+            <Hyperlink onAction="#addFolder" prefHeight="25.0" prefWidth="477.0" styleClass="dialog-hyperlink" text="Add Library/FXML from folder" GridPane.columnIndex="1" GridPane.rowIndex="6" />
+            <Hyperlink layoutX="30.0" layoutY="316.0" onAction="#manage" prefHeight="25.0" prefWidth="477.0" styleClass="dialog-hyperlink" text="%library.dialog.hyperlink.repositories" GridPane.columnIndex="1" GridPane.rowIndex="7" />
          </children>
          <padding>
             <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />

--- a/kit/src/main/resources/com/oracle/javafx/scenebuilder/kit/editor/panel/library/LibraryDialog.fxml
+++ b/kit/src/main/resources/com/oracle/javafx/scenebuilder/kit/editor/panel/library/LibraryDialog.fxml
@@ -83,7 +83,7 @@
                </GridPane.margin></Hyperlink>
             <Hyperlink layoutX="15.0" layoutY="298.0" onAction="#addManually" prefHeight="25.0" prefWidth="477.0" styleClass="dialog-hyperlink" text="%library.dialog.hyperlink.manually" GridPane.columnIndex="1" GridPane.rowIndex="4" />
             <Hyperlink layoutX="15.0" layoutY="298.0" onAction="#addJar" prefHeight="25.0" prefWidth="477.0" styleClass="dialog-hyperlink" text="%library.dialog.hyperlink.jar" GridPane.columnIndex="1" GridPane.rowIndex="5" />
-            <Hyperlink onAction="#addFolder" prefHeight="25.0" prefWidth="477.0" styleClass="dialog-hyperlink" text="Add Library/FXML from folder" GridPane.columnIndex="1" GridPane.rowIndex="6" />
+            <Hyperlink onAction="#addFolder" prefHeight="25.0" prefWidth="477.0" styleClass="dialog-hyperlink" text="%library.dialog.hyperlink.folder" GridPane.columnIndex="1" GridPane.rowIndex="6" />
             <Hyperlink layoutX="30.0" layoutY="316.0" onAction="#manage" prefHeight="25.0" prefWidth="477.0" styleClass="dialog-hyperlink" text="%library.dialog.hyperlink.repositories" GridPane.columnIndex="1" GridPane.rowIndex="7" />
          </children>
          <padding>

--- a/kit/src/main/resources/com/oracle/javafx/scenebuilder/kit/editor/panel/library/LibraryDialog.fxml
+++ b/kit/src/main/resources/com/oracle/javafx/scenebuilder/kit/editor/panel/library/LibraryDialog.fxml
@@ -83,7 +83,7 @@
                </GridPane.margin></Hyperlink>
             <Hyperlink layoutX="15.0" layoutY="298.0" onAction="#addManually" prefHeight="25.0" prefWidth="477.0" styleClass="dialog-hyperlink" text="%library.dialog.hyperlink.manually" GridPane.columnIndex="1" GridPane.rowIndex="4" />
             <Hyperlink layoutX="15.0" layoutY="298.0" onAction="#addJar" prefHeight="25.0" prefWidth="477.0" styleClass="dialog-hyperlink" text="%library.dialog.hyperlink.jar" GridPane.columnIndex="1" GridPane.rowIndex="5" />
-            <Hyperlink onAction="#addFolder" prefHeight="25.0" prefWidth="477.0" styleClass="dialog-hyperlink" text="%library.dialog.hyperlink.folder" GridPane.columnIndex="1" GridPane.rowIndex="6" />
+            <Hyperlink fx:id="classesLink" onAction="#addFolder" prefHeight="25.0" prefWidth="477.0" styleClass="dialog-hyperlink" text="%library.dialog.hyperlink.folder" GridPane.columnIndex="1" GridPane.rowIndex="6" />
             <Hyperlink layoutX="30.0" layoutY="316.0" onAction="#manage" prefHeight="25.0" prefWidth="477.0" styleClass="dialog-hyperlink" text="%library.dialog.hyperlink.repositories" GridPane.columnIndex="1" GridPane.rowIndex="7" />
          </children>
          <padding>

--- a/kit/src/main/resources/com/oracle/javafx/scenebuilder/kit/i18n/SceneBuilderKit.properties
+++ b/kit/src/main/resources/com/oracle/javafx/scenebuilder/kit/i18n/SceneBuilderKit.properties
@@ -234,7 +234,7 @@ library.dialog.title =Library Manager
 
 library.dialog.hyperlink.release = Search repositories
 library.dialog.hyperlink.manually = Manually add Library from repository
-library.dialog.hyperlink.folder = Add folder from file system
+library.dialog.hyperlink.folder = Add folder from file system for *.class files (root folder to be specified)
 library.dialog.hyperlink.jar = Add Library/FXML from file system
 library.dialog.hyperlink.repositories = Manage repositories
 

--- a/kit/src/main/resources/com/oracle/javafx/scenebuilder/kit/i18n/SceneBuilderKit.properties
+++ b/kit/src/main/resources/com/oracle/javafx/scenebuilder/kit/i18n/SceneBuilderKit.properties
@@ -234,7 +234,8 @@ library.dialog.title =Library Manager
 
 library.dialog.hyperlink.release = Search repositories
 library.dialog.hyperlink.manually = Manually add Library from repository
-library.dialog.hyperlink.folder = Add folder from file system for *.class files (root folder to be specified)
+library.dialog.hyperlink.folder = Add root folder with *.class files
+library.dialog.hyperlink.tooltip = Use this option to specify the root folder under which to scan for controls.\nE.g. add the bin/ folder produced by your IDE during development of custom components.
 library.dialog.hyperlink.jar = Add Library/FXML from file system
 library.dialog.hyperlink.repositories = Manage repositories
 

--- a/kit/src/main/resources/com/oracle/javafx/scenebuilder/kit/i18n/SceneBuilderKit.properties
+++ b/kit/src/main/resources/com/oracle/javafx/scenebuilder/kit/i18n/SceneBuilderKit.properties
@@ -68,6 +68,8 @@ label.qualifier.vertical = (vertical)
 # -----------------------------------------------------------------------------
 # Log Messages
 # -----------------------------------------------------------------------------
+log.info.explore.end = End exploring {0}
+log.info.explore.folder = Start exploring FOLDER {0}
 log.info.explore.jar = Start exploring JAR {0}
 log.warning.inline.edit.internationalized.strings = Can''t inline edit internationalized strings
 log.warning.color.creation.error.hexadecimal = Can''t create color for hexadecimal value ''{0}''
@@ -232,6 +234,7 @@ library.dialog.title =Library Manager
 
 library.dialog.hyperlink.release = Search repositories
 library.dialog.hyperlink.manually = Manually add Library from repository
+library.dialog.hyperlink.folder = Add folder from file system
 library.dialog.hyperlink.jar = Add Library/FXML from file system
 library.dialog.hyperlink.repositories = Manage repositories
 


### PR DESCRIPTION
This PR adds a long waited (by me) feature, that enables the user to add a folder (in particular, root folders with classes) to the custom components library.

![immagine](https://user-images.githubusercontent.com/14213760/55564285-df03f480-56f7-11e9-8f61-5913f810cbeb.png)

Users can add as many folders as they want.
After adding one folder to the library, that one is used as the root for loading classes in all its subfolders, and components that were able to be loaded are added to the "Custom" library panel, as if they loaded from a jar.

Bonus: the library label updates its text during scanning, so it is evident to users that a maybe long process is running..
![immagine](https://user-images.githubusercontent.com/14213760/55564515-589be280-56f8-11e9-8c47-132a015f08b6.png)

The main advatange of this PR, is that a developer can add a "bin" folder from their running Eclipse/IDEA to the library manager and have the custom components loaded into SB without the need to create and publish a jar to the library directory everytime.

Feel free to ask for clarifications...