### PR TITLE
Binding expression edition support (no resolution / string only)

### DIFF
--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/content/mode/EditModeController.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/content/mode/EditModeController.java
@@ -724,11 +724,16 @@ implements AbstractGesture.Observer {
             final DesignHierarchyMask m
                     = new DesignHierarchyMask(hitObject);
             // Do not allow inline editing of the I18N value
-            if (m.isResourceKey() == false) {
+            if (m.isResourceKey() == false && m.isBindingExpression() == false) {
                 handleInlineEditing((FXOMInstance) selectAndMoveGesture.getHitObject());
             } else {
                 final MessageLog ml = contentPanelController.getEditorController().getMessageLog();
-                ml.logWarningMessage("log.warning.inline.edit.internationalized.strings");
+                if (m.isResourceKey()) {
+                	ml.logWarningMessage("log.warning.inline.edit.internationalized.strings");
+                }
+                if (m.isBindingExpression()) {
+                	ml.logWarningMessage("log.warning.inline.edit.bindingexpression.strings");
+                }
             }
         }
     }

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/hierarchy/HierarchyItem.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/hierarchy/HierarchyItem.java
@@ -207,6 +207,14 @@ public class HierarchyItem {
         }
         return option == INFO && mask.isResourceKey();
     }
+    
+    public boolean isBindingExpression(final DisplayOption option) {
+        // Place holder items do not have display info
+        if (mask == null) {
+            return false;
+        }
+        return option == INFO && mask.isBindingExpression();
+    }
 
     public boolean isPlaceHolder() {
         return false;

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/hierarchy/treeview/HierarchyTreeCell.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/hierarchy/treeview/HierarchyTreeCell.java
@@ -506,6 +506,7 @@ public class HierarchyTreeCell<T extends HierarchyItem> extends TreeCell<Hierarc
                     final DisplayOption option = panelController.getDisplayOption();
                     if (item.hasDisplayInfo(option)
                             && item.isResourceKey(option) == false // Do not allow inline editing of the I18N value
+                            && item.isBindingExpression(option) == false // Do not allow inline editing of the binding expression value
                             && displayInfoLabel.isHover()) {
                         startEditingDisplayInfo();
                         // Consume the event so the native expand/collapse behavior is not performed
@@ -759,8 +760,8 @@ public class HierarchyTreeCell<T extends HierarchyItem> extends TreeCell<Hierarc
 
         final DisplayOption option = panelController.getDisplayOption();
         final String displayInfo = item.getDisplayInfo(option);
-        // Do not allow inline editing of the I18N value
-        if (item.isResourceKey(option)) {
+        // Do not allow inline editing of the I18N value or binding expression
+        if (item.isResourceKey(option) || item.isBindingExpression(option)) {
             displayInfoLabel.getStyleClass().removeAll(HIERARCHY_READWRITE_LABEL);
         } else {
             if (displayInfoLabel.getStyleClass().contains(HIERARCHY_READWRITE_LABEL) == false) {

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/inspector/editors/PropertyEditor.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/inspector/editors/PropertyEditor.java
@@ -364,7 +364,7 @@ public abstract class PropertyEditor extends Editor {
     }
 
     protected boolean isSetValueDone() {
-        boolean done = !isHandlingError() && (isBinding() || isEditing());
+    	boolean done = !isHandlingError() && isEditing();
         return done;
     }
 

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/fxom/BindingExpressionDisabler.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/fxom/BindingExpressionDisabler.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2020, Gluon and/or its affiliates.
+ * All rights reserved. Use is subject to license terms.
+ *
+ * This file is available and licensed under the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the distribution.
+ *  - Neither the name of Oracle Corporation nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.oracle.javafx.scenebuilder.kit.fxom;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import com.oracle.javafx.scenebuilder.kit.metadata.util.PropertyName;
+
+import javafx.fxml.FXMLLoader;
+
+/**
+ *
+ */
+public class BindingExpressionDisabler {
+
+    public static void disable(FXOMDocument fxomDocument) {
+        assert fxomDocument != null;
+        
+        final List<FXOMObject> candidates = new ArrayList<>();
+        if (fxomDocument.getFxomRoot() != null) {
+            candidates.add(fxomDocument.getFxomRoot());
+        }
+        
+        while (candidates.isEmpty() == false) {
+            final FXOMObject candidate = candidates.get(0);
+            candidates.remove(0);
+            
+            if (candidate instanceof FXOMInstance) {
+            	final FXOMInstance inst = (FXOMInstance)candidate;
+            	final Object sceneGraphObject = inst.getSceneGraphObject();
+
+                for (Map.Entry<PropertyName, FXOMProperty> e:inst.getProperties().entrySet()) {
+                	FXOMProperty property = e.getValue();
+                	PropertyName propertyName = e.getKey();
+                	
+                	if (property instanceof FXOMPropertyT) {
+                		FXOMPropertyT propertyT = (FXOMPropertyT)property;
+                		if (propertyT.getValue().startsWith(FXMLLoader.BINDING_EXPRESSION_PREFIX)) {
+                			propertyName.setValue(sceneGraphObject, propertyT.getValue());
+                		}
+                	}
+                }
+            }
+                        
+            candidates.addAll(candidate.getChildObjects());
+        }
+    }
+}

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/fxom/BindingExpressionDisabler.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/fxom/BindingExpressionDisabler.java
@@ -68,7 +68,13 @@ public class BindingExpressionDisabler {
                 	if (property instanceof FXOMPropertyT) {
                 		FXOMPropertyT propertyT = (FXOMPropertyT)property;
                 		if (propertyT.getValue().startsWith(FXMLLoader.BINDING_EXPRESSION_PREFIX)) {
-                			propertyName.setValue(sceneGraphObject, propertyT.getValue());
+                			try {
+								propertyName.setValue(sceneGraphObject, propertyT.getValue());
+							} catch (Exception ex) {
+								// Let the exception be, the binding expression can't be escaped 
+								// due to the property type not accepting string value
+								// catching the exception allow the process to go on
+							}
                 		}
                 	}
                 }

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/fxom/FXOMRefresher.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/fxom/FXOMRefresher.java
@@ -74,6 +74,9 @@ class FXOMRefresher {
                 refreshDocument(document, newDocument);
             }
             backup.restore();
+            
+            BindingExpressionDisabler.disable(document);
+            
             synchronizeDividerPositions(document);
         } catch (RuntimeException | IOException x) {
             final StringBuilder sb = new StringBuilder();

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/metadata/property/value/SingleValuePropertyMetadata.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/metadata/property/value/SingleValuePropertyMetadata.java
@@ -77,11 +77,7 @@ public abstract class SingleValuePropertyMetadata<T> extends ValuePropertyMetada
             } else if (fxomProperty instanceof FXOMPropertyT) {
                 final FXOMPropertyT fxomPropertyT = (FXOMPropertyT) fxomProperty;
                 final PrefixedValue pv = new PrefixedValue(fxomPropertyT.getValue());
-                if (pv.isBindingExpression()) {
-                    result = getDefaultValue();
-                } else {
-                    result = makeValueFromProperty(fxomPropertyT);
-                }
+                result = makeValueFromProperty(fxomPropertyT);
             } else if (fxomProperty instanceof FXOMPropertyC) {
                 final FXOMPropertyC fxomPropertyC = (FXOMPropertyC) fxomProperty;
                 assert fxomPropertyC.getValues().isEmpty() == false;

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/metadata/util/DesignHierarchyMask.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/metadata/util/DesignHierarchyMask.java
@@ -304,7 +304,8 @@ public class DesignHierarchyMask {
     /**
      * Returns the string value for this FXOM object description property.
      * If the value is internationalized, the returned value is the resolved one.
-     *
+     * If the value is a binding expression, the returned value is the expression 
+     * instead of the empty resolved one  
      * @return
      */
     public String getDescription() {
@@ -315,7 +316,9 @@ public class DesignHierarchyMask {
             final FXOMInstance fxomInstance = (FXOMInstance) fxomObject;
             final ValuePropertyMetadata vpm
                     = Metadata.getMetadata().queryValueProperty(fxomInstance, propertyName);
-            final Object description = vpm.getValueInSceneGraphObject(fxomInstance); // resolved value
+            final Object description = isBindingExpression() ? 
+            		vpm.getValueObject(fxomInstance): //original binding expression
+            		vpm.getValueInSceneGraphObject(fxomInstance); // resolved value
             return description == null ? null : description.toString();
         }
         return null;
@@ -407,6 +410,22 @@ public class DesignHierarchyMask {
             final Object description = vpm.getValueObject(fxomInstance); // unresolved value
             final PrefixedValue pv = new PrefixedValue(description.toString());
             return pv.isResourceKey();
+        }
+        return false;
+    }
+    
+    public boolean isBindingExpression() {
+        if (hasDescription()) { // (1)
+            // Retrieve the unresolved description
+            final PropertyName propertyName = getPropertyNameForDescription();
+            assert propertyName != null; // Because of (1)
+            assert fxomObject instanceof FXOMInstance; // Because of (1)
+            final FXOMInstance fxomInstance = (FXOMInstance) fxomObject;
+            final ValuePropertyMetadata vpm
+                    = Metadata.getMetadata().queryValueProperty(fxomInstance, propertyName);
+            final Object description = vpm.getValueObject(fxomInstance); // unresolved value
+            final PrefixedValue pv = new PrefixedValue(description.toString());
+            return pv.isBindingExpression();
         }
         return false;
     }

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/metadata/util/PrefixedValue.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/metadata/util/PrefixedValue.java
@@ -177,7 +177,7 @@ public class PrefixedValue {
             case BINDING_EXPRESSION: {
                 assert value.startsWith(FXMLLoader.BINDING_EXPRESSION_PREFIX);
                 assert value.endsWith(FXMLLoader.BINDING_EXPRESSION_SUFFIX);
-                result = value.substring(FXMLLoader.BINDING_EXPRESSION_PREFIX.length() - FXMLLoader.BINDING_EXPRESSION_SUFFIX.length());
+                result = value.substring(FXMLLoader.BINDING_EXPRESSION_PREFIX.length(), value.length() - FXMLLoader.BINDING_EXPRESSION_SUFFIX.length());
                 break;
             }
             case PLAIN_STRING: {

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/preview/PreviewWindowController.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/preview/PreviewWindowController.java
@@ -37,6 +37,7 @@ import com.oracle.javafx.scenebuilder.kit.editor.EditorController.Size;
 import com.oracle.javafx.scenebuilder.kit.editor.EditorPlatform;
 import com.oracle.javafx.scenebuilder.kit.editor.EditorPlatform.Theme;
 import com.oracle.javafx.scenebuilder.kit.editor.panel.util.AbstractWindowController;
+import com.oracle.javafx.scenebuilder.kit.fxom.BindingExpressionDisabler;
 import com.oracle.javafx.scenebuilder.kit.fxom.FXOMDocument;
 import com.oracle.javafx.scenebuilder.kit.i18n.I18N;
 import com.oracle.javafx.scenebuilder.kit.util.MathUtils;
@@ -282,6 +283,7 @@ public final class PreviewWindowController extends AbstractWindowController {
                                 fxomDocument.getClassLoader(),
                                 fxomDocument.getResources());
                         clone.setSampleDataEnabled(fxomDocument.isSampleDataEnabled());
+                        BindingExpressionDisabler.disable(clone);
                     } catch (IOException ex) {
                         throw new RuntimeException("Bug in PreviewWindowController::requestUpdate", ex); //NOI18N
                     }

--- a/kit/src/main/resources/com/oracle/javafx/scenebuilder/kit/i18n/SceneBuilderKit.properties
+++ b/kit/src/main/resources/com/oracle/javafx/scenebuilder/kit/i18n/SceneBuilderKit.properties
@@ -72,6 +72,7 @@ log.info.explore.end = End exploring {0}
 log.info.explore.folder = Start exploring FOLDER {0}
 log.info.explore.jar = Start exploring JAR {0}
 log.warning.inline.edit.internationalized.strings = Can''t inline edit internationalized strings
+log.warning.inline.edit.bindingexpression.strings = Can''t inline edit binding expression strings
 log.warning.color.creation.error.hexadecimal = Can''t create color for hexadecimal value ''{0}''
 log.warning.image.location.does.not.exist = Image ''{0}'' does not exist
 log.warning.invalid.fxid = Id ''{0}'' is not a valid java identifier
@@ -127,6 +128,9 @@ content.log.cannot.display.selected.n = {0} of {1} selected objects cannot be di
 # -----------------------------------------------------------------------------
 # Inspector Panel
 # -----------------------------------------------------------------------------
+inspector.bindingexpression.dummyvalue = controller.dummyprop
+inspector.bindingexpression.off = Delete Binding expression String
+inspector.bindingexpression.on = Replace with Binding expression String
 inspector.cursor.chooseimage = Choose Image...
 inspector.cursor.inherited = Inherited (Default)
 inspector.cursor.inheritedparent = Inherited from Parent (Default)

--- a/kit/src/main/resources/com/oracle/javafx/scenebuilder/kit/i18n/SceneBuilderKit_ja.properties
+++ b/kit/src/main/resources/com/oracle/javafx/scenebuilder/kit/i18n/SceneBuilderKit_ja.properties
@@ -70,6 +70,7 @@ label.qualifier.vertical = (垂直)
 # -----------------------------------------------------------------------------
 log.info.explore.jar = JAR {0}の探索を開始
 log.warning.inline.edit.internationalized.strings = 国際化された文字列をインライン編集できません
+log.warning.inline.edit.bindingexpression.strings = Can''t inline edit binding expression strings
 log.warning.color.creation.error.hexadecimal = 16進値''{0}''の色を作成できません
 log.warning.image.location.does.not.exist = 画像''{0}''は存在しません
 log.warning.invalid.fxid = ID ''{0}''は有効なJava識別子ではありません
@@ -112,6 +113,8 @@ content.log.cannot.display.selected.n = 選択されたオブジェクト{1}個�
 # -----------------------------------------------------------------------------
 # Inspector Panel
 # -----------------------------------------------------------------------------
+inspector.bindingexpression.off = Delete Binding expression String
+inspector.bindingexpression.on = Replace with Binding expression String
 inspector.cursor.chooseimage = 画像の選択...
 inspector.cursor.inherited = 継承 (デフォルト)
 inspector.cursor.inheritedparent = 親を継承 (デフォルト)


### PR DESCRIPTION
This pull request allow edition of binding expression for string values only.

![image](https://user-images.githubusercontent.com/4742433/87880505-7a56d100-c9f2-11ea-8c5b-0729f9ad01fd.png)![image](https://user-images.githubusercontent.com/4742433/87880667-cd7d5380-c9f3-11ea-9eb9-17feaf2db817.png)

If the field containing the binding expression is shown in the hierarchy view. It won't be resolved and can't be edited
The warning is kept to inform the user about the presence of a binding expression
![image](https://user-images.githubusercontent.com/4742433/87880696-087f8700-c9f4-11ea-9e47-c5f1ef95c6fc.png)

If the field containing the binding expression is shown in the scene view. It won't be resolved and can't be edited
![image](https://user-images.githubusercontent.com/4742433/87880700-0fa69500-c9f4-11ea-8f83-3029c802c376.png)

If the field containing the binding expression is shown in the previex view. It won't be resolved and can't be edited
![image](https://user-images.githubusercontent.com/4742433/87880716-2fd65400-c9f4-11ea-9949-ded15696c00e.png)

#89 seems partialy solved, at least for string fields
#97 binding expression in fields other than string still generate an exception and prevent moving components

Please, feel free to comment or require modifications on this pull request
