### PR TITLE
feat: Add support for controller skeletons in Kotlin

### DIFF
--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/AbstractSkeletonCreator.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/AbstractSkeletonCreator.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2021, Gluon and/or its affiliates.
+ * All rights reserved. Use is subject to license terms.
+ *
+ * This file is available and licensed under the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the distribution.
+ *  - Neither the name of Oracle Corporation nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.javafx.scenebuilder.kit.skeleton;
+
+import com.oracle.javafx.scenebuilder.kit.i18n.I18N;
+
+import java.lang.reflect.TypeVariable;
+import java.net.URL;
+import java.util.Map;
+import java.util.ResourceBundle;
+
+abstract class AbstractSkeletonCreator {
+
+    static final String NL = System.lineSeparator();
+    static final String INDENT = "    "; //NOI18N
+    static final String FXML_ANNOTATION = "@FXML";
+
+    String createFrom(SkeletonContext context) {
+        final StringBuilder sb = new StringBuilder();
+
+        appendHeaderComment(context, sb);
+        appendPackage(context, sb);
+        appendImports(context, sb);
+        appendClass(context, sb);
+
+        return sb.toString();
+    }
+
+    void appendHeaderComment(SkeletonContext context, StringBuilder sb) {
+        if (!context.getSettings().isWithComments()) {
+            return;
+        }
+
+        final String title = I18N.getString("skeleton.window.title", context.getDocumentName());
+        sb.append("/**").append(NL); //NOI18N
+        sb.append(" * ").append(title).append(NL); //NOI18N
+        sb.append(" */").append(NL); //NOI18N
+        sb.append(NL);
+    }
+
+    abstract void appendPackage(SkeletonContext context, StringBuilder sb);
+
+    abstract void appendImports(SkeletonContext context, StringBuilder sb);
+
+    void appendClass(SkeletonContext context, StringBuilder sb) {
+        sb.append(NL);
+
+        appendClassPart(context, sb);
+
+        sb.append(" {").append(NL).append(NL); //NOI18N
+
+        appendFields(context, sb);
+
+        appendMethods(context, sb);
+
+        sb.append("}").append(NL); //NOI18N
+    }
+
+    abstract void appendClassPart(SkeletonContext context, StringBuilder sb);
+
+    void appendFields(SkeletonContext context, StringBuilder sb) {
+        appendFieldsResourcesAndLocation(context, sb);
+
+        appendFieldsWithFxId(context, sb);
+    }
+
+    void appendFieldsResourcesAndLocation(SkeletonContext context, StringBuilder sb) {
+        if (!context.getSettings().isFull()) {
+            return;
+        }
+
+        sb.append(INDENT).append(FXML_ANNOTATION);
+        if (context.getSettings().isWithComments()) {
+            sb.append(" // ResourceBundle that was given to the FXMLLoader"); //NOI18N
+        }
+        sb.append(NL);
+        sb.append(INDENT);
+        appendField(ResourceBundle.class, "resources", sb); //NOI18N
+        sb.append(NL).append(NL);
+
+        sb.append(INDENT).append(FXML_ANNOTATION);
+        if (context.getSettings().isWithComments()) {
+            sb.append(" // URL location of the FXML file that was given to the FXMLLoader"); //NOI18N
+        }
+        sb.append(NL);
+        sb.append(INDENT);
+        appendField(URL.class, "location", sb); //NOI18N
+        sb.append(NL).append(NL);
+    }
+
+    void appendFieldsWithFxId(SkeletonContext context, StringBuilder sb) {
+        for (Map.Entry<String, Class<?>> variable : context.getVariables().entrySet()) {
+            sb.append(INDENT).append(FXML_ANNOTATION);
+            if (context.getSettings().isWithComments()) {
+                sb.append(" // fx:id=\"").append(variable.getKey()).append("\""); //NOI18N
+            }
+            sb.append(NL);
+
+            sb.append(INDENT);
+            appendField(variable.getValue(), variable.getKey(), sb);
+
+            if (context.getSettings().isWithComments()) {
+                sb.append(" // Value injected by FXMLLoader"); //NOI18N
+            }
+            sb.append(NL).append(NL);
+        }
+    }
+
+    abstract void appendField(Class<?> fieldClass, String fieldName, StringBuilder sb);
+
+    void appendFieldParameters(StringBuilder sb, Class<?> fieldClazz) {
+        final TypeVariable<? extends Class<?>>[] parameters = fieldClazz.getTypeParameters();
+        if (parameters.length > 0) {
+            sb.append("<"); //NOI18N
+            String sep = ""; //NOI18N
+            for (TypeVariable<?> ignored : parameters) {
+                sb.append(sep);
+                appendFieldParameterType(sb);
+                sep = ", "; //NOI18N
+            }
+            sb.append(">"); //NOI18N
+        }
+    }
+
+    abstract void appendFieldParameterType(StringBuilder sb);
+
+    void appendMethods(SkeletonContext context, StringBuilder sb) {
+        appendEventHandlers(context, sb);
+
+        appendInitialize(context, sb);
+    }
+
+    void appendEventHandlers(SkeletonContext context, StringBuilder sb) {
+        for (Map.Entry<String, String> entry : context.getEventHandlers().entrySet()) {
+            String methodName = entry.getKey();
+            String eventClassName = entry.getValue();
+
+            final String methodNamePured = methodName.replace("#", ""); //NOI18N
+
+            sb.append(INDENT).append(FXML_ANNOTATION).append(NL).append(INDENT);
+            appendEventHandler(methodNamePured, eventClassName, sb);
+            sb.append(NL).append(NL);
+        }
+    }
+
+    abstract void appendEventHandler(String methodName, String eventClassName, StringBuilder sb);
+
+    void appendInitialize(SkeletonContext context, StringBuilder sb) {
+        if (!context.getSettings().isFull()) {
+            return;
+        }
+
+        sb.append(INDENT).append(FXML_ANNOTATION);
+        if (context.getSettings().isWithComments()) {
+            sb.append(" // This method is called by the FXMLLoader when initialization is complete"); //NOI18N
+        }
+        sb.append(NL);
+
+        sb.append(INDENT);
+        appendInitializeMethodPart(sb);
+        sb.append(" {").append(NL); //NOI18N
+        appendAssertions(context, sb);
+        sb.append(NL);
+        sb.append(INDENT);
+        sb.append("}").append(NL).append(NL); //NOI18N
+    }
+
+    abstract void appendInitializeMethodPart(StringBuilder sb);
+
+    abstract void appendAssertions(SkeletonContext context, StringBuilder sb);
+}

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonBuffer.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonBuffer.java
@@ -37,8 +37,6 @@ import com.oracle.javafx.scenebuilder.kit.fxom.FXOMObject;
 import com.oracle.javafx.scenebuilder.kit.fxom.FXOMPropertyT;
 import com.oracle.javafx.scenebuilder.kit.i18n.I18N;
 import com.oracle.javafx.scenebuilder.kit.util.eventnames.FindEventNamesUtil;
-import javafx.fxml.FXML;
-import javafx.util.Pair;
 
 import java.net.URL;
 import java.util.ResourceBundle;
