### PR TITLE
Custom 'java.library.path' for Linux packages to avoid startup issues

### DIFF
--- a/.github/scripts/jpackage.sh
+++ b/.github/scripts/jpackage.sh
@@ -18,6 +18,6 @@ $JPACKAGE_HOME/bin/jpackage \
 --vendor Gluon \
 --verbose \
 --runtime-image app/target/runtime \
---java-options "-Djava.library.path=$APPDIR/../runtime/bin:$APPDIR/../runtime/lib" \
+--java-options "-Djava.library.path=/opt/scenebuilder/lib/runtime/bin:/opt/scenebuilder/lib/runtime/lib" \
 --dest $INSTALL_DIR \
 "$@"

--- a/.github/scripts/jpackage.sh
+++ b/.github/scripts/jpackage.sh
@@ -18,6 +18,6 @@ $JPACKAGE_HOME/bin/jpackage \
 --vendor Gluon \
 --verbose \
 --runtime-image app/target/runtime \
---java-options "-Djava.library.path=lib/runtime/bin:lib/runtime/lib" \
+--java-options "-Djava.library.path=$APPDIR/../runtime/bin:$APPDIR/../runtime/lib" \
 --dest $INSTALL_DIR \
 "$@"

--- a/.github/scripts/jpackage.sh
+++ b/.github/scripts/jpackage.sh
@@ -18,6 +18,6 @@ $JPACKAGE_HOME/bin/jpackage \
 --vendor Gluon \
 --verbose \
 --runtime-image app/target/runtime \
+--java-options "-Djava.library.path=lib/runtime/bin:lib/runtime/lib" \
 --dest $INSTALL_DIR \
---java-options "-Djava.library.path=./runtime/bin;./runtime/lib" \
 "$@"

--- a/.github/scripts/jpackage.sh
+++ b/.github/scripts/jpackage.sh
@@ -18,6 +18,5 @@ $JPACKAGE_HOME/bin/jpackage \
 --vendor Gluon \
 --verbose \
 --runtime-image app/target/runtime \
---java-options "-Djava.library.path=/opt/scenebuilder/lib/runtime/bin:/opt/scenebuilder/lib/runtime/lib" \
 --dest $INSTALL_DIR \
 "$@"

--- a/.github/scripts/jpackage.sh
+++ b/.github/scripts/jpackage.sh
@@ -19,4 +19,5 @@ $JPACKAGE_HOME/bin/jpackage \
 --verbose \
 --runtime-image app/target/runtime \
 --dest $INSTALL_DIR \
+--java-options "-Djava.library.path=./runtime/bin;./runtime/lib" \
 "$@"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -47,6 +47,7 @@ jobs:
           --icon app/assets/linux/icon-linux.png \
           --java-options '"-Djdk.gtk.version=2"' \
           --java-options '"--add-opens=javafx.fxml/javafx.fxml=ALL-UNNAMED"' \
