### PR TITLE
AbstractSkeletonCreator subclasses create now consistent line endings.

### DIFF
--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/AbstractSkeletonCreator.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/AbstractSkeletonCreator.java
@@ -40,7 +40,7 @@ import java.util.ResourceBundle;
 
 abstract class AbstractSkeletonCreator {
 
-    static final String NL = "\n"; //System.lineSeparator();
+    static final String NL = System.lineSeparator();
     static final String INDENT = "    "; //NOI18N
     static final String FXML_ANNOTATION = "@FXML";
 

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/AbstractSkeletonCreator.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/AbstractSkeletonCreator.java
@@ -40,7 +40,7 @@ import java.util.ResourceBundle;
 
 abstract class AbstractSkeletonCreator {
 
-    static final String NL = System.lineSeparator();
+    static final String NL = "\n"; //System.lineSeparator();
     static final String INDENT = "    "; //NOI18N
     static final String FXML_ANNOTATION = "@FXML";
 

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonContext.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonContext.java
@@ -175,7 +175,7 @@ class SkeletonContext {
         }
 
         private void buildAndCollectImports() {
-            imports.add(ImportBuilder.build());
+            imports.addAll(ImportBuilder.build());
             ImportBuilder.reset();
         }
 

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreatorJava.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreatorJava.java
@@ -47,7 +47,7 @@ public class SkeletonCreatorJava extends AbstractSkeletonCreator {
     @Override
     void appendImports(SkeletonContext context, StringBuilder sb) {
         for (String importStatement : context.getImports()) {
-            sb.append(importStatement);
+            sb.append(importStatement).append(";").append(NL);
         }
     }
 

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreatorKotlin.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreatorKotlin.java
@@ -47,9 +47,7 @@ public class SkeletonCreatorKotlin extends AbstractSkeletonCreator {
     @Override
     void appendImports(SkeletonContext context, StringBuilder sb) {
         for (String importStatement : context.getImports()) {
-            // importStatement built with ImportBuilder.build() contains ';' at the end
-            String kotlinImport = importStatement.replaceAll(";", "");
-            sb.append(kotlinImport);
+            sb.append(importStatement).append(NL);
         }
     }
 

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/util/eventnames/ImportBuilder.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/util/eventnames/ImportBuilder.java
@@ -86,8 +86,8 @@ public class ImportBuilder {
      */
     public static List<String> build() {
         return imports.entrySet()
-               .stream()
-               .map(preparedImport->preparedImport.getKey()+preparedImport.getValue())
-               .collect(Collectors.toList());
+                      .stream()
+                      .map(preparedImport->preparedImport.getKey()+preparedImport.getValue())
+                      .collect(Collectors.toList());
     }
 }

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/util/eventnames/ImportBuilder.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/util/eventnames/ImportBuilder.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright (c) 2021, Gluon and/or its affiliates.
+ * All rights reserved. Use is subject to license terms.
+ *
+ * This file is available and licensed under the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the distribution.
+ *  - Neither the name of Oracle Corporation nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.oracle.javafx.scenebuilder.kit.util.eventnames;
 
 import java.util.List;

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/util/eventnames/ImportBuilder.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/util/eventnames/ImportBuilder.java
@@ -87,7 +87,7 @@ public class ImportBuilder {
     public static List<String> build() {
         return imports.entrySet()
                       .stream()
-                      .map(preparedImport->preparedImport.getKey()+preparedImport.getValue())
+                      .map(preparedImport -> preparedImport.getKey() + preparedImport.getValue())
                       .collect(Collectors.toList());
     }
 }

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/util/eventnames/ImportBuilder.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/util/eventnames/ImportBuilder.java
@@ -1,7 +1,9 @@
 package com.oracle.javafx.scenebuilder.kit.util.eventnames;
 
+import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.stream.Collectors;
 
 /**
  * Builds an import statement as a key/value pair.
@@ -46,18 +48,15 @@ public class ImportBuilder {
     }
 
     /**
-     * Builds a new import statement. The key may be the "import" keyword, or the "import" keyword combined with a
+     * Builds the list of import statements. The key may be the "import" keyword, or the "import" keyword combined with a
      * "javafx.scene.input." package name. The value may be a full class name (e.g. with package) or an input event name.
      *
-     * @return new import statement
+     * @return list of new import statements
      */
-    public static String build() {
-        StringBuilder sb = new StringBuilder();
-        imports.forEach((key, value) -> {
-            sb.append(key);
-            sb.append(value);
-            sb.append(";\n");
-        });
-        return sb.toString();
+    public static List<String> build() {
+        return imports.entrySet()
+               .stream()
+               .map(imprt->imprt.getKey()+imprt.getValue())
+               .collect(Collectors.toList());
     }
 }

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/util/eventnames/ImportBuilder.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/util/eventnames/ImportBuilder.java
@@ -87,7 +87,7 @@ public class ImportBuilder {
     public static List<String> build() {
         return imports.entrySet()
                .stream()
-               .map(imprt->imprt.getKey()+imprt.getValue())
+               .map(preparedImport->preparedImport.getKey()+preparedImport.getValue())
                .collect(Collectors.toList());
     }
 }

--- a/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonBufferTest.java
+++ b/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonBufferTest.java
@@ -54,7 +54,7 @@ public class SkeletonBufferTest {
         String skeleton = skeletonBuffer.toString();
 
         // then
-        String firstLine = skeleton.substring(0, skeleton.indexOf(System.lineSeparator()));
+        String firstLine = skeleton.substring(0, skeleton.indexOf(AbstractSkeletonCreator.NL));
         assertEquals("", firstLine);
     }
 
@@ -67,7 +67,7 @@ public class SkeletonBufferTest {
         String skeleton = skeletonBuffer.toString();
 
         // then
-        String firstLine = skeleton.substring(0, skeleton.indexOf(System.lineSeparator()));
+        String firstLine = skeleton.substring(0, skeleton.indexOf(AbstractSkeletonCreator.NL));
         assertEquals("package com;", firstLine);
     }
 
@@ -80,7 +80,7 @@ public class SkeletonBufferTest {
         String skeleton = skeletonBuffer.toString();
 
         // then
-        String firstLine = skeleton.substring(0, skeleton.indexOf(System.lineSeparator()));
+        String firstLine = skeleton.substring(0, skeleton.indexOf(AbstractSkeletonCreator.NL));
         assertEquals("package com.example.app.view;", firstLine);
     }
 

--- a/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonBufferTest.java
+++ b/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonBufferTest.java
@@ -54,7 +54,7 @@ public class SkeletonBufferTest {
         String skeleton = skeletonBuffer.toString();
 
         // then
-        String firstLine = skeleton.substring(0, skeleton.indexOf("\n"));
+        String firstLine = skeleton.substring(0, skeleton.indexOf(System.lineSeparator()));
         assertEquals("", firstLine);
     }
 
@@ -67,7 +67,7 @@ public class SkeletonBufferTest {
         String skeleton = skeletonBuffer.toString();
 
         // then
-        String firstLine = skeleton.substring(0, skeleton.indexOf("\n"));
+        String firstLine = skeleton.substring(0, skeleton.indexOf(System.lineSeparator()));
         assertEquals("package com;", firstLine);
     }
 
@@ -80,7 +80,7 @@ public class SkeletonBufferTest {
         String skeleton = skeletonBuffer.toString();
 
         // then
-        String firstLine = skeleton.substring(0, skeleton.indexOf("\n"));
+        String firstLine = skeleton.substring(0, skeleton.indexOf(System.lineSeparator()));
         assertEquals("package com.example.app.view;", firstLine);
     }
 


### PR DESCRIPTION
Fixes the broken tests for FXML controller sekeleton creation on Windows. 
Root cause was a hard coded `\n` in `ImportBuilder` class. The job of creating import lines for Kotlin and Java is now delegated to AbstractSkeletonCreator subclasses.

### Issue
<!--- The issue this PR addresses -->
Fixes #376

### Progress

- [ ] Change must not contain extraneous whitespace
- [ ] License header year is updated, if required
- [ ] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)