@@ -99,13 +97,7 @@ class SkeletonBuffer {
 
     private void constructFxIds(SkeletonContext.Builder builder) {
         for (FXOMObject value : document.collectFxIds().values()) {
-            String fxId = value.getFxId();
-            Class<?> type = value.getSceneGraphObject().getClass();
-
-            builder.addImportsFor(FXML.class, type);
-
-            builder.addVariable(new Pair<>(fxId, type));
-            builder.addAssertionForFxId(fxId);
+            builder.addFxId(value);
         }
     }
 
@@ -113,11 +105,8 @@ class SkeletonBuffer {
         // need to initialize the internal events map
         FindEventNamesUtil.initializeEventsMap();
 
-        for (FXOMPropertyT handler : document.getFxomRoot().collectEventHandlers()) {
-            String eventName = FindEventNamesUtil.findEventName(handler.getName().getName());
-
-            builder.addEventHandler(handler.getValue(), eventName);
-            builder.addImportsForEvents(eventName);
+        for (FXOMPropertyT eventHandler : document.getFxomRoot().collectEventHandlers()) {
+            builder.addEventHandler(eventHandler);
         }
     }
 

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonBuffer.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonBuffer.java
@@ -41,15 +41,14 @@ import com.oracle.javafx.scenebuilder.kit.util.eventnames.FindEventNamesUtil;
 import java.net.URL;
 import java.util.ResourceBundle;
 
-/**
- *
- */
 class SkeletonBuffer {
 
     private final FXOMDocument document;
     private final String documentName;
 
     private final SkeletonSettings settings = new SkeletonSettings();
+
+    private final SkeletonCreator skeletonCreator = new SkeletonCreator();
 
     SkeletonBuffer(FXOMDocument document, String documentName) {
         assert document != null;
@@ -85,7 +84,7 @@ class SkeletonBuffer {
 
             construct(builder);
 
-            return SkeletonCreator.createFrom(builder.build());
+            return skeletonCreator.createFrom(builder.build());
         }
     }
 

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonBuffer.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Gluon and/or its affiliates.
+ * Copyright (c) 2016, 2021, Gluon and/or its affiliates.
  * Copyright (c) 2012, 2014, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonBuffer.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonBuffer.java
@@ -32,245 +32,47 @@
  */
 package com.oracle.javafx.scenebuilder.kit.skeleton;
 
-import com.oracle.javafx.scenebuilder.kit.i18n.I18N;
-import com.oracle.javafx.scenebuilder.kit.util.eventnames.EventNames;
-import com.oracle.javafx.scenebuilder.kit.util.eventnames.ImportBuilder;
-import com.oracle.javafx.scenebuilder.kit.util.eventnames.FindEventNamesUtil;
 import com.oracle.javafx.scenebuilder.kit.fxom.FXOMDocument;
 import com.oracle.javafx.scenebuilder.kit.fxom.FXOMObject;
 import com.oracle.javafx.scenebuilder.kit.fxom.FXOMPropertyT;
+import com.oracle.javafx.scenebuilder.kit.i18n.I18N;
+import com.oracle.javafx.scenebuilder.kit.util.eventnames.FindEventNamesUtil;
 import javafx.fxml.FXML;
+import javafx.util.Pair;
 
-import java.lang.reflect.TypeVariable;
 import java.net.URL;
-import java.util.*;
+import java.util.ResourceBundle;
 
 /**
  *
  */
-public class SkeletonBuffer {
+class SkeletonBuffer {
 
     private final FXOMDocument document;
-    private final String INDENT = "    "; //NOI18N
-    private final Set<String> imports = new TreeSet<>();
-    private final StringBuilder variables = new StringBuilder();
-    private final StringBuilder asserts = new StringBuilder();
-    private TEXT_TYPE textType = TEXT_TYPE.WITHOUT_COMMENTS;
-    private FORMAT_TYPE textFormat = FORMAT_TYPE.COMPACT;
-    private final StringBuilder packageLine = new StringBuilder();
-    private final StringBuilder classLine = new StringBuilder();
-    private final StringBuilder header = new StringBuilder();
-    private final StringBuilder initialize = new StringBuilder();
-    private final StringBuilder handlers = new StringBuilder();
-    private static final String FXML_ANNOTATION = "@FXML\n";
-
     private final String documentName;
 
-    public enum TEXT_TYPE {
-        WITH_COMMENTS, WITHOUT_COMMENTS
-    }
+    private final SkeletonSettings settings = new SkeletonSettings();
 
-    public enum FORMAT_TYPE {
-        COMPACT, FULL
-    }
-
-    public SkeletonBuffer(FXOMDocument document, String documentName) {
+    SkeletonBuffer(FXOMDocument document, String documentName) {
         assert document != null;
         this.document = document;
         this.documentName = documentName;
     }
 
-    public void setTextType(TEXT_TYPE type) {
-        this.textType = type;
+    void setLanguage(SkeletonSettings.LANGUAGE language) {
+        settings.setLanguage(language);
     }
 
-    public void setFormat(FORMAT_TYPE format) {
-        this.textFormat = format;
+    void setTextType(SkeletonSettings.TEXT_TYPE type) {
+        settings.setTextType(type);
     }
 
-    private void constructHeader() {
-        if (textType == TEXT_TYPE.WITH_COMMENTS) {
-            final String title = I18N.getString("skeleton.window.title", documentName);
-            header.append("/**\n"); //NOI18N
-            header.append(" * "); //NOI18N
-            header.append(title);
-            header.append("\n */\n\n"); //NOI18N
-        }
+    void setFormat(SkeletonSettings.FORMAT_TYPE format) {
+        settings.setFormat(format);
     }
 
-    private void constructPackageLine() {
-            String controller = document.getFxomRoot().getFxController();
-
-            if (controller != null && !controller.isEmpty()
-                    && controller.contains(".") && !controller.contains("$")) { //NOI18N
-                packageLine.append("package "); //NOI18N
-                packageLine.append(controller.substring(0, controller.lastIndexOf('.'))); //NOI18N
-                packageLine.append(";\n\n"); //NOI18N
-            }
-        }
-
-    private void constructClassLine() {
-            String controller = document.getFxomRoot().getFxController();
-            classLine.append("\npublic "); //NOI18N
-
-            if (controller != null && controller.contains("$")) { //NOI18N
-                classLine.append("static "); //NOI18N
-            }
-
-            classLine.append("class "); //NOI18N
-
-            if (controller != null && !controller.isEmpty()) {
-                String simpleName = controller.replace("$", "."); //NOI18N
-                int dot = simpleName.lastIndexOf('.');
-                if (dot > -1) {
-                    simpleName = simpleName.substring(dot+1);
-                }
-                classLine.append(simpleName);
-            } else {
-                classLine.append("PleaseProvideControllerClassName"); //NOI18N
-            }
-
-            classLine.append(" {\n\n"); //NOI18N
-        }
-
-    private void constructInitialize() {
-        if (textFormat == FORMAT_TYPE.FULL) {
-            initialize.append(INDENT);
-            initialize.append("@FXML"); //NOI18N
-
-            if (textType == TEXT_TYPE.WITH_COMMENTS) {
-                initialize.append(" // This method is called by the FXMLLoader when initialization is complete\n"); //NOI18N
-            } else {
-                initialize.append("\n"); //NOI18N
-            }
-
-            initialize.append(INDENT);
-            initialize.append("void initialize() {\n"); //NOI18N
-            initialize.append(asserts);
-            initialize.append("\n"); //NOI18N
-            initialize.append(INDENT);
-            initialize.append("}\n"); //NOI18N
-        }
-    }
-
-    private void construct() {
-        constructHeader();
-        constructPackageLine();
-        constructClassLine();
-
-        // All that depends on fx:id
-        Map<String, FXOMObject> fxids = document.collectFxIds();
-
-        for (FXOMObject value : fxids.values()) {
-            String key = value.getFxId();
-            final Object obj = value.getSceneGraphObject();
-            final Class<?> type = obj.getClass();
-
-            addImportsFor(FXML.class, type);
-            variables.append(INDENT).append("@FXML"); //NOI18N
-
-            if (textType == TEXT_TYPE.WITH_COMMENTS) {
-                variables.append(" // fx:id=\"").append(key).append("\""); //NOI18N
-            }
-
-            variables.append("\n"); //NOI18N
-            variables.append(INDENT).append("private ").append(type.getSimpleName()); //NOI18N
-            final TypeVariable<? extends Class<?>>[] parameters = type.getTypeParameters();
-
-            if (parameters.length > 0) {
-                variables.append("<"); //NOI18N
-                String sep = ""; //NOI18N
-                for (TypeVariable<?> t : parameters) {
-                    variables.append(sep).append("?"); //NOI18N
-                    sep = ", "; //NOI18N
-                    t.getName(); // silly call to silence FindBugs
-                }
-                variables.append(">"); //NOI18N
-            }
-
-            if (textType == TEXT_TYPE.WITH_COMMENTS) {
-                variables.append(" ").append(key).append("; // Value injected by FXMLLoader\n\n"); //NOI18N
-            } else {
-                variables.append(" ").append(key).append(";\n\n"); //NOI18N
-            }
-
-            asserts.append(INDENT).append(INDENT).append("assert ").append(key).append(" != null : ") //NOI18N
-                    .append("\"fx:id=\\\"").append(key).append("\\\" was not injected: check your FXML file ") //NOI18N
-                    .append("'").append(documentName) //NOI18N
-                    .append("'.\";\n"); //NOI18N
-        }
-
-        if (textFormat == FORMAT_TYPE.FULL) {
-            addImportsFor(URL.class, ResourceBundle.class);
-        }
-
-        // Event handlers
-        // Map with pairs of methodNames and eventTypeNames
-        final Map<String, String> methodsAndEvents = new TreeMap<>();
-        // need to initialize the internal events map
-        FindEventNamesUtil.initializeEventsMap();
-        for (FXOMPropertyT handler : document.getFxomRoot().collectEventHandlers()) {
-            String eventTypeName = handler.getName().getName();
-            methodsAndEvents.put(handler.getValue(), eventTypeName);
-        }
-        // for each method name
-        methodsAndEvents.forEach(this::generateControllerSkeleton);
-        // This method must be called once asserts has been populated.
-        constructInitialize();
-    }
-
-    /**
-     * Generates the skeleton for the controller event handler methods.
-     * For every eventTypeName, it searches for the appropriate event name.
-     *
-     * @param methodName method name chosen by the user
-     * @param eventTypeName eventTypeName, e.g. onMouseClicked
-     */
-    private void generateControllerSkeleton(String methodName, String eventTypeName) {
-        handlers.append(INDENT).append(FXML_ANNOTATION).append(INDENT).append("void "); //NOI18N
-        final String methodNamePured = methodName.replace("#", ""); //NOI18N
-        handlers.append(methodNamePured);
-        String eventName = FindEventNamesUtil.findEventName(eventTypeName);
-        handlers.append("(").append(eventName).append(" event) {\n\n").append(INDENT).append("}\n\n"); //NOI18N
-        if (textFormat == FORMAT_TYPE.FULL) {
-            addImportsForEvents(eventName);
-        }
-    }
-
-    /**
-     * Constructs import statements for event classes.
-     *
-     * @param eventName event name, for which a statement should be built.
-     */
-    private void addImportsForEvents(String eventName) {
-        if(EventNames.ACTION_EVENT.equals(eventName)) {
-            ImportBuilder.add(ImportBuilder.IMPORT_STATEMENT.concat(ImportBuilder.EVENT_PACKAGE), eventName);
-        }
-        else {
-            ImportBuilder.add(ImportBuilder.IMPORT_STATEMENT.concat(ImportBuilder.INPUT_PACKAGE), eventName);
-        }
-        buildAndCollectImports();
-    }
-
-
-    /**
-     * Constructs import statements for other classes (like URL, ResourceBundle).
-     *
-     * @param classes other classes the statement should be built.
-     */
-    private void addImportsFor(Class<?>... classes) {
-        for (Class<?> c : classes) {
-            ImportBuilder.add(ImportBuilder.IMPORT_STATEMENT, c.getName().replace("$", "."));
-            buildAndCollectImports();
-    }
-        // need an import statement for @FXML, too
-        ImportBuilder.add(ImportBuilder.IMPORT_STATEMENT, ImportBuilder.FXML_PACKAGE);
-        buildAndCollectImports();
-    }
-
-    private void buildAndCollectImports() {
-        imports.add(ImportBuilder.build());
-        ImportBuilder.reset();
+    private boolean isFull() {
+        return settings.isFull();
     }
 
     @Override
@@ -278,36 +80,50 @@ public class SkeletonBuffer {
         if (document.getFxomRoot() == null) {
             return I18N.getString("skeleton.empty");
         } else {
-            construct();
+            SkeletonContext.Builder builder = SkeletonContext.builder()
+                .withFxController(document.getFxomRoot().getFxController())
+                .withDocumentName(documentName)
+                .withSettings(settings);
 
-            StringBuilder code = new StringBuilder();
-            code.append(header);
-            code.append(packageLine);
+            construct(builder);
 
-            for (String importStatement : imports) {
-                code.append(importStatement);
-            }
+            return SkeletonCreator.createFrom(builder.build());
+        }
+    }
 
-            code.append(classLine);
+    private void construct(SkeletonContext.Builder builder) {
+        constructFxIds(builder);
+        constructEventHandlers(builder);
+        constructAdditionalImports(builder);
+    }
 
-            if (textType == TEXT_TYPE.WITH_COMMENTS && textFormat == FORMAT_TYPE.FULL) {
-                code.append(INDENT).append("@FXML // ResourceBundle that was given to the FXMLLoader\n") //NOI18N
-                        .append(INDENT).append("private ResourceBundle resources;\n\n") //NOI18N
-                        .append(INDENT).append("@FXML // URL location of the FXML file that was given to the FXMLLoader\n") //NOI18N
-                        .append(INDENT).append("private URL location;\n\n"); //NOI18N
-            } else if (textFormat == FORMAT_TYPE.FULL) {
-                code.append(INDENT).append(FXML_ANNOTATION) //NOI18N
-                        .append(INDENT).append("private ResourceBundle resources;\n\n") //NOI18N
-                        .append(INDENT).append(FXML_ANNOTATION) //NOI18N
-                        .append(INDENT).append("private URL location;\n\n"); //NOI18N
-            }
+    private void constructFxIds(SkeletonContext.Builder builder) {
+        for (FXOMObject value : document.collectFxIds().values()) {
+            String fxId = value.getFxId();
+            Class<?> type = value.getSceneGraphObject().getClass();
 
-            code.append(variables);
-            code.append(handlers);
-            code.append(initialize);
-            code.append("}\n"); //NOI18N
+            builder.addImportsFor(FXML.class, type);
 
-            return code.toString();
+            builder.addVariable(new Pair<>(fxId, type));
+            builder.addAssertionForFxId(fxId);
+        }
+    }
+
+    private void constructEventHandlers(SkeletonContext.Builder builder) {
+        // need to initialize the internal events map
+        FindEventNamesUtil.initializeEventsMap();
+
+        for (FXOMPropertyT handler : document.getFxomRoot().collectEventHandlers()) {
+            String eventName = FindEventNamesUtil.findEventName(handler.getName().getName());
+
+            builder.addEventHandler(handler.getValue(), eventName);
+            builder.addImportsForEvents(eventName);
+        }
+    }
+
+    private void constructAdditionalImports(SkeletonContext.Builder builder) {
+        if (isFull()) {
+            builder.addImportsFor(URL.class, ResourceBundle.class);
         }
     }
 }

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonContext.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonContext.java
@@ -1,3 +1,35 @@
+/*
+ * Copyright (c) 2016, 2021, Gluon and/or its affiliates.
+ * Copyright (c) 2012, 2014, Oracle and/or its affiliates.
+ * All rights reserved. Use is subject to license terms.
+ *
+ * This file is available and licensed under the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the distribution.
+ *  - Neither the name of Oracle Corporation nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.oracle.javafx.scenebuilder.kit.skeleton;
 
 import com.oracle.javafx.scenebuilder.kit.fxom.FXOMObject;

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonContext.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonContext.java
@@ -1,0 +1,152 @@
+package com.oracle.javafx.scenebuilder.kit.skeleton;
+
+import com.oracle.javafx.scenebuilder.kit.util.eventnames.EventNames;
+import com.oracle.javafx.scenebuilder.kit.util.eventnames.ImportBuilder;
+import javafx.util.Pair;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+class SkeletonContext {
+
+    private final String fxController;
+    private final String documentName;
+    private final SkeletonSettings settings;
+    private final Set<String> imports;
+    private final List<Pair<String, Class<?>>> variables;
+    private final Map<String, String> eventHandlers;
+    private final List<String> assertions;
+
+    private SkeletonContext(
+        String fxController,
+        String documentName,
+        SkeletonSettings settings,
+        Set<String> imports,
+        List<Pair<String, Class<?>>> variables,
+        Map<String, String> eventHandlers,
+        List<String> assertions
+    ) {
+        this.fxController = fxController;
+        this.documentName = documentName;
+        this.settings = Objects.requireNonNull(settings);
+        this.imports = Collections.unmodifiableSet(imports);
+        this.variables = Collections.unmodifiableList(variables);
+        this.eventHandlers = Collections.unmodifiableMap(eventHandlers);
+        this.assertions = Collections.unmodifiableList(assertions);
+    }
+
+    static Builder builder() {
+        return new Builder();
+    }
+
+    String getFxController() {
+        return fxController;
+    }
+
+    String getDocumentName() {
+        return documentName;
+    }
+
+    SkeletonSettings getSettings() {
+        return settings;
+    }
+
+    Set<String> getImports() {
+        return imports;
+    }
+
+    List<Pair<String, Class<?>>> getVariables() {
+        return variables;
+    }
+
+    Map<String, String> getEventHandlers() {
+        return eventHandlers;
+    }
+
+    List<String> getAssertions() {
+        return assertions;
+    }
+
+    static class Builder {
+
+        private String fxController;
+        private String documentName;
+        private SkeletonSettings settings;
+
+        private final Set<String> imports = new TreeSet<>();
+        private final List<Pair<String, Class<?>>> variables = new ArrayList<>();
+        private final Map<String, String> eventHandlers = new TreeMap<>();
+        private final List<String> assertions = new ArrayList<>();
+
+        Builder withFxController(String fxController) {
+            this.fxController = fxController;
+            return this;
+        }
+
+        Builder withDocumentName(String documentName) {
+            this.documentName = documentName;
+            return this;
+        }
+
+        Builder withSettings(SkeletonSettings settings) {
+            this.settings = settings;
+            return this;
+        }
+
+        void addVariable(Pair<String, Class<?>> variable) {
+            variables.add(variable);
+        }
+
+        void addEventHandler(String key, String value) {
+            eventHandlers.put(key, value);
+        }
+
+        /**
+         * Constructs import statements for event classes.
+         *
+         * @param eventName event name, for which a statement should be built.
+         */
+        void addImportsForEvents(String eventName) {
+            if (EventNames.ACTION_EVENT.equals(eventName)) {
+                ImportBuilder.add(ImportBuilder.IMPORT_STATEMENT.concat(ImportBuilder.EVENT_PACKAGE), eventName);
+            } else {
+                ImportBuilder.add(ImportBuilder.IMPORT_STATEMENT.concat(ImportBuilder.INPUT_PACKAGE), eventName);
+            }
+            buildAndCollectImports();
+        }
+
+        /**
+         * Constructs import statements for other classes (like URL, ResourceBundle).
+         *
+         * @param classes other classes the statement should be built.
+         */
+        void addImportsFor(Class<?>... classes) {
+            for (Class<?> c : classes) {
+                ImportBuilder.add(ImportBuilder.IMPORT_STATEMENT, c.getName().replace("$", "."));
+                buildAndCollectImports();
+            }
+            // need an import statement for @FXML, too
+            ImportBuilder.add(ImportBuilder.IMPORT_STATEMENT, ImportBuilder.FXML_PACKAGE);
+            buildAndCollectImports();
+        }
+
+        private void buildAndCollectImports() {
+            imports.add(ImportBuilder.build());
+            ImportBuilder.reset();
+        }
+
+        void addAssertionForFxId(String fxId) {
+            assertions.add(fxId);
+        }
+
+        SkeletonContext build() {
+            return new SkeletonContext(fxController, documentName, settings, imports, variables, eventHandlers, assertions);
+        }
+    }
+}

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonContext.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonContext.java
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Gluon and/or its affiliates.
- * Copyright (c) 2012, 2014, Oracle and/or its affiliates.
+ * Copyright (c) 2021, Gluon and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreator.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreator.java
@@ -1,3 +1,35 @@
+/*
+ * Copyright (c) 2016, 2021, Gluon and/or its affiliates.
+ * Copyright (c) 2012, 2014, Oracle and/or its affiliates.
+ * All rights reserved. Use is subject to license terms.
+ *
+ * This file is available and licensed under the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the distribution.
+ *  - Neither the name of Oracle Corporation nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.oracle.javafx.scenebuilder.kit.skeleton;
 
 class SkeletonCreator {

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreator.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreator.java
@@ -34,15 +34,18 @@ package com.oracle.javafx.scenebuilder.kit.skeleton;
 
 class SkeletonCreator {
 
+    private final SkeletonCreatorJava skeletonCreatorJava = new SkeletonCreatorJava();
+    private final SkeletonCreatorKotlin skeletonCreatorKotlin = new SkeletonCreatorKotlin();
+
     /**
      * @return a code skeleton for the given context
      */
-    static String createFrom(SkeletonContext context) {
+    String createFrom(SkeletonContext context) {
         switch (context.getSettings().getLanguage()) {
             case JAVA:
-                return SkeletonCreatorJava.createFrom(context);
+                return skeletonCreatorJava.createFrom(context);
             case KOTLIN:
-                return SkeletonCreatorKotlin.createFrom(context);
+                return skeletonCreatorKotlin.createFrom(context);
             default:
                 throw new IllegalArgumentException("Language not supported: " + context.getSettings().getLanguage());
         }

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreator.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreator.java
@@ -1,0 +1,18 @@
+package com.oracle.javafx.scenebuilder.kit.skeleton;
+
+class SkeletonCreator {
+
+    /**
+     * @return a code skeleton for the given context
+     */
+    static String createFrom(SkeletonContext context) {
+        switch (context.getSettings().getLanguage()) {
+            case JAVA:
+                return SkeletonCreatorJava.createFrom(context);
+            case KOTLIN:
+                return SkeletonCreatorKotlin.createFrom(context);
+            default:
+                throw new IllegalArgumentException("Language not supported: " + context.getSettings().getLanguage());
+        }
+    }
+}

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreator.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreator.java
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016, 2021, Gluon and/or its affiliates.
- * Copyright (c) 2012, 2014, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreator.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Gluon and/or its affiliates.
+ * Copyright (c) 2021, Gluon and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreatorJava.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreatorJava.java
@@ -32,41 +32,10 @@
  */
 package com.oracle.javafx.scenebuilder.kit.skeleton;
 
-import com.oracle.javafx.scenebuilder.kit.i18n.I18N;
+public class SkeletonCreatorJava extends AbstractSkeletonCreator {
 
-import java.lang.reflect.TypeVariable;
-import java.util.Map;
-
-public class SkeletonCreatorJava {
-
-    private static final String NL = System.lineSeparator();
-    private static final String INDENT = "    "; //NOI18N
-    private static final String FXML_ANNOTATION = "@FXML";
-
-    static String createFrom(SkeletonContext context) {
-        final StringBuilder sb = new StringBuilder();
-
-        appendHeaderComment(context, sb);
-        appendPackage(context, sb);
-        appendImports(context, sb);
-        appendClass(context, sb);
-
-        return sb.toString();
-    }
-
-    private static void appendHeaderComment(SkeletonContext context, StringBuilder sb) {
-        if (!context.getSettings().isWithComments()) {
-            return;
-        }
-
-        final String title = I18N.getString("skeleton.window.title", context.getDocumentName());
-        sb.append("/**").append(NL); //NOI18N
-        sb.append(" * ").append(title).append(NL); //NOI18N
-        sb.append(" */").append(NL); //NOI18N
-        sb.append(NL);
-    }
-
-    private static void appendPackage(SkeletonContext context, StringBuilder sb) {
+    @Override
+    void appendPackage(SkeletonContext context, StringBuilder sb) {
         String controller = context.getFxController();
 
         if (controller != null && controller.contains(".") && !controller.contains("$")) { //NOI18N
@@ -76,16 +45,18 @@ public class SkeletonCreatorJava {
         }
     }
 
-    private static void appendImports(SkeletonContext context, StringBuilder sb) {
+    @Override
+    void appendImports(SkeletonContext context, StringBuilder sb) {
         for (String importStatement : context.getImports()) {
             sb.append(importStatement);
         }
     }
 
-    private static void appendClass(SkeletonContext context, StringBuilder sb) {
+    @Override
+    void appendClassPart(SkeletonContext context, StringBuilder sb) {
         String controller = context.getFxController();
 
-        sb.append(NL).append("public "); //NOI18N
+        sb.append("public "); //NOI18N
         if (controller != null && controller.contains("$")) { //NOI18N
             sb.append("static "); //NOI18N
         }
@@ -102,114 +73,35 @@ public class SkeletonCreatorJava {
         } else {
             sb.append("PleaseProvideControllerClassName"); //NOI18N
         }
-
-        sb.append(" {").append(NL).append(NL); //NOI18N
-
-        appendFields(context, sb);
-
-        appendMethods(context, sb);
-
-        sb.append("}").append(NL); //NOI18N
     }
 
-    private static void appendFields(SkeletonContext context, StringBuilder sb) {
-        appendFieldsResourcesAndLocation(context, sb);
-
-        appendFieldsWithFxId(context, sb);
+    @Override
+    void appendField(Class<?> fieldClass, String fieldName, StringBuilder sb) {
+        sb.append("private ").append(fieldClass.getSimpleName()); //NOI18N
+        appendFieldParameters(sb, fieldClass);
+        sb.append(" ").append(fieldName).append(";"); //NOI18N
     }
 
-    private static void appendFieldsResourcesAndLocation(SkeletonContext context, StringBuilder sb) {
-        if (!context.getSettings().isFull()) {
-            return;
-        }
-
-        sb.append(INDENT).append(FXML_ANNOTATION);
-        if (context.getSettings().isWithComments()) {
-            sb.append(" // ResourceBundle that was given to the FXMLLoader"); //NOI18N
-        }
-        sb.append(NL);
-        sb.append(INDENT).append("private ResourceBundle resources;").append(NL).append(NL); //NOI18N
-
-        sb.append(INDENT).append(FXML_ANNOTATION);
-        if (context.getSettings().isWithComments()) {
-            sb.append(" // URL location of the FXML file that was given to the FXMLLoader"); //NOI18N
-        }
-        sb.append(NL);
-        sb.append(INDENT).append("private URL location;").append(NL).append(NL); //NOI18N
+    @Override
+    void appendFieldParameterType(StringBuilder sb) {
+        sb.append("?"); //NOI18N
     }
 
-    private static void appendFieldsWithFxId(SkeletonContext context, StringBuilder sb) {
-        for (Map.Entry<String, Class<?>> variable : context.getVariables().entrySet()) {
-            sb.append(INDENT).append(FXML_ANNOTATION);
-            if (context.getSettings().isWithComments()) {
-                sb.append(" // fx:id=\"").append(variable.getKey()).append("\""); //NOI18N
-            }
-            sb.append(NL);
-
-            sb.append(INDENT).append("private ").append(variable.getValue().getSimpleName()); //NOI18N
-            appendFieldParameters(sb, variable);
-
-            sb.append(" ").append(variable.getKey()).append(";");
-            if (context.getSettings().isWithComments()) {
-                sb.append(" // Value injected by FXMLLoader"); //NOI18N
-            }
-            sb.append(NL).append(NL);
-        }
+    @Override
+    void appendEventHandler(String methodName, String eventClassName, StringBuilder sb) {
+        sb.append("void "); //NOI18N
+        sb.append(methodName);
+        sb.append("(").append(eventClassName).append(" event) {").append(NL).append(NL); //NOI18N
+        sb.append(INDENT).append("}"); //NOI18N
     }
 
-    private static void appendFieldParameters(StringBuilder sb, Map.Entry<String, Class<?>> variable) {
-        final TypeVariable<? extends Class<?>>[] parameters = variable.getValue().getTypeParameters();
-        if (parameters.length > 0) {
-            sb.append("<"); //NOI18N
-            String sep = ""; //NOI18N
-            for (TypeVariable<?> t : parameters) {
-                sb.append(sep).append("?"); //NOI18N
-                sep = ", "; //NOI18N
-                t.getName(); // silly call to silence FindBugs
-            }
-            sb.append(">"); //NOI18N
-        }
+    @Override
+    void appendInitializeMethodPart(StringBuilder sb) {
+        sb.append("void initialize()"); //NOI18N
     }
 
-    private static void appendMethods(SkeletonContext context, StringBuilder sb) {
-        appendEventHandlers(context, sb);
-
-        appendInitialize(context, sb);
-    }
-
-    private static void appendEventHandlers(SkeletonContext context, StringBuilder sb) {
-        for (Map.Entry<String, String> entry : context.getEventHandlers().entrySet()) {
-            String methodName = entry.getKey();
-            String eventName = entry.getValue();
-
-            final String methodNamePured = methodName.replace("#", ""); //NOI18N
-
-            sb.append(INDENT).append(FXML_ANNOTATION).append(NL).append(INDENT).append("void "); //NOI18N
-            sb.append(methodNamePured);
-            sb.append("(").append(eventName).append(" event) {").append(NL).append(NL);
-            sb.append(INDENT).append("}").append(NL).append(NL); //NOI18N
-        }
-    }
-
-    private static void appendInitialize(SkeletonContext context, StringBuilder sb) {
-        if (!context.getSettings().isFull()) {
-            return;
-        }
-
-        sb.append(INDENT).append(FXML_ANNOTATION);
-        if (context.getSettings().isWithComments()) {
-            sb.append(" // This method is called by the FXMLLoader when initialization is complete"); //NOI18N
-        }
-        sb.append(NL);
-
-        sb.append(INDENT).append("void initialize() {").append(NL); //NOI18N
-        appendAssertions(context, sb);
-        sb.append(NL);
-        sb.append(INDENT);
-        sb.append("}").append(NL).append(NL); //NOI18N
-    }
-
-    private static void appendAssertions(SkeletonContext context, StringBuilder sb) {
+    @Override
+    void appendAssertions(SkeletonContext context, StringBuilder sb) {
         for (String assertion : context.getAssertions()) {
             sb.append(INDENT).append(INDENT)
                 .append("assert ").append(assertion).append(" != null : ") //NOI18N

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreatorJava.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreatorJava.java
@@ -1,7 +1,6 @@
 package com.oracle.javafx.scenebuilder.kit.skeleton;
 
 import com.oracle.javafx.scenebuilder.kit.i18n.I18N;
-import javafx.util.Pair;
 
 import java.lang.reflect.TypeVariable;
 import java.util.Map;
@@ -108,7 +107,7 @@ public class SkeletonCreatorJava {
     }
 
     private static void appendFieldsWithFxId(SkeletonContext context, StringBuilder sb) {
-        for (Pair<String, Class<?>> variable : context.getVariables()) {
+        for (Map.Entry<String, Class<?>> variable : context.getVariables().entrySet()) {
             sb.append(INDENT).append(FXML_ANNOTATION);
             if (context.getSettings().isWithComments()) {
                 sb.append(" // fx:id=\"").append(variable.getKey()).append("\""); //NOI18N
@@ -126,7 +125,7 @@ public class SkeletonCreatorJava {
         }
     }
 
-    private static void appendFieldParameters(StringBuilder sb, Pair<String, Class<?>> variable) {
+    private static void appendFieldParameters(StringBuilder sb, Map.Entry<String, Class<?>> variable) {
         final TypeVariable<? extends Class<?>>[] parameters = variable.getValue().getTypeParameters();
         if (parameters.length > 0) {
             sb.append("<"); //NOI18N

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreatorJava.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreatorJava.java
@@ -1,0 +1,189 @@
+package com.oracle.javafx.scenebuilder.kit.skeleton;
+
+import com.oracle.javafx.scenebuilder.kit.i18n.I18N;
+import javafx.util.Pair;
+
+import java.lang.reflect.TypeVariable;
+import java.util.Map;
+
+public class SkeletonCreatorJava {
+
+    private static final String NL = System.lineSeparator();
+    private static final String INDENT = "    "; //NOI18N
+    private static final String FXML_ANNOTATION = "@FXML";
+
+    static String createFrom(SkeletonContext context) {
+        final StringBuilder sb = new StringBuilder();
+
+        appendHeaderComment(context, sb);
+        appendPackage(context, sb);
+        appendImports(context, sb);
+        appendClass(context, sb);
+
+        return sb.toString();
+    }
+
+    private static void appendHeaderComment(SkeletonContext context, StringBuilder sb) {
+        if (!context.getSettings().isWithComments()) {
+            return;
+        }
+
+        final String title = I18N.getString("skeleton.window.title", context.getDocumentName());
+        sb.append("/**").append(NL); //NOI18N
+        sb.append(" * ").append(title).append(NL); //NOI18N
+        sb.append(" */").append(NL); //NOI18N
+        sb.append(NL);
+    }
+
+    private static void appendPackage(SkeletonContext context, StringBuilder sb) {
+        String controller = context.getFxController();
+
+        if (controller != null && controller.contains(".") && !controller.contains("$")) { //NOI18N
+            sb.append("package "); //NOI18N
+            sb.append(controller, 0, controller.lastIndexOf('.')); //NOI18N
+            sb.append(";").append(NL).append(NL); //NOI18N
+        }
+    }
+
+    private static void appendImports(SkeletonContext context, StringBuilder sb) {
+        for (String importStatement : context.getImports()) {
+            sb.append(importStatement);
+        }
+    }
+
+    private static void appendClass(SkeletonContext context, StringBuilder sb) {
+        String controller = context.getFxController();
+
+        sb.append(NL).append("public "); //NOI18N
+        if (controller != null && controller.contains("$")) { //NOI18N
+            sb.append("static "); //NOI18N
+        }
+
+        sb.append("class "); //NOI18N
+
+        if (controller != null && !controller.isEmpty()) {
+            String simpleName = controller.replace("$", "."); //NOI18N
+            int dot = simpleName.lastIndexOf('.');
+            if (dot > -1) {
+                simpleName = simpleName.substring(dot + 1);
+            }
+            sb.append(simpleName);
+        } else {
+            sb.append("PleaseProvideControllerClassName"); //NOI18N
+        }
+
+        sb.append(" {").append(NL).append(NL); //NOI18N
+
+        appendFields(context, sb);
+
+        appendMethods(context, sb);
+
+        sb.append("}").append(NL); //NOI18N
+    }
+
+    private static void appendFields(SkeletonContext context, StringBuilder sb) {
+        appendFieldsResourcesAndLocation(context, sb);
+
+        appendFieldsWithFxId(context, sb);
+    }
+
+    private static void appendFieldsResourcesAndLocation(SkeletonContext context, StringBuilder sb) {
+        if (!context.getSettings().isFull()) {
+            return;
+        }
+
+        sb.append(INDENT).append(FXML_ANNOTATION);
+        if (context.getSettings().isWithComments()) {
+            sb.append(" // ResourceBundle that was given to the FXMLLoader"); //NOI18N
+        }
+        sb.append(NL);
+        sb.append(INDENT).append("private ResourceBundle resources;").append(NL).append(NL); //NOI18N
+
+        sb.append(INDENT).append(FXML_ANNOTATION);
+        if (context.getSettings().isWithComments()) {
+            sb.append(" // URL location of the FXML file that was given to the FXMLLoader"); //NOI18N
+        }
+        sb.append(NL);
+        sb.append(INDENT).append("private URL location;").append(NL).append(NL); //NOI18N
+    }
+
+    private static void appendFieldsWithFxId(SkeletonContext context, StringBuilder sb) {
+        for (Pair<String, Class<?>> variable : context.getVariables()) {
+            sb.append(INDENT).append(FXML_ANNOTATION);
+            if (context.getSettings().isWithComments()) {
+                sb.append(" // fx:id=\"").append(variable.getKey()).append("\""); //NOI18N
+            }
+            sb.append(NL);
+
+            sb.append(INDENT).append("private ").append(variable.getValue().getSimpleName()); //NOI18N
+            appendFieldParameters(sb, variable);
+
+            sb.append(" ").append(variable.getKey()).append(";");
+            if (context.getSettings().isWithComments()) {
+                sb.append(" // Value injected by FXMLLoader"); //NOI18N
+            }
+            sb.append(NL).append(NL);
+        }
+    }
+
+    private static void appendFieldParameters(StringBuilder sb, Pair<String, Class<?>> variable) {
+        final TypeVariable<? extends Class<?>>[] parameters = variable.getValue().getTypeParameters();
+        if (parameters.length > 0) {
+            sb.append("<"); //NOI18N
+            String sep = ""; //NOI18N
+            for (TypeVariable<?> t : parameters) {
+                sb.append(sep).append("?"); //NOI18N
+                sep = ", "; //NOI18N
+                t.getName(); // silly call to silence FindBugs
+            }
+            sb.append(">"); //NOI18N
+        }
+    }
+
+    private static void appendMethods(SkeletonContext context, StringBuilder sb) {
+        appendEventHandlers(context, sb);
+
+        appendInitialize(context, sb);
+    }
+
+    private static void appendEventHandlers(SkeletonContext context, StringBuilder sb) {
+        for (Map.Entry<String, String> entry : context.getEventHandlers().entrySet()) {
+            String methodName = entry.getKey();
+            String eventName = entry.getValue();
+
+            final String methodNamePured = methodName.replace("#", ""); //NOI18N
+
+            sb.append(INDENT).append(FXML_ANNOTATION).append(NL).append(INDENT).append("void "); //NOI18N
+            sb.append(methodNamePured);
+            sb.append("(").append(eventName).append(" event) {").append(NL).append(NL);
+            sb.append(INDENT).append("}").append(NL).append(NL); //NOI18N
+        }
+    }
+
+    private static void appendInitialize(SkeletonContext context, StringBuilder sb) {
+        if (!context.getSettings().isFull()) {
+            return;
+        }
+
+        sb.append(INDENT).append(FXML_ANNOTATION);
+        if (context.getSettings().isWithComments()) {
+            sb.append(" // This method is called by the FXMLLoader when initialization is complete"); //NOI18N
+        }
+        sb.append(NL);
+
+        sb.append(INDENT).append("void initialize() {").append(NL); //NOI18N
+        appendAssertions(context, sb);
+        sb.append(NL);
+        sb.append(INDENT);
+        sb.append("}").append(NL).append(NL); //NOI18N
+    }
+
+    private static void appendAssertions(SkeletonContext context, StringBuilder sb) {
+        for (String assertion : context.getAssertions()) {
+            sb.append(INDENT).append(INDENT)
+                .append("assert ").append(assertion).append(" != null : ") //NOI18N
+                .append("\"fx:id=\\\"").append(assertion).append("\\\" was not injected: check your FXML file ") //NOI18N
+                .append("'").append(context.getDocumentName()).append("'.\";").append(NL); //NOI18N
+        }
+    }
+}

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreatorJava.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreatorJava.java
@@ -1,3 +1,35 @@
+/*
+ * Copyright (c) 2016, 2021, Gluon and/or its affiliates.
+ * Copyright (c) 2012, 2014, Oracle and/or its affiliates.
+ * All rights reserved. Use is subject to license terms.
+ *
+ * This file is available and licensed under the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the distribution.
+ *  - Neither the name of Oracle Corporation nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.oracle.javafx.scenebuilder.kit.skeleton;
 
 import com.oracle.javafx.scenebuilder.kit.i18n.I18N;

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreatorJava.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreatorJava.java
@@ -54,25 +54,36 @@ public class SkeletonCreatorJava extends AbstractSkeletonCreator {
 
     @Override
     void appendClassPart(SkeletonContext context, StringBuilder sb) {
-        String controller = context.getFxController();
-
         sb.append("public "); //NOI18N
-        if (controller != null && controller.contains("$")) { //NOI18N
+        if (hasNestedController(context)) {
             sb.append("static "); //NOI18N
         }
 
         sb.append("class "); //NOI18N
 
-        if (controller != null && !controller.isEmpty()) {
-            String simpleName = controller.replace("$", "."); //NOI18N
-            int dot = simpleName.lastIndexOf('.');
-            if (dot > -1) {
-                simpleName = simpleName.substring(dot + 1);
-            }
-            sb.append(simpleName);
+        if (hasController(context)) {
+            String controllerClassName = getControllerClassName(context);
+            sb.append(controllerClassName);
         } else {
             sb.append("PleaseProvideControllerClassName"); //NOI18N
         }
+    }
+
+    private boolean hasController(SkeletonContext context) {
+        return context.getFxController() != null && !context.getFxController().isEmpty();
+    }
+
+    private boolean hasNestedController(SkeletonContext context) {
+        return hasController(context) && context.getFxController().contains("$"); //NOI18N
+    }
+
+    private String getControllerClassName(SkeletonContext context) {
+        String simpleName = context.getFxController().replace("$", "."); //NOI18N
+        int dot = simpleName.lastIndexOf('.');
+        if (dot > -1) {
+            simpleName = simpleName.substring(dot + 1);
+        }
+        return simpleName;
     }
 
     @Override

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreatorJava.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreatorJava.java
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016, 2021, Gluon and/or its affiliates.
- * Copyright (c) 2012, 2014, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreatorJava.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreatorJava.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Gluon and/or its affiliates.
+ * Copyright (c) 2021, Gluon and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreatorKotlin.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreatorKotlin.java
@@ -32,41 +32,10 @@
  */
 package com.oracle.javafx.scenebuilder.kit.skeleton;
 
-import com.oracle.javafx.scenebuilder.kit.i18n.I18N;
+public class SkeletonCreatorKotlin extends AbstractSkeletonCreator {
 
-import java.lang.reflect.TypeVariable;
-import java.util.Map;
-
-public class SkeletonCreatorKotlin {
-
-    private static final String NL = System.lineSeparator();
-    private static final String INDENT = "    "; //NOI18N
-    private static final String FXML_ANNOTATION = "@FXML";
-
-    static String createFrom(SkeletonContext context) {
-        final StringBuilder sb = new StringBuilder();
-
-        appendHeaderComment(context, sb);
-        appendPackage(context, sb);
-        appendImports(context, sb);
-        appendClass(context, sb);
-
-        return sb.toString();
-    }
-
-    private static void appendHeaderComment(SkeletonContext context, StringBuilder sb) {
-        if (!context.getSettings().isWithComments()) {
-            return;
-        }
-
-        final String title = I18N.getString("skeleton.window.title", context.getDocumentName());
-        sb.append("/**").append(NL); //NOI18N
-        sb.append(" * ").append(title).append(NL); //NOI18N
-        sb.append(" */").append(NL); //NOI18N
-        sb.append(NL);
-    }
-
-    private static void appendPackage(SkeletonContext context, StringBuilder sb) {
+    @Override
+    void appendPackage(SkeletonContext context, StringBuilder sb) {
         String controller = context.getFxController();
 
         // TODO Verify for Kotlin: inner/static controller class
@@ -77,7 +46,8 @@ public class SkeletonCreatorKotlin {
         }
     }
 
-    private static void appendImports(SkeletonContext context, StringBuilder sb) {
+    @Override
+    void appendImports(SkeletonContext context, StringBuilder sb) {
         for (String importStatement : context.getImports()) {
             // importStatement built with ImportBuilder.build() contains ';' at the end
             String kotlinImport = importStatement.replaceAll(";", "");
@@ -85,10 +55,10 @@ public class SkeletonCreatorKotlin {
         }
     }
 
-    private static void appendClass(SkeletonContext context, StringBuilder sb) {
+    @Override
+    void appendClassPart(SkeletonContext context, StringBuilder sb) {
         String controller = context.getFxController();
 
-        sb.append(NL);
         // TODO Verify for Kotlin: inner/static controller class?
         /*
         if (controller != null && controller.contains("$")) { //NOI18N
@@ -109,115 +79,34 @@ public class SkeletonCreatorKotlin {
         } else {
             sb.append("PleaseProvideControllerClassName"); //NOI18N
         }
-
-        sb.append(" {").append(NL).append(NL); //NOI18N
-
-        appendFields(context, sb);
-
-        appendMethods(context, sb);
-
-        sb.append("}").append(NL); //NOI18N
     }
 
-    private static void appendFields(SkeletonContext context, StringBuilder sb) {
-        appendFieldsResourcesAndLocation(context, sb);
-
-        appendFieldsWithFxId(context, sb);
+    @Override
+    void appendField(Class<?> fieldClass, String fieldName, StringBuilder sb) {
+        sb.append("private lateinit var ").append(fieldName).append(": ").append(fieldClass.getSimpleName()); //NOI18N
+        appendFieldParameters(sb, fieldClass);
     }
 
-    private static void appendFieldsResourcesAndLocation(SkeletonContext context, StringBuilder sb) {
-        if (!context.getSettings().isFull()) {
-            return;
-        }
-
-        sb.append(INDENT).append(FXML_ANNOTATION);
-        if (context.getSettings().isWithComments()) {
-            sb.append(" // ResourceBundle that was given to the FXMLLoader"); //NOI18N
-        }
-        sb.append(NL);
-        sb.append(INDENT).append("private lateinit var resources: ResourceBundle").append(NL).append(NL); //NOI18N
-
-        sb.append(INDENT).append(FXML_ANNOTATION);
-        if (context.getSettings().isWithComments()) {
-            sb.append(" // URL location of the FXML file that was given to the FXMLLoader"); //NOI18N
-        }
-        sb.append(NL);
-        sb.append(INDENT).append("private lateinit var location: URL").append(NL).append(NL); //NOI18N
+    @Override
+    void appendFieldParameterType(StringBuilder sb) {
+        sb.append("Any"); //NOI18N
     }
 
-    private static void appendFieldsWithFxId(SkeletonContext context, StringBuilder sb) {
-        for (Map.Entry<String, Class<?>> variable : context.getVariables().entrySet()) {
-            sb.append(INDENT).append(FXML_ANNOTATION);
-            if (context.getSettings().isWithComments()) {
-                sb.append(" // fx:id=\"").append(variable.getKey()).append("\""); //NOI18N
-            }
-            sb.append(NL);
-
-            sb.append(INDENT).append("private lateinit var ").append(variable.getKey()); //NOI18N
-            sb.append(": ").append(variable.getValue().getSimpleName());
-            appendFieldParameters(sb, variable);
-
-            if (context.getSettings().isWithComments()) {
-                sb.append(" // Value injected by FXMLLoader"); //NOI18N
-            }
-            sb.append(NL).append(NL);
-        }
+    @Override
+    void appendEventHandler(String methodName, String eventClassName, StringBuilder sb) {
+        sb.append("fun "); //NOI18N
+        sb.append(methodName);
+        sb.append("(event: ").append(eventClassName).append(") {").append(NL).append(NL); //NOI18N
+        sb.append(INDENT).append("}"); //NOI18N
     }
 
-    // TODO Verify this is correct for Kotlin
-    private static void appendFieldParameters(StringBuilder sb, Map.Entry<String, Class<?>> variable) {
-        final TypeVariable<? extends Class<?>>[] parameters = variable.getValue().getTypeParameters();
-        if (parameters.length > 0) {
-            sb.append("<"); //NOI18N
-            String sep = ""; //NOI18N
-            for (TypeVariable<?> t : parameters) {
-                sb.append(sep).append("Any"); //NOI18N
-                sep = ", "; //NOI18N
-            }
-            sb.append(">"); //NOI18N
-        }
+    @Override
+    void appendInitializeMethodPart(StringBuilder sb) {
+        sb.append("fun initialize()"); //NOI18N
     }
 
-    private static void appendMethods(SkeletonContext context, StringBuilder sb) {
-        appendEventHandlers(context, sb);
-
-        appendInitialize(context, sb);
-    }
-
-    private static void appendEventHandlers(SkeletonContext context, StringBuilder sb) {
-        for (Map.Entry<String, String> entry : context.getEventHandlers().entrySet()) {
-            String methodName = entry.getKey();
-            String eventName = entry.getValue();
-
-            final String methodNamePured = methodName.replace("#", ""); //NOI18N
-
-            sb.append(INDENT).append(FXML_ANNOTATION).append(NL);
-            sb.append(INDENT).append("fun "); //NOI18N
-            sb.append(methodNamePured);
-            sb.append("(event: ").append(eventName).append(") {").append(NL).append(NL);
-            sb.append(INDENT).append("}").append(NL).append(NL); //NOI18N
-        }
-    }
-
-    private static void appendInitialize(SkeletonContext context, StringBuilder sb) {
-        if (!context.getSettings().isFull()) {
-            return;
-        }
-
-        sb.append(INDENT).append(FXML_ANNOTATION);
-        if (context.getSettings().isWithComments()) {
-            sb.append(" // This method is called by the FXMLLoader when initialization is complete"); //NOI18N
-        }
-        sb.append(NL);
-
-        sb.append(INDENT).append("fun initialize() {").append(NL); //NOI18N
-        appendAssertions(context, sb);
-        sb.append(NL);
-        sb.append(INDENT);
-        sb.append("}").append(NL).append(NL); //NOI18N
-    }
-
-    private static void appendAssertions(SkeletonContext context, StringBuilder sb) {
+    @Override
+    void appendAssertions(SkeletonContext context, StringBuilder sb) {
         for (String assertion : context.getAssertions()) {
             sb.append(INDENT).append(INDENT)
                 .append("assert(").append(assertion).append(" != null) {") //NOI18N

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreatorKotlin.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreatorKotlin.java
@@ -1,0 +1,197 @@
+package com.oracle.javafx.scenebuilder.kit.skeleton;
+
+import com.oracle.javafx.scenebuilder.kit.i18n.I18N;
+import javafx.util.Pair;
+
+import java.lang.reflect.TypeVariable;
+import java.util.Map;
+
+public class SkeletonCreatorKotlin {
+
+    private static final String NL = System.lineSeparator();
+    private static final String INDENT = "    "; //NOI18N
+    private static final String FXML_ANNOTATION = "@FXML";
+
+    static String createFrom(SkeletonContext context) {
+        final StringBuilder sb = new StringBuilder();
+
+        appendHeaderComment(context, sb);
+        appendPackage(context, sb);
+        appendImports(context, sb);
+        appendClass(context, sb);
+
+        return sb.toString();
+    }
+
+    private static void appendHeaderComment(SkeletonContext context, StringBuilder sb) {
+        if (!context.getSettings().isWithComments()) {
+            return;
+        }
+
+        final String title = I18N.getString("skeleton.window.title", context.getDocumentName());
+        sb.append("/**").append(NL); //NOI18N
+        sb.append(" * ").append(title).append(NL); //NOI18N
+        sb.append(" */").append(NL); //NOI18N
+        sb.append(NL);
+    }
+
+    private static void appendPackage(SkeletonContext context, StringBuilder sb) {
+        String controller = context.getFxController();
+
+        // TODO Verify for Kotlin: inner/static controller class
+        if (controller != null && controller.contains(".") && !controller.contains("$")) { //NOI18N
+            sb.append("package "); //NOI18N
+            sb.append(controller, 0, controller.lastIndexOf('.')); //NOI18N
+            sb.append(NL).append(NL); //NOI18N
+        }
+    }
+
+    private static void appendImports(SkeletonContext context, StringBuilder sb) {
+        for (String importStatement : context.getImports()) {
+            // importStatement built with ImportBuilder.build() contains ';' at the end
+            String kotlinImport = importStatement.replaceAll(";", "");
+            sb.append(kotlinImport);
+        }
+    }
+
+    private static void appendClass(SkeletonContext context, StringBuilder sb) {
+        String controller = context.getFxController();
+
+        sb.append(NL);
+        // TODO Verify for Kotlin: inner/static controller class?
+        /*
+        if (controller != null && controller.contains("$")) { //NOI18N
+            sb.append("static "); //NOI18N
+        }
+         */
+
+        sb.append("class "); //NOI18N
+
+        // TODO Verify for Kotlin: is this necessary? Can be simplified?
+        if (controller != null && !controller.isEmpty()) {
+            String simpleName = controller.replace("$", "."); //NOI18N
+            int dot = simpleName.lastIndexOf('.');
+            if (dot > -1) {
+                simpleName = simpleName.substring(dot + 1);
+            }
+            sb.append(simpleName);
+        } else {
+            sb.append("PleaseProvideControllerClassName"); //NOI18N
+        }
+
+        sb.append(" {").append(NL).append(NL); //NOI18N
+
+        appendFields(context, sb);
+
+        appendMethods(context, sb);
+
+        sb.append("}").append(NL); //NOI18N
+    }
+
+    private static void appendFields(SkeletonContext context, StringBuilder sb) {
+        appendFieldsResourcesAndLocation(context, sb);
+
+        appendFieldsWithFxId(context, sb);
+    }
+
+    private static void appendFieldsResourcesAndLocation(SkeletonContext context, StringBuilder sb) {
+        if (!context.getSettings().isFull()) {
+            return;
+        }
+
+        sb.append(INDENT).append(FXML_ANNOTATION);
+        if (context.getSettings().isWithComments()) {
+            sb.append(" // ResourceBundle that was given to the FXMLLoader"); //NOI18N
+        }
+        sb.append(NL);
+        sb.append(INDENT).append("private lateinit var resources: ResourceBundle").append(NL).append(NL); //NOI18N
+
+        sb.append(INDENT).append(FXML_ANNOTATION);
+        if (context.getSettings().isWithComments()) {
+            sb.append(" // URL location of the FXML file that was given to the FXMLLoader"); //NOI18N
+        }
+        sb.append(NL);
+        sb.append(INDENT).append("private lateinit var location: URL").append(NL).append(NL); //NOI18N
+    }
+
+    private static void appendFieldsWithFxId(SkeletonContext context, StringBuilder sb) {
+        for (Pair<String, Class<?>> variable : context.getVariables()) {
+            sb.append(INDENT).append(FXML_ANNOTATION);
+            if (context.getSettings().isWithComments()) {
+                sb.append(" // fx:id=\"").append(variable.getKey()).append("\""); //NOI18N
+            }
+            sb.append(NL);
+
+            sb.append(INDENT).append("private lateinit var ").append(variable.getKey()); //NOI18N
+            sb.append(": ").append(variable.getValue().getSimpleName());
+            appendFieldParameters(sb, variable);
+
+            if (context.getSettings().isWithComments()) {
+                sb.append(" // Value injected by FXMLLoader"); //NOI18N
+            }
+            sb.append(NL).append(NL);
+        }
+    }
+
+    // TODO Verify this is correct for Kotlin
+    private static void appendFieldParameters(StringBuilder sb, Pair<String, Class<?>> variable) {
+        final TypeVariable<? extends Class<?>>[] parameters = variable.getValue().getTypeParameters();
+        if (parameters.length > 0) {
+            sb.append("<"); //NOI18N
+            String sep = ""; //NOI18N
+            for (TypeVariable<?> t : parameters) {
+                sb.append(sep).append("?"); //NOI18N
+                sep = ", "; //NOI18N
+            }
+            sb.append(">"); //NOI18N
+        }
+    }
+
+    private static void appendMethods(SkeletonContext context, StringBuilder sb) {
+        appendEventHandlers(context, sb);
+
+        appendInitialize(context, sb);
+    }
+
+    private static void appendEventHandlers(SkeletonContext context, StringBuilder sb) {
+        for (Map.Entry<String, String> entry : context.getEventHandlers().entrySet()) {
+            String methodName = entry.getKey();
+            String eventName = entry.getValue();
+
+            final String methodNamePured = methodName.replace("#", ""); //NOI18N
+
+            sb.append(INDENT).append(FXML_ANNOTATION).append(NL);
+            sb.append(INDENT).append("fun "); //NOI18N
+            sb.append(methodNamePured);
+            sb.append("(event: ").append(eventName).append(") {").append(NL).append(NL);
+            sb.append(INDENT).append("}").append(NL).append(NL); //NOI18N
+        }
+    }
+
+    private static void appendInitialize(SkeletonContext context, StringBuilder sb) {
+        if (!context.getSettings().isFull()) {
+            return;
+        }
+
+        sb.append(INDENT).append(FXML_ANNOTATION);
+        if (context.getSettings().isWithComments()) {
+            sb.append(" // This method is called by the FXMLLoader when initialization is complete"); //NOI18N
+        }
+        sb.append(NL);
+
+        sb.append(INDENT).append("fun initialize() {").append(NL); //NOI18N
+        appendAssertions(context, sb);
+        sb.append(NL);
+        sb.append(INDENT);
+        sb.append("}").append(NL).append(NL); //NOI18N
+    }
+
+    private static void appendAssertions(SkeletonContext context, StringBuilder sb) {
+        for (String assertion : context.getAssertions()) {
+            sb.append(INDENT).append(INDENT)
+                .append("assert(").append(assertion).append(" != null) {") //NOI18N
+                .append("\"fx:id=\\\"").append(assertion).append("\\\" was not injected: check your FXML file ") //NOI18N
+                .append("'").append(context.getDocumentName()).append("'.\" }").append(NL); //NOI18N
+        }
+    }
+}

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreatorKotlin.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreatorKotlin.java
@@ -171,7 +171,7 @@ public class SkeletonCreatorKotlin {
             sb.append("<"); //NOI18N
             String sep = ""; //NOI18N
             for (TypeVariable<?> t : parameters) {
-                sb.append(sep).append("?"); //NOI18N
+                sb.append(sep).append("Any"); //NOI18N
                 sep = ", "; //NOI18N
             }
             sb.append(">"); //NOI18N

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreatorKotlin.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreatorKotlin.java
@@ -1,7 +1,6 @@
 package com.oracle.javafx.scenebuilder.kit.skeleton;
 
 import com.oracle.javafx.scenebuilder.kit.i18n.I18N;
-import javafx.util.Pair;
 
 import java.lang.reflect.TypeVariable;
 import java.util.Map;
@@ -115,7 +114,7 @@ public class SkeletonCreatorKotlin {
     }
 
     private static void appendFieldsWithFxId(SkeletonContext context, StringBuilder sb) {
-        for (Pair<String, Class<?>> variable : context.getVariables()) {
+        for (Map.Entry<String, Class<?>> variable : context.getVariables().entrySet()) {
             sb.append(INDENT).append(FXML_ANNOTATION);
             if (context.getSettings().isWithComments()) {
                 sb.append(" // fx:id=\"").append(variable.getKey()).append("\""); //NOI18N
@@ -134,7 +133,7 @@ public class SkeletonCreatorKotlin {
     }
 
     // TODO Verify this is correct for Kotlin
-    private static void appendFieldParameters(StringBuilder sb, Pair<String, Class<?>> variable) {
+    private static void appendFieldParameters(StringBuilder sb, Map.Entry<String, Class<?>> variable) {
         final TypeVariable<? extends Class<?>>[] parameters = variable.getValue().getTypeParameters();
         if (parameters.length > 0) {
             sb.append("<"); //NOI18N

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreatorKotlin.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreatorKotlin.java
@@ -1,3 +1,35 @@
+/*
+ * Copyright (c) 2016, 2021, Gluon and/or its affiliates.
+ * Copyright (c) 2012, 2014, Oracle and/or its affiliates.
+ * All rights reserved. Use is subject to license terms.
+ *
+ * This file is available and licensed under the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the distribution.
+ *  - Neither the name of Oracle Corporation nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.oracle.javafx.scenebuilder.kit.skeleton;
 
 import com.oracle.javafx.scenebuilder.kit.i18n.I18N;

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreatorKotlin.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreatorKotlin.java
@@ -38,7 +38,6 @@ public class SkeletonCreatorKotlin extends AbstractSkeletonCreator {
     void appendPackage(SkeletonContext context, StringBuilder sb) {
         String controller = context.getFxController();
 
-        // TODO Verify for Kotlin: inner/static controller class
         if (controller != null && controller.contains(".") && !controller.contains("$")) { //NOI18N
             sb.append("package "); //NOI18N
             sb.append(controller, 0, controller.lastIndexOf('.')); //NOI18N
@@ -57,28 +56,27 @@ public class SkeletonCreatorKotlin extends AbstractSkeletonCreator {
 
     @Override
     void appendClassPart(SkeletonContext context, StringBuilder sb) {
-        String controller = context.getFxController();
-
-        // TODO Verify for Kotlin: inner/static controller class?
-        /*
-        if (controller != null && controller.contains("$")) { //NOI18N
-            sb.append("static "); //NOI18N
-        }
-         */
-
         sb.append("class "); //NOI18N
 
-        // TODO Verify for Kotlin: is this necessary? Can be simplified?
-        if (controller != null && !controller.isEmpty()) {
-            String simpleName = controller.replace("$", "."); //NOI18N
-            int dot = simpleName.lastIndexOf('.');
-            if (dot > -1) {
-                simpleName = simpleName.substring(dot + 1);
-            }
-            sb.append(simpleName);
+        if (hasController(context)) {
+            String controllerClassName = getControllerClassName(context);
+            sb.append(controllerClassName);
         } else {
             sb.append("PleaseProvideControllerClassName"); //NOI18N
         }
+    }
+
+    private boolean hasController(SkeletonContext context) {
+        return context.getFxController() != null && !context.getFxController().isEmpty();
+    }
+
+    private String getControllerClassName(SkeletonContext context) {
+        String simpleName = context.getFxController().replace("$", "."); //NOI18N
+        int dot = simpleName.lastIndexOf('.');
+        if (dot > -1) {
+            simpleName = simpleName.substring(dot + 1);
+        }
+        return simpleName;
     }
 
     @Override

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreatorKotlin.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreatorKotlin.java
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016, 2021, Gluon and/or its affiliates.
- * Copyright (c) 2012, 2014, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreatorKotlin.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreatorKotlin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Gluon and/or its affiliates.
+ * Copyright (c) 2021, Gluon and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonSettings.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonSettings.java
@@ -1,3 +1,35 @@
+/*
+ * Copyright (c) 2016, 2021, Gluon and/or its affiliates.
+ * Copyright (c) 2012, 2014, Oracle and/or its affiliates.
+ * All rights reserved. Use is subject to license terms.
+ *
+ * This file is available and licensed under the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the distribution.
+ *  - Neither the name of Oracle Corporation nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.oracle.javafx.scenebuilder.kit.skeleton;
 
 class SkeletonSettings {

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonSettings.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonSettings.java
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016, 2021, Gluon and/or its affiliates.
- * Copyright (c) 2012, 2014, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonSettings.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonSettings.java
@@ -1,0 +1,65 @@
+package com.oracle.javafx.scenebuilder.kit.skeleton;
+
+class SkeletonSettings {
+
+    private LANGUAGE language = LANGUAGE.JAVA;
+    private TEXT_TYPE textType = TEXT_TYPE.WITHOUT_COMMENTS;
+    private FORMAT_TYPE textFormat = FORMAT_TYPE.COMPACT;
+
+    enum LANGUAGE {
+        JAVA("Java"), KOTLIN("Kotlin");
+
+        private final String name;
+
+        LANGUAGE(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String toString() {
+            return name;
+        }
+    }
+
+    enum TEXT_TYPE {
+        WITH_COMMENTS, WITHOUT_COMMENTS
+    }
+
+    enum FORMAT_TYPE {
+        COMPACT, FULL
+    }
+
+    void setLanguage(LANGUAGE language) {
+        this.language = language;
+    }
+
+    public LANGUAGE getLanguage() {
+        return language;
+    }
+
+    void setTextType(TEXT_TYPE type) {
+        this.textType = type;
+    }
+
+    SkeletonSettings withTextType(TEXT_TYPE type) {
+        this.textType = type;
+        return this;
+    }
+
+    void setFormat(FORMAT_TYPE format) {
+        this.textFormat = format;
+    }
+
+    SkeletonSettings withFormat(FORMAT_TYPE format) {
+        this.textFormat = format;
+        return this;
+    }
+
+    boolean isWithComments() {
+        return textType == TEXT_TYPE.WITH_COMMENTS;
+    }
+
+    boolean isFull() {
+        return textFormat == FORMAT_TYPE.FULL;
+    }
+}

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonSettings.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Gluon and/or its affiliates.
+ * Copyright (c) 2021, Gluon and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonWindowController.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonWindowController.java
@@ -132,10 +132,9 @@ public class SkeletonWindowController extends AbstractFxmlWindowController {
         languageChoiceBox.getItems().addAll(SkeletonSettings.LANGUAGE.values());
         languageChoiceBox.getSelectionModel().select(SkeletonSettings.LANGUAGE.JAVA);
 
-        ChangeListener<Object> updateOnChangeListener = (ov, t, t1) -> update();
-        languageChoiceBox.getSelectionModel().selectedItemProperty().addListener(updateOnChangeListener);
-        commentCheckBox.selectedProperty().addListener(updateOnChangeListener);
-        formatCheckBox.selectedProperty().addListener(updateOnChangeListener);
+        languageChoiceBox.getSelectionModel().selectedItemProperty().addListener(fxomDocumentRevisionListener);
+        commentCheckBox.selectedProperty().addListener(fxomDocumentRevisionListener);
+        formatCheckBox.selectedProperty().addListener(fxomDocumentRevisionListener);
 
         update();
     }
@@ -143,7 +142,7 @@ public class SkeletonWindowController extends AbstractFxmlWindowController {
     /*
      * Private
      */
-    private final ChangeListener<Number> fxomDocumentRevisionListener
+    private final ChangeListener<Object> fxomDocumentRevisionListener
         = (observable, oldValue, newValue) -> update();
 
     private void updateTitle() {

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonWindowController.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonWindowController.java
@@ -36,6 +36,7 @@ import com.oracle.javafx.scenebuilder.kit.editor.EditorController;
 import com.oracle.javafx.scenebuilder.kit.editor.panel.util.AbstractFxmlWindowController;
 import com.oracle.javafx.scenebuilder.kit.fxom.FXOMDocument;
 import com.oracle.javafx.scenebuilder.kit.i18n.I18N;
+import javafx.beans.InvalidationListener;
 import javafx.beans.value.ChangeListener;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
@@ -142,8 +143,7 @@ public class SkeletonWindowController extends AbstractFxmlWindowController {
     /*
      * Private
      */
-    private final ChangeListener<Object> fxomDocumentRevisionListener
-        = (observable, oldValue, newValue) -> update();
+    private final InvalidationListener fxomDocumentRevisionListener = (observable) -> update();
 
     private void updateTitle() {
         final String title = I18N.getString("skeleton.window.title", documentName);

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonWindowController.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonWindowController.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2021, Gluon and/or its affiliates.
  * Copyright (c) 2012, 2014, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonWindowController.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonWindowController.java
@@ -34,27 +34,28 @@ package com.oracle.javafx.scenebuilder.kit.skeleton;
 import com.oracle.javafx.scenebuilder.kit.editor.EditorController;
 import com.oracle.javafx.scenebuilder.kit.editor.panel.util.AbstractFxmlWindowController;
 import com.oracle.javafx.scenebuilder.kit.fxom.FXOMDocument;
-
-import java.util.HashMap;
-import java.util.Map;
-
 import com.oracle.javafx.scenebuilder.kit.i18n.I18N;
 import javafx.beans.value.ChangeListener;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.scene.control.CheckBox;
+import javafx.scene.control.ChoiceBox;
 import javafx.scene.control.TextArea;
 import javafx.scene.input.Clipboard;
 import javafx.scene.input.DataFormat;
 import javafx.stage.Stage;
-import javafx.stage.Window;
 import javafx.stage.WindowEvent;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  *
  */
 public class SkeletonWindowController extends AbstractFxmlWindowController {
 
+    @FXML
+    ChoiceBox<SkeletonSettings.LANGUAGE> languageChoiceBox;
     @FXML
     CheckBox commentCheckBox;
     @FXML
@@ -78,7 +79,7 @@ public class SkeletonWindowController extends AbstractFxmlWindowController {
     private final EditorController editorController;
     private boolean dirty = false;
 
-    private String documentName;
+    private final String documentName;
 
     public SkeletonWindowController(EditorController editorController, String documentName, Stage owner) {
         super(SkeletonWindowController.class.getResource("SkeletonWindow.fxml"), I18N.getBundle(), owner); //NOI18N
@@ -86,16 +87,16 @@ public class SkeletonWindowController extends AbstractFxmlWindowController {
         this.documentName = documentName;
 
         this.editorController.fxomDocumentProperty().addListener(
-                (ChangeListener<FXOMDocument>) (ov, od, nd) -> {
-                    assert editorController.getFxomDocument() == nd;
-                    if (od != null) {
-                        od.sceneGraphRevisionProperty().removeListener(fxomDocumentRevisionListener);
-                    }
-                    if (nd != null) {
-                        nd.sceneGraphRevisionProperty().addListener(fxomDocumentRevisionListener);
-                        update();
-                    }
-                });
+            (ChangeListener<FXOMDocument>) (ov, od, nd) -> {
+                assert editorController.getFxomDocument() == nd;
+                if (od != null) {
+                    od.sceneGraphRevisionProperty().removeListener(fxomDocumentRevisionListener);
+                }
+                if (nd != null) {
+                    nd.sceneGraphRevisionProperty().addListener(fxomDocumentRevisionListener);
+                    update();
+                }
+            });
 
         if (editorController.getFxomDocument() != null) {
             editorController.getFxomDocument().sceneGraphRevisionProperty().addListener(fxomDocumentRevisionListener);
@@ -122,13 +123,18 @@ public class SkeletonWindowController extends AbstractFxmlWindowController {
     @Override
     protected void controllerDidLoadFxml() {
         super.controllerDidLoadFxml();
+        assert languageChoiceBox != null;
         assert commentCheckBox != null;
         assert formatCheckBox != null;
         assert textArea != null;
 
-        commentCheckBox.selectedProperty().addListener((ChangeListener<Boolean>) (ov, t, t1) -> update());
+        languageChoiceBox.getItems().addAll(SkeletonSettings.LANGUAGE.values());
+        languageChoiceBox.getSelectionModel().select(SkeletonSettings.LANGUAGE.JAVA);
 
-        formatCheckBox.selectedProperty().addListener((ChangeListener<Boolean>) (ov, t, t1) -> update());
+        ChangeListener<Object> updateOnChangeListener = (ov, t, t1) -> update();
+        languageChoiceBox.getSelectionModel().selectedItemProperty().addListener(updateOnChangeListener);
+        commentCheckBox.selectedProperty().addListener(updateOnChangeListener);
+        formatCheckBox.selectedProperty().addListener(updateOnChangeListener);
 
         update();
     }
@@ -137,7 +143,7 @@ public class SkeletonWindowController extends AbstractFxmlWindowController {
      * Private
      */
     private final ChangeListener<Number> fxomDocumentRevisionListener
-            = (observable, oldValue, newValue) -> update();
+        = (observable, oldValue, newValue) -> update();
 
     private void updateTitle() {
         final String title = I18N.getString("skeleton.window.title", documentName);
@@ -152,16 +158,18 @@ public class SkeletonWindowController extends AbstractFxmlWindowController {
             updateTitle();
             final SkeletonBuffer buf = new SkeletonBuffer(editorController.getFxomDocument(), documentName);
 
+            buf.setLanguage(languageChoiceBox.getSelectionModel().getSelectedItem());
+
             if (commentCheckBox.isSelected()) {
-                buf.setTextType(SkeletonBuffer.TEXT_TYPE.WITH_COMMENTS);
+                buf.setTextType(SkeletonSettings.TEXT_TYPE.WITH_COMMENTS);
             } else {
-                buf.setTextType(SkeletonBuffer.TEXT_TYPE.WITHOUT_COMMENTS);
+                buf.setTextType(SkeletonSettings.TEXT_TYPE.WITHOUT_COMMENTS);
             }
 
             if (formatCheckBox.isSelected()) {
-                buf.setFormat(SkeletonBuffer.FORMAT_TYPE.FULL);
+                buf.setFormat(SkeletonSettings.FORMAT_TYPE.FULL);
             } else {
-                buf.setFormat(SkeletonBuffer.FORMAT_TYPE.COMPACT);
+                buf.setFormat(SkeletonSettings.FORMAT_TYPE.COMPACT);
             }
 
             textArea.setText(buf.toString());

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonWindowController.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonWindowController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Gluon and/or its affiliates.
+ * Copyright (c) 2016, 2021, Gluon and/or its affiliates.
  * Copyright (c) 2012, 2014, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *

--- a/kit/src/main/resources/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonWindow.fxml
+++ b/kit/src/main/resources/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonWindow.fxml
@@ -36,6 +36,7 @@
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Button?>
 <?import javafx.scene.control.CheckBox?>
+<?import javafx.scene.control.ChoiceBox?>
 <?import javafx.scene.control.TextArea?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.StackPane?>
@@ -51,6 +52,7 @@
                         <Button mnemonicParsing="false" onAction="#onCopyAction" text="%label.copy" HBox.hgrow="ALWAYS" />
                         <HBox alignment="BASELINE_RIGHT" spacing="5.0" HBox.hgrow="ALWAYS">
                             <children>
+                                <ChoiceBox fx:id="languageChoiceBox" />
                                 <CheckBox fx:id="commentCheckBox" mnemonicParsing="false" text="%skeleton.add.comments">
                                 </CheckBox><CheckBox fx:id="formatCheckBox" mnemonicParsing="false" text="%skeleton.format.full" />
                             </children>

--- a/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/JfxInitializer.java
+++ b/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/JfxInitializer.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2021, Gluon and/or its affiliates.
+ * All rights reserved. Use is subject to license terms.
+ *
+ * This file is available and licensed under the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the distribution.
+ *  - Neither the name of Oracle Corporation and Gluon nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.javafx.scenebuilder.kit;
+
+import javafx.application.Application;
+import javafx.stage.Stage;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class JfxInitializer {
+
+    private static final AtomicBoolean initialized = new AtomicBoolean(false);
+
+    public static void initialize() {
+        if (initialized.compareAndSet(false, true)) {
+            Thread t = new Thread("JavaFX Init Thread") {
+
+                @Override
+                public void run() {
+                    Application.launch(DummyApp.class);
+                }
+            };
+            t.setDaemon(true);
+            t.start();
+        }
+    }
+
+    public static class DummyApp extends Application {
+
+        @Override
+        public void start(Stage primaryStage) {
+            // noop
+        }
+    }
+}

--- a/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/fxom/FXOMSaverUpdateImportInstructionsTest.java
+++ b/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/fxom/FXOMSaverUpdateImportInstructionsTest.java
@@ -46,6 +46,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
+import com.oracle.javafx.scenebuilder.kit.JfxInitializer;
 import com.oracle.javafx.scenebuilder.kit.fxom.glue.GlueCharacters;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -67,7 +68,7 @@ public class FXOMSaverUpdateImportInstructionsTest {
 
     @BeforeClass
     public static void initialize() {
-        new JFXPanel();
+        JfxInitializer.initialize();
     }
 
     @Test

--- a/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/fxom/StaticLoadTest.java
+++ b/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/fxom/StaticLoadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Gluon and/or its affiliates.
+ * Copyright (c) 2017, 2021, Gluon and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -34,8 +34,9 @@ package com.oracle.javafx.scenebuilder.kit.fxom;
 import com.oracle.javafx.scenebuilder.kit.editor.EditorController;
 import java.io.IOException;
 import java.net.URL;
-import javafx.application.Application;
-import javafx.stage.Stage;
+
+import com.oracle.javafx.scenebuilder.kit.JfxInitializer;
+
 import static org.junit.Assert.assertFalse;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -47,23 +48,9 @@ public class StaticLoadTest {
     
     private boolean thrown;
     
-    public static class DummyApp extends Application {
-        @Override
-        public void start(Stage primaryStage) throws Exception {
-            // noop
-        }
-    }
-
     @BeforeClass
     public static void initJFX() {
-        Thread t = new Thread("JavaFX Init Thread") {
-            @Override
-            public void run() {
-                Application.launch(DummyApp.class, new String[0]);
-            }
-        };
-        t.setDaemon(true);
-        t.start();
+        JfxInitializer.initialize();
     }
     
     @Test

--- a/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/EmptyController.java
+++ b/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/EmptyController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Gluon and/or its affiliates.
+ * Copyright (c) 2021, Gluon and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:

--- a/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/EmptyController.java
+++ b/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/EmptyController.java
@@ -1,0 +1,5 @@
+package com.oracle.javafx.scenebuilder.kit.skeleton;
+
+public class EmptyController {
+
+}

--- a/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/EmptyController.java
+++ b/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/EmptyController.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright (c) 2021 Gluon and/or its affiliates.
+ * All rights reserved. Use is subject to license terms.
+ *
+ * This file is available and licensed under the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the distribution.
+ *  - Neither the name of Oracle Corporation and Gluon nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.oracle.javafx.scenebuilder.kit.skeleton;
 
 public class EmptyController {

--- a/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/NestedClassController.java
+++ b/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/NestedClassController.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2021, Gluon and/or its affiliates.
+ * All rights reserved. Use is subject to license terms.
+ *
+ * This file is available and licensed under the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the distribution.
+ *  - Neither the name of Oracle Corporation and Gluon nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.javafx.scenebuilder.kit.skeleton;
+
+public class NestedClassController {
+
+    public static class InnerController {
+
+    }
+}

--- a/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonBufferJavaTest.java
+++ b/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonBufferJavaTest.java
@@ -53,7 +53,7 @@ public class SkeletonBufferJavaTest {
     }
 
     @Test
-    public void skeletonToString_nestedTestFxml_full_withComments() throws IOException {
+    public void skeletonToString_nestedTestFxml() throws IOException {
         // given
         SkeletonBuffer skeletonBuffer = load("TestNested.fxml");
 

--- a/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonBufferJavaTest.java
+++ b/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonBufferJavaTest.java
@@ -33,6 +33,8 @@ package com.oracle.javafx.scenebuilder.kit.skeleton;
 
 import com.oracle.javafx.scenebuilder.kit.editor.EditorController;
 import com.oracle.javafx.scenebuilder.kit.fxom.FXOMDocument;
+import javafx.embed.swing.JFXPanel;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.File;
@@ -44,6 +46,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 public class SkeletonBufferJavaTest {
+
+    @BeforeClass
+    public static void initialize() {
+        new JFXPanel();
+    }
 
     @Test
     public void skeletonToString_testFxml_full_withComments() throws IOException {

--- a/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonBufferJavaTest.java
+++ b/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonBufferJavaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017 Gluon and/or its affiliates.
+ * Copyright (c) 2021 Gluon and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:

--- a/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonBufferJavaTest.java
+++ b/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonBufferJavaTest.java
@@ -53,6 +53,18 @@ public class SkeletonBufferJavaTest {
     }
 
     @Test
+    public void skeletonToString_nestedTestFxml_full_withComments() throws IOException {
+        // given
+        SkeletonBuffer skeletonBuffer = load("TestNested.fxml");
+
+        // when
+        String skeleton = skeletonBuffer.toString();
+
+        // then
+        assertEqualsFileContent("skeleton_java_nested.txt", skeleton);
+    }
+
+    @Test
     public void skeletonToString_testFxml_full_withComments() throws IOException {
         // given
         SkeletonBuffer skeletonBuffer = load("Test.fxml");

--- a/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonBufferJavaTest.java
+++ b/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonBufferJavaTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2016, 2017 Gluon and/or its affiliates.
+ * All rights reserved. Use is subject to license terms.
+ *
+ * This file is available and licensed under the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the distribution.
+ *  - Neither the name of Oracle Corporation and Gluon nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.javafx.scenebuilder.kit.skeleton;
+
+import com.oracle.javafx.scenebuilder.kit.editor.EditorController;
+import com.oracle.javafx.scenebuilder.kit.fxom.FXOMDocument;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class SkeletonBufferJavaTest {
+
+    @Test
+    public void skeletonToString_testFxml_full_withComments() throws IOException {
+        // given
+        SkeletonBuffer skeletonBuffer = load("Test.fxml");
+        skeletonBuffer.setFormat(SkeletonSettings.FORMAT_TYPE.FULL);
+        skeletonBuffer.setTextType(SkeletonSettings.TEXT_TYPE.WITH_COMMENTS);
+
+        // when
+        String skeleton = skeletonBuffer.toString();
+
+        // then
+        assertEqualsFileContent("skeleton_java_full_comments.txt", skeleton);
+    }
+
+    @Test
+    public void skeletonToString_testFxml_withComments() throws IOException {
+        // given
+        SkeletonBuffer skeletonBuffer = load("Test.fxml");
+        skeletonBuffer.setTextType(SkeletonSettings.TEXT_TYPE.WITH_COMMENTS);
+
+        // when
+        String skeleton = skeletonBuffer.toString();
+
+        // then
+        assertEqualsFileContent("skeleton_java_comments.txt", skeleton);
+    }
+
+    @Test
+    public void skeletonToString_testFxml_fullFormat() throws IOException {
+        // given
+        SkeletonBuffer skeletonBuffer = load("Test.fxml");
+        skeletonBuffer.setFormat(SkeletonSettings.FORMAT_TYPE.FULL);
+
+        // when
+        String skeleton = skeletonBuffer.toString();
+
+        // then
+        assertEqualsFileContent("skeleton_java_full.txt", skeleton);
+    }
+
+    private void assertEqualsFileContent(String fileName, String actual) {
+        URL url = this.getClass().getResource(fileName);
+        File file = new File(url.getFile());
+
+        try {
+            String expectedFileContent = Files.readString(file.toPath());
+            assertEquals(expectedFileContent, actual);
+        } catch (IOException e) {
+            fail("Unable to open file: " + fileName);
+        }
+    }
+
+    private SkeletonBuffer load(String fxmlFile) throws IOException {
+        EditorController editorController = new EditorController();
+        final URL fxmlURL = SkeletonBufferJavaTest.class.getResource(fxmlFile);
+        final String fxmlText = FXOMDocument.readContentFromURL(fxmlURL);
+        editorController.setFxmlTextAndLocation(fxmlText, fxmlURL, false);
+
+        SkeletonBuffer skeletonBuffer = new SkeletonBuffer(editorController.getFxomDocument(), "test");
+        skeletonBuffer.setLanguage(SkeletonSettings.LANGUAGE.JAVA);
+        return skeletonBuffer;
+    }
+}

--- a/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonBufferJavaTest.java
+++ b/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonBufferJavaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Gluon and/or its affiliates.
+ * Copyright (c) 2021, Gluon and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -31,9 +31,9 @@
  */
 package com.oracle.javafx.scenebuilder.kit.skeleton;
 
+import com.oracle.javafx.scenebuilder.kit.JfxInitializer;
 import com.oracle.javafx.scenebuilder.kit.editor.EditorController;
 import com.oracle.javafx.scenebuilder.kit.fxom.FXOMDocument;
-import javafx.embed.swing.JFXPanel;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -49,7 +49,7 @@ public class SkeletonBufferJavaTest {
 
     @BeforeClass
     public static void initialize() {
-        new JFXPanel();
+        JfxInitializer.initialize();
     }
 
     @Test

--- a/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonBufferKotlinTest.java
+++ b/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonBufferKotlinTest.java
@@ -53,6 +53,18 @@ public class SkeletonBufferKotlinTest {
     }
 
     @Test
+    public void skeletonToString_nestedTestFxml_full_withComments() throws IOException {
+        // given
+        SkeletonBuffer skeletonBuffer = load("TestNested.fxml");
+
+        // when
+        String skeleton = skeletonBuffer.toString();
+
+        // then
+        assertEqualsFileContent("skeleton_kotlin_nested.txt", skeleton);
+    }
+
+    @Test
     public void skeletonToString_testFxml_full_withComments() throws IOException {
         // given
         SkeletonBuffer skeletonBuffer = load("Test.fxml");

--- a/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonBufferKotlinTest.java
+++ b/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonBufferKotlinTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2016, 2017 Gluon and/or its affiliates.
+ * All rights reserved. Use is subject to license terms.
+ *
+ * This file is available and licensed under the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the distribution.
+ *  - Neither the name of Oracle Corporation and Gluon nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.javafx.scenebuilder.kit.skeleton;
+
+import com.oracle.javafx.scenebuilder.kit.editor.EditorController;
+import com.oracle.javafx.scenebuilder.kit.fxom.FXOMDocument;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class SkeletonBufferKotlinTest {
+
+    @Test
+    public void skeletonToString_testFxml_full_withComments() throws IOException {
+        // given
+        SkeletonBuffer skeletonBuffer = load("Test.fxml");
+        skeletonBuffer.setFormat(SkeletonSettings.FORMAT_TYPE.FULL);
+        skeletonBuffer.setTextType(SkeletonSettings.TEXT_TYPE.WITH_COMMENTS);
+
+        // when
+        String skeleton = skeletonBuffer.toString();
+
+        // then
+        assertEqualsFileContent("skeleton_kotlin_full_comments.txt", skeleton);
+    }
+
+    @Test
+    public void skeletonToString_testFxml_withComments() throws IOException {
+        // given
+        SkeletonBuffer skeletonBuffer = load("Test.fxml");
+        skeletonBuffer.setTextType(SkeletonSettings.TEXT_TYPE.WITH_COMMENTS);
+
+        // when
+        String skeleton = skeletonBuffer.toString();
+
+        // then
+        assertEqualsFileContent("skeleton_kotlin_comments.txt", skeleton);
+    }
+
+    @Test
+    public void skeletonToString_testFxml_fullFormat() throws IOException {
+        // given
+        SkeletonBuffer skeletonBuffer = load("Test.fxml");
+        skeletonBuffer.setFormat(SkeletonSettings.FORMAT_TYPE.FULL);
+
+        // when
+        String skeleton = skeletonBuffer.toString();
+
+        // then
+        assertEqualsFileContent("skeleton_kotlin_full.txt", skeleton);
+    }
+
+    private void assertEqualsFileContent(String fileName, String actual) {
+        URL url = this.getClass().getResource(fileName);
+        File file = new File(url.getFile());
+
+        try {
+            String expectedFileContent = Files.readString(file.toPath());
+            assertEquals(expectedFileContent, actual);
+        } catch (IOException e) {
+            fail("Unable to open file: " + fileName);
+        }
+    }
+
+    private SkeletonBuffer load(String fxmlFile) throws IOException {
+        EditorController editorController = new EditorController();
+        final URL fxmlURL = SkeletonBufferKotlinTest.class.getResource(fxmlFile);
+        final String fxmlText = FXOMDocument.readContentFromURL(fxmlURL);
+        editorController.setFxmlTextAndLocation(fxmlText, fxmlURL, false);
+
+        SkeletonBuffer skeletonBuffer = new SkeletonBuffer(editorController.getFxomDocument(), "test");
+        skeletonBuffer.setLanguage(SkeletonSettings.LANGUAGE.KOTLIN);
+        return skeletonBuffer;
+    }
+}

--- a/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonBufferKotlinTest.java
+++ b/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonBufferKotlinTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017 Gluon and/or its affiliates.
+ * Copyright (c) 2021 Gluon and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:

--- a/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonBufferKotlinTest.java
+++ b/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonBufferKotlinTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Gluon and/or its affiliates.
+ * Copyright (c) 2021, Gluon and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -31,9 +31,9 @@
  */
 package com.oracle.javafx.scenebuilder.kit.skeleton;
 
+import com.oracle.javafx.scenebuilder.kit.JfxInitializer;
 import com.oracle.javafx.scenebuilder.kit.editor.EditorController;
 import com.oracle.javafx.scenebuilder.kit.fxom.FXOMDocument;
-import javafx.embed.swing.JFXPanel;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -49,7 +49,7 @@ public class SkeletonBufferKotlinTest {
 
     @BeforeClass
     public static void initialize() {
-        new JFXPanel();
+        JfxInitializer.initialize();
     }
 
     @Test

--- a/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonBufferKotlinTest.java
+++ b/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonBufferKotlinTest.java
@@ -53,7 +53,7 @@ public class SkeletonBufferKotlinTest {
     }
 
     @Test
-    public void skeletonToString_nestedTestFxml_full_withComments() throws IOException {
+    public void skeletonToString_nestedTestFxml() throws IOException {
         // given
         SkeletonBuffer skeletonBuffer = load("TestNested.fxml");
 

--- a/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonBufferKotlinTest.java
+++ b/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonBufferKotlinTest.java
@@ -33,6 +33,8 @@ package com.oracle.javafx.scenebuilder.kit.skeleton;
 
 import com.oracle.javafx.scenebuilder.kit.editor.EditorController;
 import com.oracle.javafx.scenebuilder.kit.fxom.FXOMDocument;
+import javafx.embed.swing.JFXPanel;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.File;
@@ -44,6 +46,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 public class SkeletonBufferKotlinTest {
+
+    @BeforeClass
+    public static void initialize() {
+        new JFXPanel();
+    }
 
     @Test
     public void skeletonToString_testFxml_full_withComments() throws IOException {

--- a/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonBufferTest.java
+++ b/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonBufferTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021 Gluon and/or its affiliates.
+ * Copyright (c) 2016, 2021, Gluon and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:

--- a/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonBufferTest.java
+++ b/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonBufferTest.java
@@ -47,43 +47,48 @@ public class SkeletonBufferTest {
 
     @Test
     public void testControllerWithoutPackageName() throws IOException {
-        EditorController editorController = new EditorController();
-        final URL fxmlURL = SkeletonBufferTest.class.getResource("ControllerWithoutPackage.fxml");
-        final String fxmlText = FXOMDocument.readContentFromURL(fxmlURL);
-        editorController.setFxmlTextAndLocation(fxmlText, fxmlURL, false);
+        // given
+        SkeletonBuffer skeletonBuffer = load("ControllerWithoutPackage.fxml");
 
-        SkeletonBuffer skeletonBuffer = new SkeletonBuffer(editorController.getFxomDocument(), "test");
+        // when
         String skeleton = skeletonBuffer.toString();
 
+        // then
         String firstLine = skeleton.substring(0, skeleton.indexOf("\n"));
         assertEquals("", firstLine);
     }
 
     @Test
     public void testControllerWithSimplePackageName() throws IOException {
-        EditorController editorController = new EditorController();
-        final URL fxmlURL = SkeletonBufferTest.class.getResource("ControllerWithSimplePackage.fxml");
-        final String fxmlText = FXOMDocument.readContentFromURL(fxmlURL);
-        editorController.setFxmlTextAndLocation(fxmlText, fxmlURL, false);
+        // given
+        SkeletonBuffer skeletonBuffer = load("ControllerWithSimplePackage.fxml");
 
-        SkeletonBuffer skeletonBuffer = new SkeletonBuffer(editorController.getFxomDocument(), "test");
+        // when
         String skeleton = skeletonBuffer.toString();
 
+        // then
         String firstLine = skeleton.substring(0, skeleton.indexOf("\n"));
         assertEquals("package com;", firstLine);
     }
 
     @Test
     public void testControllerWithAdvancedPackageName() throws IOException {
-        EditorController editorController = new EditorController();
-        final URL fxmlURL = SkeletonBufferTest.class.getResource("ControllerWithAdvancedPackage.fxml");
-        final String fxmlText = FXOMDocument.readContentFromURL(fxmlURL);
-        editorController.setFxmlTextAndLocation(fxmlText, fxmlURL, false);
+        // given
+        SkeletonBuffer skeletonBuffer = load("ControllerWithAdvancedPackage.fxml");
 
-        SkeletonBuffer skeletonBuffer = new SkeletonBuffer(editorController.getFxomDocument(), "test");
+        // when
         String skeleton = skeletonBuffer.toString();
 
+        // then
         String firstLine = skeleton.substring(0, skeleton.indexOf("\n"));
         assertEquals("package com.example.app.view;", firstLine);
+    }
+
+    private SkeletonBuffer load(String fxmlFile) throws IOException {
+        EditorController editorController = new EditorController();
+        final URL fxmlURL = SkeletonBufferTest.class.getResource(fxmlFile);
+        final String fxmlText = FXOMDocument.readContentFromURL(fxmlURL);
+        editorController.setFxmlTextAndLocation(fxmlText, fxmlURL, false);
+        return new SkeletonBuffer(editorController.getFxomDocument(), "test");
     }
 }

--- a/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonBufferTest.java
+++ b/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonBufferTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017 Gluon and/or its affiliates.
+ * Copyright (c) 2016, 2017, 2021 Gluon and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:

--- a/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonBufferTest.java
+++ b/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonBufferTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017, 2021 Gluon and/or its affiliates.
+ * Copyright (c) 2016, 2021 Gluon and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:

--- a/kit/src/test/resources/com/oracle/javafx/scenebuilder/kit/skeleton/Test.fxml
+++ b/kit/src/test/resources/com/oracle/javafx/scenebuilder/kit/skeleton/Test.fxml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.layout.VBox?>
+
+
+<VBox fx:id="myVbox" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" onMouseEntered="#onMyVboxMouseEntered" prefHeight="400.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/8.0.60" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.oracle.javafx.scenebuilder.kit.skeleton.EmptyController" />

--- a/kit/src/test/resources/com/oracle/javafx/scenebuilder/kit/skeleton/Test.fxml
+++ b/kit/src/test/resources/com/oracle/javafx/scenebuilder/kit/skeleton/Test.fxml
@@ -1,6 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<?import javafx.scene.control.TableColumn?>
+<?import javafx.scene.control.TableView?>
 <?import javafx.scene.layout.VBox?>
 
 
-<VBox fx:id="myVbox" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" onMouseEntered="#onMyVboxMouseEntered" prefHeight="400.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/8.0.60" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.oracle.javafx.scenebuilder.kit.skeleton.EmptyController" />
+<VBox fx:id="myVbox" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" onMouseEntered="#onMyVboxMouseEntered" prefHeight="400.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/15.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.oracle.javafx.scenebuilder.kit.skeleton.EmptyController">
+   <children>
+      <TableView fx:id="myTableView" prefHeight="200.0" prefWidth="200.0">
+        <columns>
+          <TableColumn prefWidth="75.0" text="C1" />
+          <TableColumn prefWidth="75.0" text="C2" />
+        </columns>
+      </TableView>
+   </children>
+</VBox>

--- a/kit/src/test/resources/com/oracle/javafx/scenebuilder/kit/skeleton/TestNested.fxml
+++ b/kit/src/test/resources/com/oracle/javafx/scenebuilder/kit/skeleton/TestNested.fxml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.control.TableColumn?>
+<?import javafx.scene.control.TableView?>
+<?import javafx.scene.layout.VBox?>
+
+
+<VBox fx:id="myVbox" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" onMouseEntered="#onMyVboxMouseEntered" prefHeight="400.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/15.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.oracle.javafx.scenebuilder.kit.skeleton.NestedClassController$InnerController">
+   <children>
+      <TableView fx:id="myTableView" prefHeight="200.0" prefWidth="200.0">
+        <columns>
+          <TableColumn prefWidth="75.0" text="C1" />
+          <TableColumn prefWidth="75.0" text="C2" />
+        </columns>
+      </TableView>
+   </children>
+</VBox>

--- a/kit/src/test/resources/com/oracle/javafx/scenebuilder/kit/skeleton/skeleton_java_comments.txt
+++ b/kit/src/test/resources/com/oracle/javafx/scenebuilder/kit/skeleton/skeleton_java_comments.txt
@@ -5,10 +5,14 @@
 package com.oracle.javafx.scenebuilder.kit.skeleton;
 
 import javafx.fxml.FXML;
+import javafx.scene.control.TableView;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.VBox;
 
 public class EmptyController {
+
+    @FXML // fx:id="myTableView"
+    private TableView<?> myTableView; // Value injected by FXMLLoader
 
     @FXML // fx:id="myVbox"
     private VBox myVbox; // Value injected by FXMLLoader

--- a/kit/src/test/resources/com/oracle/javafx/scenebuilder/kit/skeleton/skeleton_java_comments.txt
+++ b/kit/src/test/resources/com/oracle/javafx/scenebuilder/kit/skeleton/skeleton_java_comments.txt
@@ -1,0 +1,21 @@
+/**
+ * Sample Skeleton for 'test' Controller Class
+ */
+
+package com.oracle.javafx.scenebuilder.kit.skeleton;
+
+import javafx.fxml.FXML;
+import javafx.scene.input.MouseEvent;
+import javafx.scene.layout.VBox;
+
+public class EmptyController {
+
+    @FXML // fx:id="myVbox"
+    private VBox myVbox; // Value injected by FXMLLoader
+
+    @FXML
+    void onMyVboxMouseEntered(MouseEvent event) {
+
+    }
+
+}

--- a/kit/src/test/resources/com/oracle/javafx/scenebuilder/kit/skeleton/skeleton_java_full.txt
+++ b/kit/src/test/resources/com/oracle/javafx/scenebuilder/kit/skeleton/skeleton_java_full.txt
@@ -1,0 +1,31 @@
+package com.oracle.javafx.scenebuilder.kit.skeleton;
+
+import java.net.URL;
+import java.util.ResourceBundle;
+import javafx.fxml.FXML;
+import javafx.scene.input.MouseEvent;
+import javafx.scene.layout.VBox;
+
+public class EmptyController {
+
+    @FXML
+    private ResourceBundle resources;
+
+    @FXML
+    private URL location;
+
+    @FXML
+    private VBox myVbox;
+
+    @FXML
+    void onMyVboxMouseEntered(MouseEvent event) {
+
+    }
+
+    @FXML
+    void initialize() {
+        assert myVbox != null : "fx:id=\"myVbox\" was not injected: check your FXML file 'test'.";
+
+    }
+
+}

--- a/kit/src/test/resources/com/oracle/javafx/scenebuilder/kit/skeleton/skeleton_java_full.txt
+++ b/kit/src/test/resources/com/oracle/javafx/scenebuilder/kit/skeleton/skeleton_java_full.txt
@@ -3,6 +3,7 @@ package com.oracle.javafx.scenebuilder.kit.skeleton;
 import java.net.URL;
 import java.util.ResourceBundle;
 import javafx.fxml.FXML;
+import javafx.scene.control.TableView;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.VBox;
 
@@ -15,6 +16,9 @@ public class EmptyController {
     private URL location;
 
     @FXML
+    private TableView<?> myTableView;
+
+    @FXML
     private VBox myVbox;
 
     @FXML
@@ -24,6 +28,7 @@ public class EmptyController {
 
     @FXML
     void initialize() {
+        assert myTableView != null : "fx:id=\"myTableView\" was not injected: check your FXML file 'test'.";
         assert myVbox != null : "fx:id=\"myVbox\" was not injected: check your FXML file 'test'.";
 
     }

--- a/kit/src/test/resources/com/oracle/javafx/scenebuilder/kit/skeleton/skeleton_java_full_comments.txt
+++ b/kit/src/test/resources/com/oracle/javafx/scenebuilder/kit/skeleton/skeleton_java_full_comments.txt
@@ -1,0 +1,35 @@
+/**
+ * Sample Skeleton for 'test' Controller Class
+ */
+
+package com.oracle.javafx.scenebuilder.kit.skeleton;
+
+import java.net.URL;
+import java.util.ResourceBundle;
+import javafx.fxml.FXML;
+import javafx.scene.input.MouseEvent;
+import javafx.scene.layout.VBox;
+
+public class EmptyController {
+
+    @FXML // ResourceBundle that was given to the FXMLLoader
+    private ResourceBundle resources;
+
+    @FXML // URL location of the FXML file that was given to the FXMLLoader
+    private URL location;
+
+    @FXML // fx:id="myVbox"
+    private VBox myVbox; // Value injected by FXMLLoader
+
+    @FXML
+    void onMyVboxMouseEntered(MouseEvent event) {
+
+    }
+
+    @FXML // This method is called by the FXMLLoader when initialization is complete
+    void initialize() {
+        assert myVbox != null : "fx:id=\"myVbox\" was not injected: check your FXML file 'test'.";
+
+    }
+
+}

--- a/kit/src/test/resources/com/oracle/javafx/scenebuilder/kit/skeleton/skeleton_java_full_comments.txt
+++ b/kit/src/test/resources/com/oracle/javafx/scenebuilder/kit/skeleton/skeleton_java_full_comments.txt
@@ -7,6 +7,7 @@ package com.oracle.javafx.scenebuilder.kit.skeleton;
 import java.net.URL;
 import java.util.ResourceBundle;
 import javafx.fxml.FXML;
+import javafx.scene.control.TableView;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.VBox;
 
@@ -18,6 +19,9 @@ public class EmptyController {
     @FXML // URL location of the FXML file that was given to the FXMLLoader
     private URL location;
 
+    @FXML // fx:id="myTableView"
+    private TableView<?> myTableView; // Value injected by FXMLLoader
+
     @FXML // fx:id="myVbox"
     private VBox myVbox; // Value injected by FXMLLoader
 
@@ -28,6 +32,7 @@ public class EmptyController {
 
     @FXML // This method is called by the FXMLLoader when initialization is complete
     void initialize() {
+        assert myTableView != null : "fx:id=\"myTableView\" was not injected: check your FXML file 'test'.";
         assert myVbox != null : "fx:id=\"myVbox\" was not injected: check your FXML file 'test'.";
 
     }

--- a/kit/src/test/resources/com/oracle/javafx/scenebuilder/kit/skeleton/skeleton_java_nested.txt
+++ b/kit/src/test/resources/com/oracle/javafx/scenebuilder/kit/skeleton/skeleton_java_nested.txt
@@ -1,0 +1,19 @@
+import javafx.fxml.FXML;
+import javafx.scene.control.TableView;
+import javafx.scene.input.MouseEvent;
+import javafx.scene.layout.VBox;
+
+public static class InnerController {
+
+    @FXML
+    private TableView<?> myTableView;
+
+    @FXML
+    private VBox myVbox;
+
+    @FXML
+    void onMyVboxMouseEntered(MouseEvent event) {
+
+    }
+
+}

--- a/kit/src/test/resources/com/oracle/javafx/scenebuilder/kit/skeleton/skeleton_kotlin_comments.txt
+++ b/kit/src/test/resources/com/oracle/javafx/scenebuilder/kit/skeleton/skeleton_kotlin_comments.txt
@@ -1,0 +1,21 @@
+/**
+ * Sample Skeleton for 'test' Controller Class
+ */
+
+package com.oracle.javafx.scenebuilder.kit.skeleton
+
+import javafx.fxml.FXML
+import javafx.scene.input.MouseEvent
+import javafx.scene.layout.VBox
+
+class EmptyController {
+
+    @FXML // fx:id="myVbox"
+    private lateinit var myVbox: VBox // Value injected by FXMLLoader
+
+    @FXML
+    fun onMyVboxMouseEntered(event: MouseEvent) {
+
+    }
+
+}

--- a/kit/src/test/resources/com/oracle/javafx/scenebuilder/kit/skeleton/skeleton_kotlin_comments.txt
+++ b/kit/src/test/resources/com/oracle/javafx/scenebuilder/kit/skeleton/skeleton_kotlin_comments.txt
@@ -5,10 +5,14 @@
 package com.oracle.javafx.scenebuilder.kit.skeleton
 
 import javafx.fxml.FXML
+import javafx.scene.control.TableView
 import javafx.scene.input.MouseEvent
 import javafx.scene.layout.VBox
 
 class EmptyController {
+
+    @FXML // fx:id="myTableView"
+    private lateinit var myTableView: TableView<Any> // Value injected by FXMLLoader
 
     @FXML // fx:id="myVbox"
     private lateinit var myVbox: VBox // Value injected by FXMLLoader

--- a/kit/src/test/resources/com/oracle/javafx/scenebuilder/kit/skeleton/skeleton_kotlin_full.txt
+++ b/kit/src/test/resources/com/oracle/javafx/scenebuilder/kit/skeleton/skeleton_kotlin_full.txt
@@ -1,0 +1,31 @@
+package com.oracle.javafx.scenebuilder.kit.skeleton
+
+import java.net.URL
+import java.util.ResourceBundle
+import javafx.fxml.FXML
+import javafx.scene.input.MouseEvent
+import javafx.scene.layout.VBox
+
+class EmptyController {
+
+    @FXML
+    private lateinit var resources: ResourceBundle
+
+    @FXML
+    private lateinit var location: URL
+
+    @FXML
+    private lateinit var myVbox: VBox
+
+    @FXML
+    fun onMyVboxMouseEntered(event: MouseEvent) {
+
+    }
+
+    @FXML
+    fun initialize() {
+        assert(myVbox != null) {"fx:id=\"myVbox\" was not injected: check your FXML file 'test'." }
+
+    }
+
+}

--- a/kit/src/test/resources/com/oracle/javafx/scenebuilder/kit/skeleton/skeleton_kotlin_full.txt
+++ b/kit/src/test/resources/com/oracle/javafx/scenebuilder/kit/skeleton/skeleton_kotlin_full.txt
@@ -3,6 +3,7 @@ package com.oracle.javafx.scenebuilder.kit.skeleton
 import java.net.URL
 import java.util.ResourceBundle
 import javafx.fxml.FXML
+import javafx.scene.control.TableView
 import javafx.scene.input.MouseEvent
 import javafx.scene.layout.VBox
 
@@ -15,6 +16,9 @@ class EmptyController {
     private lateinit var location: URL
 
     @FXML
+    private lateinit var myTableView: TableView<Any>
+
+    @FXML
     private lateinit var myVbox: VBox
 
     @FXML
@@ -24,6 +28,7 @@ class EmptyController {
 
     @FXML
     fun initialize() {
+        assert(myTableView != null) {"fx:id=\"myTableView\" was not injected: check your FXML file 'test'." }
         assert(myVbox != null) {"fx:id=\"myVbox\" was not injected: check your FXML file 'test'." }
 
     }

--- a/kit/src/test/resources/com/oracle/javafx/scenebuilder/kit/skeleton/skeleton_kotlin_full_comments.txt
+++ b/kit/src/test/resources/com/oracle/javafx/scenebuilder/kit/skeleton/skeleton_kotlin_full_comments.txt
@@ -7,6 +7,7 @@ package com.oracle.javafx.scenebuilder.kit.skeleton
 import java.net.URL
 import java.util.ResourceBundle
 import javafx.fxml.FXML
+import javafx.scene.control.TableView
 import javafx.scene.input.MouseEvent
 import javafx.scene.layout.VBox
 
@@ -18,6 +19,9 @@ class EmptyController {
     @FXML // URL location of the FXML file that was given to the FXMLLoader
     private lateinit var location: URL
 
+    @FXML // fx:id="myTableView"
+    private lateinit var myTableView: TableView<Any> // Value injected by FXMLLoader
+
     @FXML // fx:id="myVbox"
     private lateinit var myVbox: VBox // Value injected by FXMLLoader
 
@@ -28,6 +32,7 @@ class EmptyController {
 
     @FXML // This method is called by the FXMLLoader when initialization is complete
     fun initialize() {
+        assert(myTableView != null) {"fx:id=\"myTableView\" was not injected: check your FXML file 'test'." }
         assert(myVbox != null) {"fx:id=\"myVbox\" was not injected: check your FXML file 'test'." }
 
     }

--- a/kit/src/test/resources/com/oracle/javafx/scenebuilder/kit/skeleton/skeleton_kotlin_full_comments.txt
+++ b/kit/src/test/resources/com/oracle/javafx/scenebuilder/kit/skeleton/skeleton_kotlin_full_comments.txt
@@ -1,0 +1,35 @@
+/**
+ * Sample Skeleton for 'test' Controller Class
+ */
+
+package com.oracle.javafx.scenebuilder.kit.skeleton
+
+import java.net.URL
+import java.util.ResourceBundle
+import javafx.fxml.FXML
+import javafx.scene.input.MouseEvent
+import javafx.scene.layout.VBox
+
+class EmptyController {
+
+    @FXML // ResourceBundle that was given to the FXMLLoader
+    private lateinit var resources: ResourceBundle
+
+    @FXML // URL location of the FXML file that was given to the FXMLLoader
+    private lateinit var location: URL
+
+    @FXML // fx:id="myVbox"
+    private lateinit var myVbox: VBox // Value injected by FXMLLoader
+
+    @FXML
+    fun onMyVboxMouseEntered(event: MouseEvent) {
+
+    }
+
+    @FXML // This method is called by the FXMLLoader when initialization is complete
+    fun initialize() {
+        assert(myVbox != null) {"fx:id=\"myVbox\" was not injected: check your FXML file 'test'." }
+
+    }
+
+}

--- a/kit/src/test/resources/com/oracle/javafx/scenebuilder/kit/skeleton/skeleton_kotlin_nested.txt
+++ b/kit/src/test/resources/com/oracle/javafx/scenebuilder/kit/skeleton/skeleton_kotlin_nested.txt
@@ -1,0 +1,19 @@
+import javafx.fxml.FXML
+import javafx.scene.control.TableView
+import javafx.scene.input.MouseEvent
+import javafx.scene.layout.VBox
+
+class InnerController {
+
+    @FXML
+    private lateinit var myTableView: TableView<Any>
+
+    @FXML
+    private lateinit var myVbox: VBox
+
+    @FXML
+    fun onMyVboxMouseEntered(event: MouseEvent) {
+
+    }
+
+}


### PR DESCRIPTION
Adds support to create a skeleton for Kotlin.

A major refactoring of the SkeletonBuffer was necessary:
- split up into "construct" phase (SkeletonBuffer, which constructs a context for SkeletonCreator) and "create" phase (SkeletonCreator)
- create phase has no side-effects (everything is now determined from the given input)
- Kotlin and Java are two different create-phases
- added tests that validate the whole skeleton (until now only the "package" line was validated for Java)
- more tests verifying the whole skeleton could be added easily (e.g. for Java, too)

### Issue

Fixes #259 

### Progress

- [x] Change must not contain extraneous whitespace
- [x] License header year is updated, if required
- [x] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)
