### PR TITLE
Update release workflows to use Java 16

### DIFF
--- a/.github/workflows/kit.yml
+++ b/.github/workflows/kit.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup java
         uses: joschi/setup-jdk@v2
         with:
-          java-version: 15
+          java-version: 16
       - name: Store Variables
         id: variables
         run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup java
         uses: joschi/setup-jdk@v2
         with:
-          java-version: 15
+          java-version: 16
       - name: Store Variables
         id: variables
         run: |

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Setup java
         uses: joschi/setup-jdk@v2
         with:
-          java-version: 15
+          java-version: 16
       - uses: Apple-Actions/import-codesign-certs@v1
         with:
           p12-file-base64: ${{ secrets.CERTIFICATES_FILE_BASE64 }}

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup java
         uses: joschi/setup-jdk@v2
         with:
-          java-version: 15
+          java-version: 16
       - name: Store Variables
         id: variables
         run: |


### PR DESCRIPTION
Use Java 16 to build and release Scene Builder

### Progress

- [x] Change must not contain extraneous whitespace
- [x] License header year is updated, if required
- [x] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)