### PR TITLE
Add release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,5 @@
+exclude-labels:
+  - 'housekeeping'
+template: |
+  ## What’s Changed
+  $CHANGES

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,3 +32,10 @@ jobs:
           vncserver :90 -localhost -nolisten tcp
           mvn clean verify -X
           vncserver -kill :90
+
+      - name: Draft release
+        if: github.ref == 'refs/heads/master'
+        # Drafts your next Release notes as Pull Requests are merged into "master"
+        uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Automates release notes from PR. Each time a PR is merged into the master branch, it is added to the release notes in Github Release.

Example: https://github.com/gluonhq/substrate/releases