### PR TITLE
Fix typo in gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ kit/build/
 # Eclipse
 .classpath
 .project
-.settinigs/
+.settings/
 bin/
 
 # Netbeans


### PR DESCRIPTION
The gitignore file has a typo that causes Eclipse project settings files to be tracked.