### PR TITLE
The Library Manager ListView is now backed by a SortedList.

### DIFF
--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/manager/DialogListItemComparator.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/manager/DialogListItemComparator.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2021, Gluon and/or its affiliates.
+ * All rights reserved. Use is subject to license terms.
+ *
+ * This file is available and licensed under the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the distribution.
+ *  - Neither the name of Oracle Corporation and Gluon nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.oracle.javafx.scenebuilder.kit.editor.panel.library.manager;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+
+class DialogListItemComparator implements Comparator<DialogListItem> {
+
+    @Override
+    public int compare(DialogListItem a, DialogListItem b) {
+
+        if (a instanceof ArtifactDialogListItem && b instanceof ArtifactDialogListItem) {            
+            return compareUsingArtifactCoordinates((ArtifactDialogListItem) a, (ArtifactDialogListItem) b);
+        }
+
+        if (a instanceof LibraryDialogListItem && b instanceof LibraryDialogListItem) {            
+            return compareUsingPaths((LibraryDialogListItem) a, (LibraryDialogListItem) b);
+        }
+
+        if (a instanceof LibraryDialogListItem) {
+            return -1;            
+        } else {            
+            return 1;
+        }
+    }
+
+    private int compareUsingArtifactCoordinates(ArtifactDialogListItem a, ArtifactDialogListItem b) {
+        return a.getCoordinates().compareTo(b.getCoordinates());
+    }
+
+    private int compareUsingPaths(LibraryDialogListItem a, LibraryDialogListItem b) {
+
+        Path first = a.getFilePath();
+        Path second = b.getFilePath();
+
+        if (Files.isDirectory(first) && Files.isRegularFile(second)) {            
+            return -1;
+        }
+
+        if (Files.isRegularFile(first) && Files.isDirectory(second)) {            
+            return 1;
+        }
+
+        return first.compareTo(second);
+    }
+
+}

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/manager/LibraryDialogController.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/manager/LibraryDialogController.java
@@ -180,6 +180,7 @@ public class LibraryDialogController extends AbstractFxmlWindowController {
                 .collect(Collectors.toList()));
         
         libraryListView.getSelectionModel().selectFirst();
+        libraryListView.requestFocus();
     }
 
     @FXML

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/manager/LibraryDialogController.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/manager/LibraryDialogController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017 Gluon and/or its affiliates.
+ * Copyright (c) 2016, 2021, Gluon and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -66,6 +66,7 @@ import javafx.beans.InvalidationListener;
 import javafx.beans.Observable;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import javafx.collections.transformation.SortedList;
 import javafx.fxml.FXML;
 import javafx.scene.control.Hyperlink;
 import javafx.scene.control.ListView;
@@ -147,7 +148,10 @@ public class LibraryDialogController extends AbstractFxmlWindowController {
             listItems = FXCollections.observableArrayList();
         }
         listItems.clear();
-        libraryListView.setItems(listItems);
+        
+        SortedList<DialogListItem> sortedItems = listItems.sorted(new DialogListItemComparator());
+        libraryListView.setItems(sortedItems);
+        libraryListView.getSelectionModel().selectFirst();
         libraryListView.setCellFactory(param -> new LibraryDialogListCell());
         
         final Path folder = Paths.get(this.userLibrary.getPath());
