### PR TITLE
#243 per-user-install and directory selection activated for Windows-MSI installer

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -164,9 +164,11 @@ task jpackage(type: Exec) {
                 '--type', 'msi',
                 '--java-options', '--add-opens javafx.fxml/javafx.fxml=ALL-UNNAMED',
                 '--icon', '../assets/windows/icon-windows.ico',
+                '--win-dir-chooser',
                 '--win-menu',
-                '--win-shortcut',
-                '--win-menu-group', 'SceneBuilder'
+                '--win-menu-group', 'Scene Builder',
+                '--win-per-user-install',
+                '--win-shortcut'
             ]
         }
         argsList.addAll(options)


### PR DESCRIPTION
<!--- Provide a brief summary of the PR -->

### Issue

The standard MSI installer requests administrative privileges. The per-user-install doesn't.
Furthermore the new configuration allows the user to specify an installation directory.

<!--- The issue this PR addresses -->
Fixes #243

### Progress

- [x] Change must not contain extraneous whitespace
- [x] License header year is updated, if required
- [x] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)  