### PR TITLE
Updated instruction in README how to execute Scene Builder using Maven.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,16 @@ It will create a partial shadow cross-platform jar under `app/target/lib/scenebu
 
 ### How to run Scene Builder ###
 
-You can run it with Maven:
+Before starting the app, all dependencies must be installed locally.
+This is achieved by:
+
+`mvn install`
+
+Then Scene Builder can be started with Maven:
 
 `mvn javafx:run -f app`
 
-or you can run the partial shadow jar, providing you have downloaded the JavaFX SDK from [here](https://gluonhq.com/products/javafx/):
+Alternatively, you can run the partial shadow jar, providing you have downloaded the JavaFX SDK from [here](https://gluonhq.com/products/javafx/):
 
 ```
 java 


### PR DESCRIPTION
Updated Readme.md in order to provide correct instruction how to run Scene Builder using Maven.

### Issue

Fixes #348 

### Progress

- [x] Change must not contain extraneous whitespace
- [x] License header year is updated, if required
- [x] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)