@@ -179,7 +183,7 @@ public class LibraryDialogController extends AbstractFxmlWindowController {
 
     @FXML
     private void close() {
-        libraryListView.getItems().clear();
+        listItems.clear();
         closeWindow();
     }
 

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/manager/LibraryDialogController.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/manager/LibraryDialogController.java
@@ -151,7 +151,6 @@ public class LibraryDialogController extends AbstractFxmlWindowController {
         
         SortedList<DialogListItem> sortedItems = listItems.sorted(new DialogListItemComparator());
         libraryListView.setItems(sortedItems);
-        libraryListView.getSelectionModel().selectFirst();
         libraryListView.setCellFactory(param -> new LibraryDialogListCell());
         
         final Path folder = Paths.get(this.userLibrary.getPath());
@@ -179,6 +178,8 @@ public class LibraryDialogController extends AbstractFxmlWindowController {
                 .stream()
                 .map(c -> new ArtifactDialogListItem(this, c))
                 .collect(Collectors.toList()));
+        
+        libraryListView.getSelectionModel().selectFirst();
     }
 
     @FXML

--- a/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/manager/DialogListItemComparatorTest.java
+++ b/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/manager/DialogListItemComparatorTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2021, Gluon and/or its affiliates.
+ * All rights reserved. Use is subject to license terms.
+ *
+ * This file is available and licensed under the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the distribution.
+ *  - Neither the name of Oracle Corporation and Gluon nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.oracle.javafx.scenebuilder.kit.editor.panel.library.manager;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.Test;
+
+public class DialogListItemComparatorTest {
+
+    private DialogListItemComparator classUnderTest = new DialogListItemComparator();
+
+    @Test
+    public void testSortingOrArifactItems() {
+
+        DialogListItem artifactItem = new ArtifactDialogListItem(null, "net.somegroup.package:myArtifact:0.1.17");
+        DialogListItem actuallySameItem = new ArtifactDialogListItem(null, "net.somegroup.package:myArtifact:0.1.17");
+
+        DialogListItem otherRevisionItem = new ArtifactDialogListItem(null, "net.somegroup.package:myArtifact:0.2.17");
+        DialogListItem commercialItem = new ArtifactDialogListItem(null, "com.acme.main:business:4.0");
+
+        assertTrue(classUnderTest.compare(artifactItem, otherRevisionItem) < 0);
+        assertTrue(classUnderTest.compare(artifactItem, commercialItem) > 0);
+        assertEquals(0, classUnderTest.compare(artifactItem, actuallySameItem));
+
+    }
+
+    @Test
+    public void testLibraryDirectoriesPreceedFiles() throws Exception {
+
+        URL resource = getClass().getClassLoader().getResource("libraryManager/Empty-Dummy-Library.jar");
+        Path libFile = Paths.get(resource.toURI());
+        Path libDir = libFile.getParent();
+
+        DialogListItem libraryFileItem = new LibraryDialogListItem(null, libFile);
+        DialogListItem libraryDirItem = new LibraryDialogListItem(null, libDir);
+
+        assertTrue(classUnderTest.compare(libraryDirItem, libraryFileItem) < 0);
+        assertTrue(classUnderTest.compare(libraryFileItem, libraryDirItem) > 0);
+
+    }
+
+    @Test
+    public void testLibraryFilesPreceedArtifacts() {
+
+        DialogListItem artifactItem = new ArtifactDialogListItem(null, "net.somegroup.package:myArtifact:0.1.17");
+        DialogListItem libraryFileItem = new LibraryDialogListItem(null,
+                Paths.get("c:/mylibrary/my-special-controls.jar"));
+
+        assertEquals(1, classUnderTest.compare(artifactItem, libraryFileItem));
+        assertEquals(-1, classUnderTest.compare(libraryFileItem, artifactItem));
+
+    }
+
+    @Test
+    public void testLibraryDirectoriesAreSortedCorrectly() throws Exception {
+
+        URL resource = getClass().getClassLoader().getResource("libraryManager/Empty-Dummy-Library.jar");
+        Path libDir = Paths.get(resource.toURI()).getParent();
+        Path parentLibDir = libDir.getParent();
+
+        DialogListItem secondDir = new LibraryDialogListItem(null, libDir);
+        DialogListItem firstDir = new LibraryDialogListItem(null, parentLibDir);
+
+        assertTrue(classUnderTest.compare(secondDir, firstDir) > 0);
+        assertTrue(classUnderTest.compare(firstDir, secondDir) < 0);
+
+    }
+
+    @Test
+    public void testLibraryFilesAreSortedCorrectly() throws Exception {
+
+        URL resource = getClass().getClassLoader().getResource("libraryManager/Empty-Dummy-Library.jar");
+        Path libFile = Paths.get(resource.toURI());
+
+        DialogListItem fileItem = new LibraryDialogListItem(null, libFile);
+
+        assertEquals(0, classUnderTest.compare(fileItem, fileItem));
+
+    }
+
+}


### PR DESCRIPTION
<!--- Provide a brief summary of the PR -->

### Issue #324

The Library Manager ListView is now backed by a SortedList.
A specific comparator class has been created which puts directories at first, then files, then Maven coordinates.
The sorting on files is performed with Path.compare() and for Maven coordinate comparison String comparison is used.

For the sake of testing, a resource (empty file serving as jar) has been added. With that it can be ensured that the test works on an existing file and existing folder, so that the behaviour of folders first/then files/then Maven coordinates can be tested.

### Progress

- [x] Change must not contain extraneous whitespace
- [X] License header year is updated, if required
- [x] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)