### PR TITLE
Fix some Maven compile warnings

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -52,7 +52,7 @@
                                 </excludes>
                             </artifactSet>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
-                            <outputFile>target/lib/scenebuilder-${version}-all.jar</outputFile>
+                            <outputFile>target/lib/scenebuilder-${project.version}-all.jar</outputFile>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <mainClass>${main.class.name}</mainClass>

--- a/kit/pom.xml
+++ b/kit/pom.xml
@@ -105,6 +105,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
+                <version>3.2.0</version>
                 <configuration>
                     <finalName>scenebuilder-kit-${project.version}</finalName>
                     <outputDirectory>target/lib</outputDirectory>

--- a/kit/pom.xml
+++ b/kit/pom.xml
@@ -106,7 +106,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
-                    <finalName>scenebuilder-kit-${version}</finalName>
+                    <finalName>scenebuilder-kit-${project.version}</finalName>
                     <outputDirectory>target/lib</outputDirectory>
                     <archive>
                         <manifestEntries>


### PR DESCRIPTION
Fixes some warnings during the Maven build process:

```
$ mvn clean package
[INFO] Scanning for projects...
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for com.gluonhq.scenebuilder:kit:jar:16.0.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ line 105, column 21
[WARNING] The expression ${version} is deprecated. Please use ${project.version} instead.
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for com.gluonhq.scenebuilder:app:jar:16.0.0-SNAPSHOT
[WARNING] The expression ${version} is deprecated. Please use ${project.version} instead.
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]
```

### Issue
None.

### Progress

- [x] Change must not contain extraneous whitespace
- [x] License header year is updated, if required
- [x] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)