### PR TITLE
Add display to build workflow before running tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Install packages
+        run: |
+          sudo apt-get install xvfb tigervnc-standalone-server tigervnc-common
+
       - name: Checkout
         uses: actions/checkout@v2
 
@@ -23,4 +27,11 @@ jobs:
         run: chmod +x gradlew
 
       - name: Build project
-        run: ./gradlew -i build
+        run: |
+          export DISPLAY=:90
+          mkdir /home/runner/.vnc
+          echo 123456 | vncpasswd -f > /home/runner/.vnc/passwd
+          chmod -v 600 /home/runner/.vnc/passwd
+          vncserver :90 -localhost -nolisten tcp
+          ./gradlew -i build
+          vncserver -kill :90


### PR DESCRIPTION
Currently the build workflow stucks indefinitely as tests needs a DISPLAY on Linux systems to run, This change adds vncserver to enable display on linux environments.