### PR TITLE
section name for imported libraries

### DIFF
--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/library/user/LibraryFolderWatcher.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/library/user/LibraryFolderWatcher.java
@@ -411,9 +411,19 @@ class LibraryFolderWatcher implements Runnable {
                 final String canonicalName = e.getKlass().getCanonicalName();
                 if (!excludedItems.contains(canonicalName) && 
                     !artifactsFilter.contains(canonicalName)) {
-                    final String name = e.getKlass().getSimpleName();
-                    final String fxmlText = JarExplorer.makeFxmlText(e.getKlass());
-                    result.add(new LibraryItem(name, UserLibrary.TAG_USER_DEFINED, fxmlText, iconURL, library));
+                	
+                	final String name = e.getKlass().getSimpleName();
+                	String sectionName =jarOrFolderReport.getJar().toString();
+                	
+                	// if some os don't use '/' for folder path (don't know if there is)
+                	if (sectionName.lastIndexOf("\\")==-1)
+                		sectionName=UserLibrary.TAG_USER_DEFINED;
+                	else
+                		sectionName=sectionName.substring(sectionName.lastIndexOf("\\")+1, 
+                					sectionName.lastIndexOf("."));
+                	
+                	final String fxmlText = JarExplorer.makeFxmlText(e.getKlass());
+                    result.add(new LibraryItem(name, sectionName, fxmlText, iconURL, library));
                 }
             }
         }


### PR DESCRIPTION
A minor update changing the section names of imported librairies for more visibility

from  
![image](https://user-images.githubusercontent.com/41478485/83655443-b9ee6880-a5be-11ea-96d4-8cd86f32b305.png)
to  
![image](https://user-images.githubusercontent.com/41478485/83655572-e0140880-a5be-11ea-9040-f1a2ec6914fc.png)