+          --java-options '"-Djava.library.path=/opt/scenebuilder/lib/runtime/bin:/opt/scenebuilder/lib/runtime/lib"' \
           --install-dir /opt \
           --type deb
           mv $INSTALL_DIR/*.deb $INSTALL_DIR/SceneBuilder-${{ env.TAG }}.deb

--- a/app/src/main/java/com/oracle/javafx/scenebuilder/app/about/AboutWindowController.java
+++ b/app/src/main/java/com/oracle/javafx/scenebuilder/app/about/AboutWindowController.java
@@ -143,15 +143,15 @@ public final class AboutWindowController extends AbstractFxmlWindowController {
     }
 
     private StringBuilder getApplicationDirectoriesParagraph() {
-        return new StringBuilder("Application Data Folder:")
+        return new StringBuilder(I18N.getString("about.app.data.directory"))
                 .append("\n\t") // NOI18N
                 .append(Paths.get(AppPlatform.getApplicationDataFolder()).normalize()) //NOI18N 
                 .append("\n\n") //NOI18N
-                .append("User Library Folder:")
+                .append(I18N.getString("about.app.user.library"))
                 .append("\n\t") //NOI18N
                 .append(Paths.get(AppPlatform.getUserLibraryFolder()).normalize()) //NOI18N
                 .append("\n\n") //NOI18N
-                .append("Application Directory:")
+                .append(I18N.getString("about.app.program.directory"))
                 .append("\n\t") //NOI18N
                 .append(Paths.get(".").toAbsolutePath().normalize()) //NOI18N
                 .append("\n\n"); //NOI18N
@@ -224,7 +224,8 @@ public final class AboutWindowController extends AbstractFxmlWindowController {
     }
     
     private StringBuilder getJavaLibraryPathParagraph() {
-        StringBuilder sb = new StringBuilder("Java Library Path(s):\n"); //NOI18N
+        StringBuilder sb = new StringBuilder(I18N.getString("about.java.library.paths"))
+                .append("\n"); //NOI18N
         String libPaths = System.getProperty("java.library.path"); //NOI18N
         List<String> invalidPaths = new ArrayList<>();
         String separator = getPathSeparator();
@@ -243,7 +244,8 @@ public final class AboutWindowController extends AbstractFxmlWindowController {
         }
         sb.append("\n");
         if (!invalidPaths.isEmpty()) {
-            sb.append("Missing or invalid Java Library Path(s): \n"); //NOI18N
+            sb.append(I18N.getString("about.java.library.paths.invalids")); //NOI18N
+            sb.append("\n");
             invalidPaths.forEach(invalidPath -> sb.append("\t").append(invalidPath).append("\n"));
             sb.append("\n");
         }

--- a/app/src/main/java/com/oracle/javafx/scenebuilder/app/about/AboutWindowController.java
+++ b/app/src/main/java/com/oracle/javafx/scenebuilder/app/about/AboutWindowController.java
@@ -63,7 +63,7 @@ public final class AboutWindowController extends AbstractFxmlWindowController {
     private GridPane vbox;
     @FXML
     private TextArea textArea;
-    
+
     private String sbBuildInfo;
     private String sbBuildVersion;
     private String sbBuildDate;
@@ -93,7 +93,7 @@ public final class AboutWindowController extends AbstractFxmlWindowController {
             // We go with default values
         }
     }
-    
+
     @FXML
     public void onMousePressed(MouseEvent event) {
         if ((event.getClickCount() == 2) && event.isAltDown()) {
@@ -140,7 +140,7 @@ public final class AboutWindowController extends AbstractFxmlWindowController {
         
         return text.toString();
     }
-    
+
     /**
      *
      * @treatAsPrivate
@@ -148,7 +148,7 @@ public final class AboutWindowController extends AbstractFxmlWindowController {
     public String getBuildJavaVersion() {
         return sbBuildJavaVersion;
     }
-    
+
     /**
      *
      * @treatAsPrivate
@@ -156,7 +156,7 @@ public final class AboutWindowController extends AbstractFxmlWindowController {
     public String getBuildInfo() {
         return sbBuildInfo;
     }
-    
+
     private StringBuilder getVersionParagraph() {
         StringBuilder sb = new StringBuilder(I18N.getString("about.product.version"));
         sb.append("\nJavaFX Scene Builder ").append(sbBuildVersion) //NOI18N
@@ -203,8 +203,7 @@ public final class AboutWindowController extends AbstractFxmlWindowController {
         StringBuilder sb = new StringBuilder("Java\n"); //NOI18N
         sb.append(System.getProperty("java.runtime.version")).append(", ") //NOI18N
                 .append(System.getProperty("java.vendor")) // NOI18N
-                .append("\n\n"); 
-        
+                .append("\n\n");
         return sb;
     }
     
@@ -232,7 +231,6 @@ public final class AboutWindowController extends AbstractFxmlWindowController {
             invalidPaths.forEach(invalidPath -> sb.append("\t").append(invalidPath).append("\n"));
             sb.append("\n");
         }
-
         return sb;
     }
 

--- a/app/src/main/java/com/oracle/javafx/scenebuilder/app/about/AboutWindowController.java
+++ b/app/src/main/java/com/oracle/javafx/scenebuilder/app/about/AboutWindowController.java
@@ -195,7 +195,11 @@ public final class AboutWindowController extends AbstractFxmlWindowController {
     private StringBuilder getJavaParagraph() {
         StringBuilder sb = new StringBuilder("Java\n"); //NOI18N
         sb.append(System.getProperty("java.runtime.version")).append(", ") //NOI18N
-                .append(System.getProperty("java.vendor")).append("\n\n"); //NOI18N
+                .append(System.getProperty("java.vendor")).append("\n") // NOI18N
+                .append("Java Library Path: ")
+                .append(System.getProperty("java.library.path")).append("\n\n"); //NOI18N
+        
+        ;
         return sb;
     }
     

--- a/app/src/main/java/com/oracle/javafx/scenebuilder/app/about/AboutWindowController.java
+++ b/app/src/main/java/com/oracle/javafx/scenebuilder/app/about/AboutWindowController.java
@@ -136,9 +136,25 @@ public final class AboutWindowController extends AbstractFxmlWindowController {
                 .append(getJavaParagraph())
                 .append(getJavaLibraryPathParagraph())
                 .append(getOsParagraph())
+                .append(getApplicationDirectoriesParagraph())
                 .append(I18N.getString(sbAboutCopyrightKeyName));
         
         return text.toString();
+    }
+
+    private StringBuilder getApplicationDirectoriesParagraph() {
+        return new StringBuilder("Application Data Folder:")
+                .append("\n\t") // NOI18N
+                .append(Paths.get(AppPlatform.getApplicationDataFolder()).normalize()) //NOI18N 
+                .append("\n\n") //NOI18N
+                .append("User Library Folder:")
+                .append("\n\t") //NOI18N
+                .append(Paths.get(AppPlatform.getUserLibraryFolder()).normalize()) //NOI18N
+                .append("\n\n") //NOI18N
+                .append("Application Directory:")
+                .append("\n\t") //NOI18N
+                .append(Paths.get(".").toAbsolutePath().normalize()) //NOI18N
+                .append("\n\n"); //NOI18N
     }
 
     /**

--- a/app/src/main/java/com/oracle/javafx/scenebuilder/app/about/AboutWindowController.java
+++ b/app/src/main/java/com/oracle/javafx/scenebuilder/app/about/AboutWindowController.java
@@ -210,16 +210,15 @@ public final class AboutWindowController extends AbstractFxmlWindowController {
     
     private StringBuilder getJavaLibraryPathParagraph() {
         StringBuilder sb = new StringBuilder("Java Library Path(s):\n"); //NOI18N
-        
-        String libPaths = System.getProperty("java.library.path");       //NOI18N
+        String libPaths = System.getProperty("java.library.path"); //NOI18N
         List<String> invalidPaths = new ArrayList<>();
         String separator = getPathSeparator();
         for (String libPath : libPaths.split(separator)) {
             try {
                 Path absolutePath = Paths.get(libPath).normalize().toAbsolutePath();
-                if (Files.exists(absolutePath)) {                    
+                if (Files.exists(absolutePath)) {
                     String path = absolutePath.toString();
-                    sb.append("\t").append(path).append("\n");           //NOI18N                      
+                    sb.append("\t").append(path).append("\n");
                 } else {
                     invalidPaths.add(libPath);
                 }
@@ -228,25 +227,23 @@ public final class AboutWindowController extends AbstractFxmlWindowController {
             }
         }
         sb.append("\n");
-        
         if (!invalidPaths.isEmpty()) {
             sb.append("Missing or invalid Java Library Path(s): ") //NOI18N
-              .append("\n"); 
-            
-            invalidPaths.forEach(invalidPath -> sb.append("\t")   //NOI18N
+              .append("\n");
+            invalidPaths.forEach(invalidPath -> sb.append("\t")
                                                   .append(invalidPath)
                                                   .append("\n"));
             sb.append("\n");
         }
-        
+
         return sb;
     }
-    
+
     private String getPathSeparator() {
         String os = System.getProperty("os.name").toLowerCase();
-        if (os.indexOf("win")>=0) {
-            return ";";            
-        } else {            
+        if (os.indexOf("win") >= 0) {
+            return ";";
+        } else {
             return ":";
         }
     }

--- a/app/src/main/java/com/oracle/javafx/scenebuilder/app/about/AboutWindowController.java
+++ b/app/src/main/java/com/oracle/javafx/scenebuilder/app/about/AboutWindowController.java
@@ -134,6 +134,7 @@ public final class AboutWindowController extends AbstractFxmlWindowController {
                 .append(getLoggingParagraph())
                 .append(getJavaFXParagraph())
                 .append(getJavaParagraph())
+                .append(getJavaLibraryPathParagraph())
                 .append(getOsParagraph())
                 .append(I18N.getString(sbAboutCopyrightKeyName));
         
@@ -201,19 +202,24 @@ public final class AboutWindowController extends AbstractFxmlWindowController {
     private StringBuilder getJavaParagraph() {
         StringBuilder sb = new StringBuilder("Java\n"); //NOI18N
         sb.append(System.getProperty("java.runtime.version")).append(", ") //NOI18N
-                .append(System.getProperty("java.vendor")).append("\n") // NOI18N
-                .append("Java Library Path(s): ").append("\n");
+                .append(System.getProperty("java.vendor")) // NOI18N
+                .append("\n\n"); 
         
+        return sb;
+    }
+    
+    private StringBuilder getJavaLibraryPathParagraph() {
+        StringBuilder sb = new StringBuilder("Java Library Path(s):\n"); //NOI18N
+        
+        String libPaths = System.getProperty("java.library.path");       //NOI18N
         List<String> invalidPaths = new ArrayList<>();
-        String libPaths = System.getProperty("java.library.path");
-        
         String separator = getPathSeparator();
         for (String libPath : libPaths.split(separator)) {
             try {
                 Path absolutePath = Paths.get(libPath).normalize().toAbsolutePath();
                 if (Files.exists(absolutePath)) {                    
                     String path = absolutePath.toString();
-                    sb.append("\t").append(path).append("\n");                            
+                    sb.append("\t").append(path).append("\n");           //NOI18N                      
                 } else {
                     invalidPaths.add(libPath);
                 }
@@ -224,8 +230,12 @@ public final class AboutWindowController extends AbstractFxmlWindowController {
         sb.append("\n");
         
         if (!invalidPaths.isEmpty()) {
-            sb.append("Missing or invalid Java Library Path(s): ").append("\n");
-            invalidPaths.forEach(invalidPath -> sb.append("\t").append(invalidPath).append("\n"));
+            sb.append("Missing or invalid Java Library Path(s): ") //NOI18N
+              .append("\n"); 
+            
+            invalidPaths.forEach(invalidPath -> sb.append("\t")   //NOI18N
+                                                  .append(invalidPath)
+                                                  .append("\n"));
             sb.append("\n");
         }
         
@@ -234,9 +244,11 @@ public final class AboutWindowController extends AbstractFxmlWindowController {
     
     private String getPathSeparator() {
         String os = System.getProperty("os.name").toLowerCase();
-        if (os.indexOf("win")>=0)
-            return ";";
-        return ":";
+        if (os.indexOf("win")>=0) {
+            return ";";            
+        } else {            
+            return ":";
+        }
     }
 
     private StringBuilder getOsParagraph() {

--- a/app/src/main/java/com/oracle/javafx/scenebuilder/app/about/AboutWindowController.java
+++ b/app/src/main/java/com/oracle/javafx/scenebuilder/app/about/AboutWindowController.java
@@ -228,11 +228,8 @@ public final class AboutWindowController extends AbstractFxmlWindowController {
         }
         sb.append("\n");
         if (!invalidPaths.isEmpty()) {
-            sb.append("Missing or invalid Java Library Path(s): ") //NOI18N
-              .append("\n");
-            invalidPaths.forEach(invalidPath -> sb.append("\t")
-                                                  .append(invalidPath)
-                                                  .append("\n"));
+            sb.append("Missing or invalid Java Library Path(s): \n"); //NOI18N
+            invalidPaths.forEach(invalidPath -> sb.append("\t").append(invalidPath).append("\n"));
             sb.append("\n");
         }
 

--- a/app/src/main/resources/com/oracle/javafx/scenebuilder/app/i18n/SceneBuilderApp.properties
+++ b/app/src/main/resources/com/oracle/javafx/scenebuilder/app/i18n/SceneBuilderApp.properties
@@ -1,4 +1,4 @@
-# Copyright (c) 2016, 2019, 2021, Gluon and/or its affiliates.
+# Copyright (c) 2016, 2021, Gluon and/or its affiliates.
 # Copyright (c) 2012, 2014, Oracle and/or its affiliates.
 # All rights reserved. Use is subject to license terms.
 #
@@ -304,7 +304,7 @@ about.app.data.directory = Application Data Folder:
 about.app.user.library = User Library Folder:
 about.app.program.directory = Application Folder:
 
-about.java.library.paths = Java Library Path(s): 
+about.java.library.paths = Java Library Path(s):
 about.java.library.paths.invalids = Missing or invalid Java Library Path(s):
 
 # -----------------------------------------------------------------------------

--- a/app/src/main/resources/com/oracle/javafx/scenebuilder/app/i18n/SceneBuilderApp.properties
+++ b/app/src/main/resources/com/oracle/javafx/scenebuilder/app/i18n/SceneBuilderApp.properties
@@ -1,4 +1,4 @@
-# Copyright (c) 2016, 2019, Gluon and/or its affiliates.
+# Copyright (c) 2016, 2019, 2021, Gluon and/or its affiliates.
 # Copyright (c) 2012, 2014, Oracle and/or its affiliates.
 # All rights reserved. Use is subject to license terms.
 #

--- a/app/src/main/resources/com/oracle/javafx/scenebuilder/app/i18n/SceneBuilderApp.properties
+++ b/app/src/main/resources/com/oracle/javafx/scenebuilder/app/i18n/SceneBuilderApp.properties
@@ -300,6 +300,13 @@ about.logging.body.second = The default file path is {0}
 about.operating.system = Operating System
 about.product.version = Product Version
 
+about.app.data.directory = Application Data Folder:
+about.app.user.library = User Library Folder:
+about.app.program.directory = Application Folder:
+
+about.java.library.paths = Java Library Path(s): 
+about.java.library.paths.invalids = Missing or invalid Java Library Path(s):
+
 # -----------------------------------------------------------------------------
 # Themes
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
<!--- Provide a brief summary of the PR -->

### Issue

In some cases, due to library path pollution by old JDK/JavaFX installations, startup of Scene Builder after installation from DEB or RPM package will fail. Thus, instead going with default `java.library.path` setting, a custom `java.library.path` is provided in the `jpackage.sh` script file.

The text in the About dialog has been updated in order to show effective `java.library.path` configuration (incl. configured but missing or invalid directories). The dialog text shows only normalized absolute paths.

<!--- The issue this PR addresses -->
Fixes #362


### Progress

- [x] Change must not contain extraneous whitespace
- [x] License header year is updated, if required
- [x] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)