### PR TITLE
Added a "save as" function for the controller skeleton preview.

### DIFF
--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonFileNameProposal.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonFileNameProposal.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2021, Gluon and/or its affiliates.
+ * All rights reserved. Use is subject to license terms.
+ *
+ * This file is available and licensed under the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the distribution.
+ *  - Neither the name of Oracle Corporation and Gluon nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.javafx.scenebuilder.kit.skeleton;
+
+import java.io.File;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+/**
+ * 
+ * Provides logic to create a proposal for a controller skeleton file for a
+ * given language.
+ * 
+ * The proposal is created based on the actual fxmlLocation and the 
+ * fxController name.
+ *
+ * <ol>
+ * <li>undefined fxmlLocation and fxControllerName: - users directory with
+ * PleaseProvideControllerClassName.java or PleaseProvideControllerClassName.kt.
+ * 
+ * <li>undefined fxControllerName but known fxmlLocation: - the name of the FXML
+ * file (e.g. MyView.fxml) changed to MyViewController.fxml.
+ * 
+ * <li>undefined fxControllerName but known fxmlLocation, FXML stored in
+ * src/main/resources: - for MyView.fxml and Java, the result would be
+ * src/main/java/MyViewController.java, for Kotlin it would be
+ * src/main/kotlin/MyViewController.kt
+ *   
+ * <li>controller name (e.g. MyController) defined and known fxmlLocation: - the
+ * file would be MyController.java or MyController.kt at the place where the
+ * FXML is stored - the proposal is also adjusted to reside in src/main/language
+ * if possible.
+ * <li>A provided controller name is always preferred over an adjusted FXML file
+ * name.
+ * </ol>
+ * 
+ * If the language specific directory does not exist, the original location is 
+ * used with an adjusted file name.
+ * 
+ */
+class SkeletonFileNameProposal {
+
+    private static final String DEFAULT_CONTROLLER_CLASS_NAME = "PleaseProvideControllerClassName";
+    private final SkeletonSettings.LANGUAGE language;
+
+    public SkeletonFileNameProposal(SkeletonSettings.LANGUAGE language) {
+        this.language = language;
+    }
+
+    /**
+     * Creates a controller skeleton file name proposal depending on values for
+     * fxmlLocation and fxControllerName.
+     * 
+     * @param fxmlLocation     The location of the FXML file in works. In case the
+     *                         file has not been saved, this location will be null.
+     * @param fxControllerName This is usually the name of the controller as defined
+     *                         in the FXML file. If no controller name has been
+     *                         given, this value might be null
+     * @return file name proposal
+     */
+    public File create(URL fxmlLocation, String fxControllerName) {
+        if (fxControllerName == null || fxControllerName.isBlank()) {
+            if (null != fxmlLocation) {
+                File controllerAtFxmlLocation = createFileAccordingToFxml(fxmlLocation);
+                return adjustToSrcMainDirWhenPossible(controllerAtFxmlLocation);
+            }
+        } else {
+            File fromControllerName = createFileFromControllerName(fxmlLocation, fxControllerName);
+            return adjustToSrcMainDirWhenPossible(fromControllerName);
+        }
+        return createFileInUsersDir();
+    }
+
+    private File adjustToSrcMainDirWhenPossible(File controllerAtFxmlLocation) {
+        String location = controllerAtFxmlLocation.toPath().toString().replace('\\', '/');
+        /*
+         * TODO: Discuss if this is a good function or not and if it is worth adding "src/test" to the source packages as
+         * well. This strongly depends on how users work with SceneBuilder.
+         * 
+         */
+        List<Path> sourcePackages = List.of(Paths.get("src/main"));
+        for (Path sourcePackage : sourcePackages) {
+            String resources = resolvePath(sourcePackage, "resources");
+            String java      = resolvePath(sourcePackage, "java");
+            String kotlin    = resolvePath(sourcePackage, "kotlin");
+            if (location.contains(resources)) {
+                switch (language) {
+                case JAVA:
+                    location = location.replace(resources, java);
+                    break;
+                case KOTLIN:
+                    location = location.replace(resources, kotlin);
+                    break;
+                }
+            }
+        }
+        File adjustedLocation = new File(location); 
+        if (Files.exists(adjustedLocation.toPath().getParent())) {
+            return adjustedLocation;
+        }
+        return controllerAtFxmlLocation;
+    }
+    
+    private String resolvePath(Path source, String child) {
+        return source.resolve(child)
+                     .toString()
+                     .replace('\\', '/');
+    }
+
+    private File createFileFromControllerName(URL fxmlLocation, String fxControllerName) {
+        String directory = obtainUserDirectory();
+        if (null != fxmlLocation) {
+            URI uri = resolveURI(fxmlLocation);
+            Path location = Paths.get(uri).toAbsolutePath().getParent();
+            if (Files.exists(location)) {
+                directory = location.toString();
+            }
+        }
+        String simpleControllerClassName = extractSimpleControllerName(fxControllerName);
+        String controllerFileName = simpleControllerClassName + language.getExtension();
+        return new File(directory, controllerFileName);
+    }
+
+    private URI resolveURI(URL fxmlLocation) {
+        try {
+            return fxmlLocation.toURI();
+        } catch (URISyntaxException e) {
+            File usersDir = new File(obtainUserDirectory()).getAbsoluteFile();
+            return usersDir.toURI();
+        }
+    }
+
+    private File createFileAccordingToFxml(URL fxmlLocation) {
+        URI  uri = resolveURI(fxmlLocation);
+        Path fxmlFile = Paths.get(uri);        
+        String fxmlResource = fxmlFile.toString();
+        String controllerSuffix = "Controller" + language.getExtension();
+        int lastDot = fxmlResource.lastIndexOf('.');
+        if (lastDot > -1) {
+            String newFileName = fxmlResource.substring(0, lastDot) + controllerSuffix;
+            return Paths.get(newFileName).toFile();
+        }
+
+        return Paths.get(fxmlResource + controllerSuffix).toFile();
+
+    }
+
+    private File createFileInUsersDir() {
+        String fileName = DEFAULT_CONTROLLER_CLASS_NAME + language.getExtension();
+        String usersDirectory = obtainUserDirectory();
+        return buildFileName(usersDirectory, fileName);
+    }
+
+    private String obtainUserDirectory() {
+        return System.getProperty("user.home");
+    }
+
+    private File buildFileName(String usersDirectory, String fileName) {
+        return Paths.get(usersDirectory, fileName).normalize().toAbsolutePath().toFile();
+    }
+
+    /*
+     * TODO: Consider moving this into a shared place as this code snippet is used multiple times.
+     * 
+     */
+    private String extractSimpleControllerName(String fxControllerName) {
+        String simpleName = fxControllerName.replace("$", "."); // NOI18N
+        int dot = simpleName.lastIndexOf('.');
+        if (dot > -1) {
+            simpleName = simpleName.substring(dot + 1);
+        }
+        return simpleName;
+    }
+
+}

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonFileNameProposal.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonFileNameProposal.java
@@ -49,7 +49,7 @@ import java.util.List;
  * fxController name.
  *
  * <ol>
- * <li>undefined fxmlLocation and fxControllerName: - users directory with
+ * <li>undefined fxmlLocation and fxControllerName: - user directory with
  * PleaseProvideControllerClassName.java or PleaseProvideControllerClassName.kt.
  * 
  * <li>undefined fxControllerName but known fxmlLocation: - the name of the FXML
@@ -102,21 +102,16 @@ class SkeletonFileNameProposal {
             File fromControllerName = createFileFromControllerName(fxmlLocation, fxControllerName);
             return adjustToSrcMainDirWhenPossible(fromControllerName);
         }
-        return createFileInUsersDir();
+        return createFileInUserDir();
     }
 
     private File adjustToSrcMainDirWhenPossible(File controllerAtFxmlLocation) {
         String location = controllerAtFxmlLocation.toPath().toString().replace('\\', '/');
-        /*
-         * TODO: Discuss if this is a good function or not and if it is worth adding "src/test" to the source packages as
-         * well. This strongly depends on how users work with SceneBuilder.
-         * 
-         */
         List<Path> sourcePackages = List.of(Paths.get("src/main"));
         for (Path sourcePackage : sourcePackages) {
             String resources = resolvePath(sourcePackage, "resources");
-            String java      = resolvePath(sourcePackage, "java");
-            String kotlin    = resolvePath(sourcePackage, "kotlin");
+            String java = resolvePath(sourcePackage, "java");
+            String kotlin = resolvePath(sourcePackage, "kotlin");
             if (location.contains(resources)) {
                 switch (language) {
                 case JAVA:
@@ -159,8 +154,8 @@ class SkeletonFileNameProposal {
         try {
             return fxmlLocation.toURI();
         } catch (URISyntaxException e) {
-            File usersDir = new File(obtainUserDirectory()).getAbsoluteFile();
-            return usersDir.toURI();
+            File userDir = new File(obtainUserDirectory()).getAbsoluteFile();
+            return userDir.toURI();
         }
     }
 
@@ -179,18 +174,18 @@ class SkeletonFileNameProposal {
 
     }
 
-    private File createFileInUsersDir() {
+    private File createFileInUserDir() {
         String fileName = DEFAULT_CONTROLLER_CLASS_NAME + language.getExtension();
-        String usersDirectory = obtainUserDirectory();
-        return buildFileName(usersDirectory, fileName);
+        String userDirectory = obtainUserDirectory();
+        return buildFileName(userDirectory, fileName);
     }
 
     private String obtainUserDirectory() {
         return System.getProperty("user.home");
     }
 
-    private File buildFileName(String usersDirectory, String fileName) {
-        return Paths.get(usersDirectory, fileName).normalize().toAbsolutePath().toFile();
+    private File buildFileName(String userDirectory, String fileName) {
+        return Paths.get(userDirectory, fileName).normalize().toAbsolutePath().toFile();
     }
 
     /*

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonFileNameProposal.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonFileNameProposal.java
@@ -161,7 +161,7 @@ class SkeletonFileNameProposal {
 
     private File createFileAccordingToFxml(URL fxmlLocation) {
         URI  uri = resolveURI(fxmlLocation);
-        Path fxmlFile = Paths.get(uri);        
+        Path fxmlFile = Paths.get(uri);
         String fxmlResource = fxmlFile.toString();
         String controllerSuffix = "Controller" + language.getExtension();
         int lastDot = fxmlResource.lastIndexOf('.');

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonFileWriter.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonFileWriter.java
@@ -1,0 +1,265 @@
+/*
+ * Copyright (c) 2021, Gluon and/or its affiliates.
+ * All rights reserved. Use is subject to license terms.
+ *
+ * This file is available and licensed under the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the distribution.
+ *  - Neither the name of Oracle Corporation and Gluon nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.javafx.scenebuilder.kit.skeleton;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javafx.beans.property.ReadOnlyStringProperty;
+import javafx.stage.FileChooser;
+import javafx.stage.FileChooser.ExtensionFilter;
+import javafx.stage.Stage;
+
+final class SkeletonFileWriter {
+
+    private final Supplier<Stage> stageSupplier;
+
+    private final Map<SkeletonSettings.LANGUAGE, File> savedFilePerLanguage;
+    
+    private final Map<SkeletonSettings.LANGUAGE, ExtensionFilter> extensionFilterByLanguage;
+    
+    private final BiFunction<FileChooser,Stage,File> saveDialogInteraction;
+    
+    private final Function<Supplier<Stage>,Consumer<File>> onSuccess;
+    
+    private final Function<Supplier<Stage>,BiConsumer<File, Exception>> onError;
+       
+    private SkeletonSettings.LANGUAGE language;
+    
+    private URL fxmlLocation;
+
+    private String controllerName;
+
+    private FileChooser saveFileChooser;
+    
+    private ReadOnlyStringProperty textProperty;   
+
+    /**
+     * Provides the option to save a controller skeleton to a file considering
+     * language specifics.
+     * 
+     * @param stageSupplier As a file chooser and alerts are used, the reference to
+     *                      the parent stage is required. Must not be null.
+     * @param textProperty  The contents of the file is read from this property.
+     *                      Must not be null.
+     * 
+     */
+    public SkeletonFileWriter(Supplier<Stage> stageSupplier, ReadOnlyStringProperty textProperty) {
+        this(stageSupplier, textProperty, (fileChooser,stage)->fileChooser.showSaveDialog(stage),
+                SkeletonFileWriterSuccessAlert::new, SkeletonFileWriterErrorAlert::new);    
+    }
+    
+    /**
+     * This constructor only exists for the purpose of testing. It allows to replace
+     * the way how the file chooser interaction is handled. Also it allows to replace
+     * the GUI interaction using alerts with custom logic for testing.
+     * 
+     * @param stageSupplier         As a file chooser and alerts are used, the
+     *                              reference to the parent stage is required. Must
+     *                              not be null.
+     * @param textProperty          The contents of the file is read from this
+     *                              property. Must not be null.
+     * @param saveDialogInteraction Allows to replace the dialog interaction with
+     *                              the file chooser with custom functionality (e.g.
+     *                              for testing).
+     * @param onSuccessNotify       This parameter provides the notification which
+     *                              is raised in case of successfully writing the
+     *                              skeleton file.
+     * @param onErrorNotify         This parameter provides the notification which
+     *                              is raised in case of an exception during an
+     *                              attempt to write the skeleton file.
+     */
+    protected SkeletonFileWriter(Supplier<Stage> stageSupplier, ReadOnlyStringProperty textProperty, 
+                                 BiFunction<FileChooser,Stage,File> saveDialogInteraction, 
+                                 Function<Supplier<Stage>,Consumer<File>> onSuccessNotify,
+                                 Function<Supplier<Stage>,BiConsumer<File, Exception>> onErrorNotify) {
+        this.stageSupplier = Objects.requireNonNull(stageSupplier);
+        this.textProperty = Objects.requireNonNull(textProperty);
+        this.saveDialogInteraction = Objects.requireNonNull(saveDialogInteraction);
+        this.onSuccess = Objects.requireNonNull(onSuccessNotify);
+        this.onError   = Objects.requireNonNull(onErrorNotify);
+        this.savedFilePerLanguage = new EnumMap<>(SkeletonSettings.LANGUAGE.class);
+        this.extensionFilterByLanguage = new EnumMap<>(SkeletonSettings.LANGUAGE.class);     
+    }
+
+
+    /**
+     * Prepares a language specific file name proposal for a controller skeleton
+     * file. Then, a file chooser is shown to allow adjustments to the proposed file
+     * name. Finally, the contents of the provided textProperty is saved to the
+     * file. In case of success, a message is shown - same applies for the error
+     * case.
+     * 
+     * The file name proposal is based on values of fxmlLocation and fxControllerName.
+     * Once a filename has been defined, either by accepting the proposal or by 
+     * manually overriding it in the FileChooser, the filename will remain the one
+     * provided by the FileChooser. The accepted file name is remembered for each
+     * available language.
+     * 
+     * To create a new file name proposal, the FXML file must be closed and re-opened in
+     * SceneBuilder.
+     * 
+     * Please refer to {@link SkeletonFileNameProposal} for details.
+     * 
+     * 
+     * @param fxmlLocation     The location of the FXML file in works. In case the
+     *                         file has not been saved, this location will be null.
+     * @param fxControllerName This is usually the name of the controller as defined
+     *                         in the FXML file. If no controller name has been
+     *                         given, this value might be null
+     * @param language         The language is required in order to adjust file naming
+     *                         according to language specific rules. Must not be null.
+     */
+    public void run(URL fxmlLocation, String fxControllerName, SkeletonSettings.LANGUAGE language) {
+        this.fxmlLocation = fxmlLocation;
+        this.controllerName = fxControllerName;
+        this.language = Objects.requireNonNull(language);
+        createFileChooserWhenNeeded();
+        /*
+         * TODO: Ask user if a corresponding directory src/main/java or 
+         * src/main/kotlin shall be created if it does not exist.
+         * 
+         */
+        File fileToSave = determineSaveFileName();
+        updateFileChooser(fileToSave);        
+        saveToFileWhenConfirmed();
+    }
+    
+    /**
+     * This method allows to verify which files have been previously saved per language.
+     *  
+     * @return The map of the previously saved file per language.
+     */
+    Map<SkeletonSettings.LANGUAGE,File> getLastSavedFilesPerLanguage() {
+        return Collections.unmodifiableMap(savedFilePerLanguage);
+    }
+    
+    /**
+     * @return the defined notification function for the success case.
+     */
+    Function<Supplier<Stage>, Consumer<File>> getOnSuccess() {
+        return onSuccess;
+    }
+
+    /**
+     * @return the effectively defined error handling function. 
+     */
+    Function<Supplier<Stage>, BiConsumer<File, Exception>> getOnError() {
+        return onError;
+    }
+
+    private void saveToFileWhenConfirmed() {
+        File confirmedSavedFile = saveDialogInteraction.apply(saveFileChooser, stageSupplier.get());
+        if (null != confirmedSavedFile) {
+            updateFileChooserAndSave(confirmedSavedFile);
+        }
+    }
+
+    private File determineSaveFileName() {
+        File fileToSave = savedFilePerLanguage.get(language);
+        if (fileToSave == null) {
+            fileToSave = new SkeletonFileNameProposal(language).create(fxmlLocation, controllerName);
+        }
+        return fileToSave;
+    }
+
+    private void createFileChooserWhenNeeded() {
+        if (saveFileChooser == null) {
+            saveFileChooser = new FileChooser(); 
+            createExtensionFilters();
+        }
+    }
+
+    private void createExtensionFilters() {
+        for (SkeletonSettings.LANGUAGE lang : SkeletonSettings.LANGUAGE.values()) {
+            ExtensionFilter filter = new ExtensionFilter(lang.toString(), "*"+lang.getExtension());
+            extensionFilterByLanguage.put(lang, filter);
+            saveFileChooser.getExtensionFilters().add(filter);
+        }
+    }
+
+    private void updateFileChooser(File fileToSave) {
+        saveFileChooser.setInitialDirectory(fileToSave.getParentFile());
+        saveFileChooser.setInitialFileName(fileToSave.getName());
+        saveFileChooser.setSelectedExtensionFilter(extensionFilterByLanguage.get(language));
+    }
+    
+    private void updateFileChooserAndSave(File savedFile) {
+        updateFileChooser(savedFile);
+        rememberLastSavedFilePerLanguage(savedFile);
+        saveToFile(savedFile.toPath().toAbsolutePath());
+    }
+
+    private void rememberLastSavedFilePerLanguage(File savedFile) {
+        savedFilePerLanguage.put(language, savedFile);
+    }
+
+    private void saveToFile(Path skeletonFile) {
+        try {
+            writeSkeletonFileAndNotifyUser(skeletonFile);
+        } catch (IOException error) {
+            logErrorAndNotifyUser(skeletonFile, error);
+        }
+    }
+
+    private void writeSkeletonFileAndNotifyUser(Path skeletonFile) throws IOException {
+        String skeleton = textProperty.getValueSafe();
+        OpenOption openOption = Files.exists(skeletonFile) ? StandardOpenOption.TRUNCATE_EXISTING : StandardOpenOption.CREATE_NEW;
+        Files.write(skeletonFile, skeleton.getBytes(), openOption);        
+        onSuccess.apply(stageSupplier)
+                 .accept(skeletonFile.toFile());
+    }
+    
+    private void logErrorAndNotifyUser(Path skeletonFile, IOException error) {
+        onError.apply(stageSupplier)
+               .accept(skeletonFile.toFile(),error);
+        Logger logger = Logger.getLogger(SkeletonFileWriter.class.getSimpleName());
+        String template = "Could not write controller skeleton to file: %s .";
+        logger.log(Level.SEVERE, String.format(template, skeletonFile.normalize().toAbsolutePath()), error);
+    }
+}

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonFileWriter.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonFileWriter.java
@@ -60,24 +60,18 @@ final class SkeletonFileWriter {
     private final Supplier<Stage> stageSupplier;
 
     private final Map<SkeletonSettings.LANGUAGE, File> savedFilePerLanguage;
-    
     private final Map<SkeletonSettings.LANGUAGE, ExtensionFilter> extensionFilterByLanguage;
-    
+
     private final BiFunction<FileChooser,Stage,File> saveDialogInteraction;
-    
+
     private final Function<Supplier<Stage>,Consumer<File>> onSuccess;
-    
     private final Function<Supplier<Stage>,BiConsumer<File, Exception>> onError;
-       
+
     private SkeletonSettings.LANGUAGE language;
-    
     private URL fxmlLocation;
-
     private String controllerName;
-
     private FileChooser saveFileChooser;
-    
-    private ReadOnlyStringProperty textProperty;   
+    private ReadOnlyStringProperty textProperty;
 
     /**
      * Provides the option to save a controller skeleton to a file considering
@@ -90,10 +84,10 @@ final class SkeletonFileWriter {
      * 
      */
     public SkeletonFileWriter(Supplier<Stage> stageSupplier, ReadOnlyStringProperty textProperty) {
-        this(stageSupplier, textProperty, (fileChooser,stage)->fileChooser.showSaveDialog(stage),
-                SkeletonFileWriterSuccessAlert::new, SkeletonFileWriterErrorAlert::new);    
+        this(stageSupplier, textProperty, (fileChooser,stage) -> fileChooser.showSaveDialog(stage),
+                SkeletonFileWriterSuccessAlert::new, SkeletonFileWriterErrorAlert::new);
     }
-    
+
     /**
      * This constructor only exists for the purpose of testing. It allows to replace
      * the way how the file chooser interaction is handled. Also it allows to replace
@@ -114,8 +108,8 @@ final class SkeletonFileWriter {
      *                              is raised in case of an exception during an
      *                              attempt to write the skeleton file.
      */
-    protected SkeletonFileWriter(Supplier<Stage> stageSupplier, ReadOnlyStringProperty textProperty, 
-                                 BiFunction<FileChooser,Stage,File> saveDialogInteraction, 
+    protected SkeletonFileWriter(Supplier<Stage> stageSupplier, ReadOnlyStringProperty textProperty,
+                                 BiFunction<FileChooser,Stage,File> saveDialogInteraction,
                                  Function<Supplier<Stage>,Consumer<File>> onSuccessNotify,
                                  Function<Supplier<Stage>,BiConsumer<File, Exception>> onErrorNotify) {
         this.stageSupplier = Objects.requireNonNull(stageSupplier);
@@ -124,7 +118,7 @@ final class SkeletonFileWriter {
         this.onSuccess = Objects.requireNonNull(onSuccessNotify);
         this.onError   = Objects.requireNonNull(onErrorNotify);
         this.savedFilePerLanguage = new EnumMap<>(SkeletonSettings.LANGUAGE.class);
-        this.extensionFilterByLanguage = new EnumMap<>(SkeletonSettings.LANGUAGE.class);     
+        this.extensionFilterByLanguage = new EnumMap<>(SkeletonSettings.LANGUAGE.class);
     }
 
 
@@ -163,13 +157,12 @@ final class SkeletonFileWriter {
         /*
          * TODO: Ask user if a corresponding directory src/main/java or 
          * src/main/kotlin shall be created if it does not exist.
-         * 
          */
         File fileToSave = determineSaveFileName();
-        updateFileChooser(fileToSave);        
+        updateFileChooser(fileToSave);
         saveToFileWhenConfirmed();
     }
-    
+
     /**
      * This method allows to verify which files have been previously saved per language.
      *  
@@ -178,7 +171,7 @@ final class SkeletonFileWriter {
     Map<SkeletonSettings.LANGUAGE,File> getLastSavedFilesPerLanguage() {
         return Collections.unmodifiableMap(savedFilePerLanguage);
     }
-    
+
     /**
      * @return the defined notification function for the success case.
      */
@@ -228,7 +221,7 @@ final class SkeletonFileWriter {
         saveFileChooser.setInitialFileName(fileToSave.getName());
         saveFileChooser.setSelectedExtensionFilter(extensionFilterByLanguage.get(language));
     }
-    
+
     private void updateFileChooserAndSave(File savedFile) {
         updateFileChooser(savedFile);
         rememberLastSavedFilePerLanguage(savedFile);
@@ -250,11 +243,11 @@ final class SkeletonFileWriter {
     private void writeSkeletonFileAndNotifyUser(Path skeletonFile) throws IOException {
         String skeleton = textProperty.getValueSafe();
         OpenOption openOption = Files.exists(skeletonFile) ? StandardOpenOption.TRUNCATE_EXISTING : StandardOpenOption.CREATE_NEW;
-        Files.write(skeletonFile, skeleton.getBytes(), openOption);        
+        Files.write(skeletonFile, skeleton.getBytes(), openOption);
         onSuccess.apply(stageSupplier)
                  .accept(skeletonFile.toFile());
     }
-    
+
     private void logErrorAndNotifyUser(Path skeletonFile, IOException error) {
         onError.apply(stageSupplier)
                .accept(skeletonFile.toFile(),error);

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonFileWriterErrorAlert.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonFileWriterErrorAlert.java
@@ -57,7 +57,7 @@ import javafx.stage.Stage;
 final class SkeletonFileWriterErrorAlert implements BiConsumer<File, Exception> {
 
     private final Supplier<Stage> stageSupplier;
-    
+
     /**
      * Creates a bi-consumer which accepts a file and an exception
      * so that an appropriate error message can be presented to the
@@ -68,7 +68,7 @@ final class SkeletonFileWriterErrorAlert implements BiConsumer<File, Exception> 
     SkeletonFileWriterErrorAlert(Supplier<Stage> stageSupplier) {
         this.stageSupplier = Objects.requireNonNull(stageSupplier);
     }
-    
+
     @Override
     public void accept(File skeletonFile, Exception error) {
         SBAlert alert = prepareErrorAlert(skeletonFile, error);
@@ -81,7 +81,7 @@ final class SkeletonFileWriterErrorAlert implements BiConsumer<File, Exception> 
         alert.getDialogPane().setExpandableContent(textArea);
         Platform.runLater(()->alert.showAndWait());
     }
-    
+
     private SBAlert prepareErrorAlert(File skeletonFile, Exception error) {
         var alert = new SBAlert(AlertType.ERROR, stageSupplier.get());
         alert.setTitle(I18N.getString("alert.skeleton.title"));
@@ -91,7 +91,7 @@ final class SkeletonFileWriterErrorAlert implements BiConsumer<File, Exception> 
                             + error.getLocalizedMessage());
         return alert;
     }
-    
+
     private String collectExceptionDetails(Exception error) {
         StringWriter stringWriter = new StringWriter();
         PrintWriter printWriter = new PrintWriter(stringWriter);

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonFileWriterErrorAlert.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonFileWriterErrorAlert.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2021, Gluon and/or its affiliates.
+ * All rights reserved. Use is subject to license terms.
+ *
+ * This file is available and licensed under the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the distribution.
+ *  - Neither the name of Oracle Corporation and Gluon nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.javafx.scenebuilder.kit.skeleton;
+
+import java.io.File;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Objects;
+import java.util.function.BiConsumer;
+import java.util.function.Supplier;
+
+import com.oracle.javafx.scenebuilder.kit.alert.SBAlert;
+import com.oracle.javafx.scenebuilder.kit.i18n.I18N;
+
+import javafx.application.Platform;
+import javafx.scene.control.Alert.AlertType;
+import javafx.scene.control.TextArea;
+import javafx.stage.Stage;
+
+/**
+ * This class provides an alert for the case that a controller skeleton
+ * cannot be written into a file.
+ * 
+ * The alert provides the actual file name, the error message and the
+ * exception stack trace inside the expandable pane.
+ *
+ */
+final class SkeletonFileWriterErrorAlert implements BiConsumer<File, Exception> {
+
+    private final Supplier<Stage> stageSupplier;
+    
+    /**
+     * Creates a bi-consumer which accepts a file and an exception
+     * so that an appropriate error message can be presented to the
+     * user.
+     *  
+     * @param stageSupplier Reference to the parent JavaFX window
+     */
+    SkeletonFileWriterErrorAlert(Supplier<Stage> stageSupplier) {
+        this.stageSupplier = Objects.requireNonNull(stageSupplier);
+    }
+    
+    @Override
+    public void accept(File skeletonFile, Exception error) {
+        SBAlert alert = prepareErrorAlert(skeletonFile, error);
+        String exceptionDetails = collectExceptionDetails(error);
+        TextArea textArea = new TextArea(exceptionDetails);
+        textArea.setEditable(false);
+        textArea.setWrapText(true);
+        textArea.setMaxWidth(Double.MAX_VALUE);
+        textArea.setMaxHeight(Double.MAX_VALUE);
+        alert.getDialogPane().setExpandableContent(textArea);
+        Platform.runLater(()->alert.showAndWait());
+    }
+    
+    private SBAlert prepareErrorAlert(File skeletonFile, Exception error) {
+        var alert = new SBAlert(AlertType.ERROR, stageSupplier.get());
+        alert.setTitle(I18N.getString("alert.skeleton.title"));
+        alert.setHeaderText(I18N.getString("alert.skeleton.header.failed"));
+        alert.setContentText(I18N.getString("alert.skeleton.saving.failed")+"\n"
+                            + skeletonFile + "\n\n" 
+                            + error.getLocalizedMessage());
+        return alert;
+    }
+    
+    private String collectExceptionDetails(Exception error) {
+        StringWriter stringWriter = new StringWriter();
+        PrintWriter printWriter = new PrintWriter(stringWriter);
+        error.printStackTrace(printWriter);
+        return stringWriter.toString();
+    }
+
+}

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonFileWriterSuccessAlert.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonFileWriterSuccessAlert.java
@@ -63,7 +63,7 @@ import javafx.stage.Stage;
 final class SkeletonFileWriterSuccessAlert implements Consumer<File> {
 
     private final Supplier<Stage> stageSupplier;
-    
+
     /**
      * Creates a consumer which accepts the written file so
      * that an appropriate notification can be presented
@@ -74,7 +74,7 @@ final class SkeletonFileWriterSuccessAlert implements Consumer<File> {
     SkeletonFileWriterSuccessAlert(Supplier<Stage> stageSupplier) {
         this.stageSupplier = Objects.requireNonNull(stageSupplier);
     }
-    
+
     @Override
     public void accept(File fileWritten) {
         var alert = prepareSuccessAlert();
@@ -85,17 +85,16 @@ final class SkeletonFileWriterSuccessAlert implements Consumer<File> {
         HBox hbox = new HBox(textField,copyButton);
         HBox.setHgrow(textField, Priority.ALWAYS);
         dialogPane.setContent(hbox);
-        Platform.runLater(()->alert.showAndWait());
-        
+        Platform.runLater(() -> alert.showAndWait());
     }
-    
+
     private SBAlert prepareSuccessAlert() {
         var alert = new SBAlert(AlertType.INFORMATION, stageSupplier.get());
         alert.setTitle(I18N.getString("alert.skeleton.title"));
         alert.setHeaderText(I18N.getString("alert.skeleton.header.success"));
         return alert;
     }
-    
+
     private Button createCopyToClipboardButton(TextField textField) {
         SVGPath clipboardIcon = new SVGPath();
         clipboardIcon.setContent("M11.983,1.973L11.983,12.001L3.935,12.001L3.935,1.973L3.319,1.973C2.577,1.973 1.975,2.575 1.975,3.317L1.975,12.684C1.975,13.426 2.577,14.029 3.319,14.029L12.644,14.029C13.386,14.029 13.989,13.426 13.989,12.684L13.989,3.317C13.989,2.575 13.386,1.973 12.644,1.973L11.983,1.973ZM10.959,0.997L4.965,0.997L4.965,5.018L10.959,5.018L10.959,0.997ZM10.021,3.948L10.038,3.948L10.038,1.932L6.016,1.932L6.016,3.948L6.034,3.948L6.034,4.005L10.021,4.005L10.021,3.948Z");

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonFileWriterSuccessAlert.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonFileWriterSuccessAlert.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2021, Gluon and/or its affiliates.
+ * All rights reserved. Use is subject to license terms.
+ *
+ * This file is available and licensed under the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the distribution.
+ *  - Neither the name of Oracle Corporation and Gluon nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.javafx.scenebuilder.kit.skeleton;
+
+import java.io.File;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import com.oracle.javafx.scenebuilder.kit.alert.SBAlert;
+import com.oracle.javafx.scenebuilder.kit.i18n.I18N;
+
+import javafx.application.Platform;
+import javafx.scene.control.Alert.AlertType;
+import javafx.scene.control.Button;
+import javafx.scene.control.DialogPane;
+import javafx.scene.control.TextField;
+import javafx.scene.control.Tooltip;
+import javafx.scene.input.Clipboard;
+import javafx.scene.input.DataFormat;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+import javafx.scene.shape.SVGPath;
+import javafx.stage.Stage;
+/**
+ * When a controller skeleton file has been successfully saved as file,
+ * this class provides an alert which shows the file name (incl. path)
+ * inside a text field. A button with a copy to clip board icon 
+ * is placed right next to the text field. If clicked, the content of
+ * the text field is copied into the system clip board.
+ *  
+ */
+final class SkeletonFileWriterSuccessAlert implements Consumer<File> {
+
+    private final Supplier<Stage> stageSupplier;
+    
+    /**
+     * Creates a consumer which accepts the written file so
+     * that an appropriate notification can be presented
+     * to the user.
+     *  
+     * @param stageSupplier Reference to the parent JavaFX window
+     */
+    SkeletonFileWriterSuccessAlert(Supplier<Stage> stageSupplier) {
+        this.stageSupplier = Objects.requireNonNull(stageSupplier);
+    }
+    
+    @Override
+    public void accept(File fileWritten) {
+        var alert = prepareSuccessAlert();
+        DialogPane dialogPane = alert.getDialogPane();
+        TextField textField = new TextField(fileWritten.toString());
+        textField.setEditable(false);
+        Button copyButton = createCopyToClipboardButton(textField);
+        HBox hbox = new HBox(textField,copyButton);
+        HBox.setHgrow(textField, Priority.ALWAYS);
+        dialogPane.setContent(hbox);
+        Platform.runLater(()->alert.showAndWait());
+        
+    }
+    
+    private SBAlert prepareSuccessAlert() {
+        var alert = new SBAlert(AlertType.INFORMATION, stageSupplier.get());
+        alert.setTitle(I18N.getString("alert.skeleton.title"));
+        alert.setHeaderText(I18N.getString("alert.skeleton.header.success"));
+        return alert;
+    }
+    
+    private Button createCopyToClipboardButton(TextField textField) {
+        SVGPath clipboardIcon = new SVGPath();
+        clipboardIcon.setContent("M11.983,1.973L11.983,12.001L3.935,12.001L3.935,1.973L3.319,1.973C2.577,1.973 1.975,2.575 1.975,3.317L1.975,12.684C1.975,13.426 2.577,14.029 3.319,14.029L12.644,14.029C13.386,14.029 13.989,13.426 13.989,12.684L13.989,3.317C13.989,2.575 13.386,1.973 12.644,1.973L11.983,1.973ZM10.959,0.997L4.965,0.997L4.965,5.018L10.959,5.018L10.959,0.997ZM10.021,3.948L10.038,3.948L10.038,1.932L6.016,1.932L6.016,3.948L6.034,3.948L6.034,4.005L10.021,4.005L10.021,3.948Z");
+        Button copyButton = new Button(null, clipboardIcon);
+        copyButton.setTooltip(new Tooltip(I18N.getString("alert.skeleton.copy2clipboard")));
+        copyButton.setOnAction(event -> Clipboard.getSystemClipboard()
+                  .setContent(Map.of(DataFormat.PLAIN_TEXT, textField.getText())));
+        return copyButton;
+    }
+
+}

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonSettings.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonSettings.java
@@ -41,7 +41,6 @@ class SkeletonSettings {
         JAVA("Java", ".java"), KOTLIN("Kotlin", ".kt");
 
         private final String name;
-
         private final String ext;
 
         LANGUAGE(String name, String fileNameExt) {

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonWindowController.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonWindowController.java
@@ -84,16 +84,15 @@ public class SkeletonWindowController extends AbstractFxmlWindowController {
 
     @FXML
     private void onSaveAction(ActionEvent event) {
-        
+
         if (skeletonFileWriter == null) {           
-            skeletonFileWriter = new SkeletonFileWriter(()->getStage(), textArea.textProperty());
+            skeletonFileWriter = new SkeletonFileWriter(() -> getStage(), textArea.textProperty());
         }
-        
+
         SkeletonSettings.LANGUAGE language = languageChoiceBox.getSelectionModel()
                                                               .getSelectedItem();
-        
+
         skeletonFileWriter.run(editorController.getFxmlLocation(), controllerName, language);
-        
     }
 
     private final EditorController editorController;
@@ -191,11 +190,9 @@ public class SkeletonWindowController extends AbstractFxmlWindowController {
             }
 
             /*
-             * 
              * TODO: Discuss, if this is the correct way to obtain the FxController.
              * As of now, the code to extract the controller class name would exist on
              * 3 different locations.
-             * 
              */
             controllerName = editorController.getFxomDocument().getFxomRoot().getFxController();
             textArea.setText(buf.toString());

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonWindowController.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonWindowController.java
@@ -32,10 +32,14 @@
  */
 package com.oracle.javafx.scenebuilder.kit.skeleton;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import com.oracle.javafx.scenebuilder.kit.editor.EditorController;
 import com.oracle.javafx.scenebuilder.kit.editor.panel.util.AbstractFxmlWindowController;
 import com.oracle.javafx.scenebuilder.kit.fxom.FXOMDocument;
 import com.oracle.javafx.scenebuilder.kit.i18n.I18N;
+
 import javafx.beans.InvalidationListener;
 import javafx.beans.value.ChangeListener;
 import javafx.event.ActionEvent;
@@ -47,9 +51,6 @@ import javafx.scene.input.Clipboard;
 import javafx.scene.input.DataFormat;
 import javafx.stage.Stage;
 import javafx.stage.WindowEvent;
-
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  *
@@ -65,6 +66,9 @@ public class SkeletonWindowController extends AbstractFxmlWindowController {
     @FXML
     TextArea textArea;
 
+    private String controllerName = null;
+    private SkeletonFileWriter skeletonFileWriter = null;
+
     @FXML
     private void onCopyAction(ActionEvent event) {
         final Map<DataFormat, Object> content = new HashMap<>();
@@ -76,6 +80,20 @@ public class SkeletonWindowController extends AbstractFxmlWindowController {
         }
 
         Clipboard.getSystemClipboard().setContent(content);
+    }
+
+    @FXML
+    private void onSaveAction(ActionEvent event) {
+        
+        if (skeletonFileWriter == null) {           
+            skeletonFileWriter = new SkeletonFileWriter(()->getStage(), textArea.textProperty());
+        }
+        
+        SkeletonSettings.LANGUAGE language = languageChoiceBox.getSelectionModel()
+                                                              .getSelectedItem();
+        
+        skeletonFileWriter.run(editorController.getFxmlLocation(), controllerName, language);
+        
     }
 
     private final EditorController editorController;
@@ -172,6 +190,14 @@ public class SkeletonWindowController extends AbstractFxmlWindowController {
                 buf.setFormat(SkeletonSettings.FORMAT_TYPE.COMPACT);
             }
 
+            /*
+             * 
+             * TODO: Discuss, if this is the correct way to obtain the FxController.
+             * As of now, the code to extract the controller class name would exist on
+             * 3 different locations.
+             * 
+             */
+            controllerName = editorController.getFxomDocument().getFxomRoot().getFxController();
             textArea.setText(buf.toString());
             dirty = false;
         } else {

--- a/kit/src/main/resources/com/oracle/javafx/scenebuilder/kit/alert/Alert.css
+++ b/kit/src/main/resources/com/oracle/javafx/scenebuilder/kit/alert/Alert.css
@@ -38,5 +38,5 @@
 
 .SB-alert.alert .label.content {
     -fx-background-color: #f6f6f7;
-    -fx-padding: 16 10 3em 10;
+    -fx-padding: 16 10 2em 10;
 }

--- a/kit/src/main/resources/com/oracle/javafx/scenebuilder/kit/alert/Alert.css
+++ b/kit/src/main/resources/com/oracle/javafx/scenebuilder/kit/alert/Alert.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Gluon and/or its affiliates.
+ * Copyright (c) 2017, 2021, Gluon and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:

--- a/kit/src/main/resources/com/oracle/javafx/scenebuilder/kit/i18n/SceneBuilderKit.properties
+++ b/kit/src/main/resources/com/oracle/javafx/scenebuilder/kit/i18n/SceneBuilderKit.properties
@@ -36,6 +36,7 @@ label.ok = OK
 label.cancel = Cancel
 label.close = Close
 label.copy = Copy
+label.save.as = Save as...
 
 label.action.edit.trim = Trim Document to Selection
 label.action.edit.delete.n = Delete {0} Objects
@@ -502,6 +503,13 @@ skeleton.empty = No skeleton can be constructed from an empty document
 skeleton.format.full = Full
 # Parameter is a fxml file name
 skeleton.window.title = Sample Skeleton for ''{0}'' Controller Class
+
+################ Alert for saving Skeletons to file
+alert.skeleton.title = Controller Skeleton
+alert.skeleton.header.success = The controller skeleton was successfully written!
+alert.skeleton.saving.failed = Could not write controller skeleton to file: 
+alert.skeleton.header.failed = An error has occurred!
+alert.skeleton.copy2clipboard = Copy to clipboard.
 
 ################# Templates Window
 template.dialog.title = Templates

--- a/kit/src/main/resources/com/oracle/javafx/scenebuilder/kit/i18n/SceneBuilderKit.properties
+++ b/kit/src/main/resources/com/oracle/javafx/scenebuilder/kit/i18n/SceneBuilderKit.properties
@@ -1,4 +1,4 @@
-# Copyright (c) 2016, 2020, Gluon and/or its affiliates.
+# Copyright (c) 2016, 2021, Gluon and/or its affiliates.
 # Copyright (c) 2012, 2014, Oracle and/or its affiliates.
 # All rights reserved. Use is subject to license terms.
 #

--- a/kit/src/main/resources/com/oracle/javafx/scenebuilder/kit/i18n/SceneBuilderKit_ja.properties
+++ b/kit/src/main/resources/com/oracle/javafx/scenebuilder/kit/i18n/SceneBuilderKit_ja.properties
@@ -1,4 +1,4 @@
-# Copyright (c) 2016, 2018, Gluon and/or its affiliates.
+# Copyright (c) 2016, 2021, Gluon and/or its affiliates.
 # Copyright (c) 2012, 2014, Oracle and/or its affiliates.
 # All rights reserved. Use is subject to license terms.
 #

--- a/kit/src/main/resources/com/oracle/javafx/scenebuilder/kit/i18n/SceneBuilderKit_ja.properties
+++ b/kit/src/main/resources/com/oracle/javafx/scenebuilder/kit/i18n/SceneBuilderKit_ja.properties
@@ -36,6 +36,7 @@ label.ok = OK
 label.cancel = 取消
 label.close = 閉じる
 label.copy = コピー
+label.save.as=別名保存...
 
 label.action.edit.trim = ドキュメントを選択範囲まで切取り
 label.action.edit.delete.n = オブジェクト{0}の削除
@@ -482,6 +483,13 @@ skeleton.empty = 空のドキュメントからはスケルトンを構築でき
 skeleton.format.full = Full
 # Parameter is a fxml file name
 skeleton.window.title = "{0}"コントローラ・クラスのサンプル・スケルトン
+
+################ Alert for saving Skeletons to file
+alert.skeleton.title = コントローラースケルトン
+alert.skeleton.header.success = コントローラスケルトンがファイルに正常に書き込まれました
+alert.skeleton.header.failed = エラーが発生しました！
+alert.skeleton.saving.failed = コントローラスケルトンをファイルに書き込めませんでした：
+alert.skeleton.copy2clipboard = クリップボードにコピー
 
 ################# Templates Window
 template.dialog.title = テンプレート

--- a/kit/src/main/resources/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonWindow.fxml
+++ b/kit/src/main/resources/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonWindow.fxml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2019, Gluon and/or its affiliates.
+  Copyright (c) 2019, 2021, Gluon and/or its affiliates.
   Copyright (c) 2012, 2014, Oracle and/or its affiliates.
   All rights reserved. Use is subject to license terms.
 
@@ -42,19 +42,24 @@
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
 
-<StackPane xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+<StackPane xmlns="http://javafx.com/javafx/16" xmlns:fx="http://javafx.com/fxml/1">
     <children>
         <VBox>
             <children>
                 <TextArea fx:id="textArea" editable="false" focusTraversable="false" prefHeight="500.0" styleClass="theme-presets" VBox.vgrow="ALWAYS" />
-                <HBox alignment="BASELINE_RIGHT" prefWidth="600.0" spacing="20.0">
+                <HBox alignment="BASELINE_RIGHT" prefWidth="600.0" spacing="20.0" VBox.vgrow="NEVER">
                     <children>
-                        <Button mnemonicParsing="false" onAction="#onCopyAction" text="%label.copy" HBox.hgrow="ALWAYS" />
+                        <HBox alignment="BASELINE_LEFT" spacing="5.0" HBox.hgrow="SOMETIMES">
+                            <children>
+                                <Button mnemonicParsing="false" onAction="#onCopyAction" text="%label.copy" HBox.hgrow="ALWAYS" />
+                                <Button mnemonicParsing="false" onAction="#onSaveAction" text="%label.save.as" />
+                            </children>
+                        </HBox>
                         <HBox alignment="BASELINE_RIGHT" spacing="5.0" HBox.hgrow="ALWAYS">
                             <children>
                                 <ChoiceBox fx:id="languageChoiceBox" />
-                                <CheckBox fx:id="commentCheckBox" mnemonicParsing="false" text="%skeleton.add.comments">
-                                </CheckBox><CheckBox fx:id="formatCheckBox" mnemonicParsing="false" text="%skeleton.format.full" />
+                                <CheckBox fx:id="commentCheckBox" mnemonicParsing="false" text="%skeleton.add.comments" />
+                                <CheckBox fx:id="formatCheckBox" mnemonicParsing="false" text="%skeleton.format.full" />
                             </children>
                         </HBox>
                     </children>

--- a/kit/src/main/resources/com/oracle/javafx/scenebuilder/kit/skeleton/clipboard-copy-icon.svg
+++ b/kit/src/main/resources/com/oracle/javafx/scenebuilder/kit/skeleton/clipboard-copy-icon.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+    <path d="M11.983,1.973L11.983,12.001L3.935,12.001L3.935,1.973L3.319,1.973C2.577,1.973 1.975,2.575 1.975,3.317L1.975,12.684C1.975,13.426 2.577,14.029 3.319,14.029L12.644,14.029C13.386,14.029 13.989,13.426 13.989,12.684L13.989,3.317C13.989,2.575 13.386,1.973 12.644,1.973L11.983,1.973ZM10.959,0.997L4.965,0.997L4.965,5.018L10.959,5.018L10.959,0.997ZM10.021,3.948L10.038,3.948L10.038,1.932L6.016,1.932L6.016,3.948L6.034,3.948L6.034,4.005L10.021,4.005L10.021,3.948Z" style="fill:rgb(67,67,67);"/>
+</svg>

--- a/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonFileNameProposalTest.java
+++ b/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonFileNameProposalTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2021, Gluon and/or its affiliates.
+ * All rights reserved. Use is subject to license terms.
+ *
+ * This file is available and licensed under the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the distribution.
+ *  - Neither the name of Oracle Corporation and Gluon nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.javafx.scenebuilder.kit.skeleton;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import com.oracle.javafx.scenebuilder.kit.skeleton.SkeletonSettings.LANGUAGE;
+
+public class SkeletonFileNameProposalTest {
+
+    private SkeletonFileNameProposal classUnderTest;
+
+    @Rule
+    public TemporaryFolder temporaryDirectory = new TemporaryFolder();
+
+    @Test
+    public void that_default_java_file_is_created_on_new_documents() {
+        classUnderTest = new SkeletonFileNameProposal(LANGUAGE.JAVA);
+        File result = classUnderTest.create(null, null);
+        File expected = new File(System.getProperty("user.home"), "PleaseProvideControllerClassName.java");
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void that_default_kotlin_file_is_created_on_new_documents() {
+        classUnderTest = new SkeletonFileNameProposal(LANGUAGE.KOTLIN);
+        File result = classUnderTest.create(null, null);
+        File expected = new File(System.getProperty("user.home"), "PleaseProvideControllerClassName.kt");
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void that_controllerName_is_used_when_available() {
+        classUnderTest = new SkeletonFileNameProposal(LANGUAGE.JAVA);
+        String fxControllerName = "com.oracle.javafx.scenebuilder.kit.skeleton.SkeletonTest$SkeletonTestController";
+        File result = classUnderTest.create(null, fxControllerName);
+        File expected = new File(System.getProperty("user.home"), "SkeletonTestController.java");
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void that_controllerName_is_preferred_over_fxmlLocation_and_directory_is_used_from_fxml() throws Exception {
+        classUnderTest = new SkeletonFileNameProposal(LANGUAGE.JAVA);
+        String fxControllerName = "com.oracle.javafx.scenebuilder.kit.skeleton.SkeletonTest$SkeletonTestController";
+        URL fxmlLocation = new File("src/test/resources/com/oracle/javafx/scenebuilder/kit/fxom/Empty.fxml").toURI()
+                .toURL();
+        File result = classUnderTest.create(fxmlLocation, fxControllerName);
+        File expected = new File("src/test/resources/com/oracle/javafx/scenebuilder/kit/fxom",
+                "SkeletonTestController.java").getAbsoluteFile();
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void that_fxmlLocation_in_resources_dir_is_changed_to_java_specific_directory() throws Exception {
+        classUnderTest = new SkeletonFileNameProposal(LANGUAGE.JAVA);
+        String fxControllerName = "com.oracle.javafx.scenebuilder.kit.skeleton.SkeletonTest$SkeletonTestController";
+        URL fxmlLocation = new File("src/main/resources/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonWindow.fxml").toURI().toURL();
+        File result = classUnderTest.create(fxmlLocation, fxControllerName);
+        File expected = new File("src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton",
+                "SkeletonTestController.java").getAbsoluteFile();
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void that_fxmlLocation_in_resources_dir_is_changed_to_kotlin_specific_directory() throws Exception {
+
+        String sourceFolder = "com/oracle/javafx/scenebuilder/kit/skeleton";
+        Path resourcesDir = temporaryDirectory.getRoot().toPath().resolve("src/main/resources").resolve(sourceFolder);
+        Path kotlinDir = temporaryDirectory.getRoot().toPath().resolve("src/main/kotlin").resolve(sourceFolder);
+        
+        Files.createDirectories(resourcesDir);
+        Files.createDirectories(kotlinDir);
+
+        classUnderTest = new SkeletonFileNameProposal(LANGUAGE.KOTLIN);
+        String fxControllerName = "com.oracle.javafx.scenebuilder.kit.skeleton.SkeletonTest$SkeletonTestController";
+        URL fxmlLocation = resourcesDir.resolve("SkeletonWindow.fxml").toFile().toURI().toURL();
+
+        File result = classUnderTest.create(fxmlLocation, fxControllerName);
+        File expected = kotlinDir.resolve("SkeletonTestController.kt").toFile();
+
+        assertEquals(expected.toString(), result.toString());
+    }
+  
+    @Test
+    public void that_controllerName_is_preferred_over_fxmlLocation_in_user_directory() throws Exception {
+        classUnderTest = new SkeletonFileNameProposal(LANGUAGE.JAVA);
+        String fxControllerName = "com.oracle.javafx.scenebuilder.kit.skeleton.SkeletonTest$SkeletonTestController";
+        URL fxmlLocation = new File("not-existing-location/Empty.fxml").toURI().toURL();
+        File result = classUnderTest.create(fxmlLocation, fxControllerName);
+        File expected = new File(System.getProperty("user.home"), "SkeletonTestController.java");
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void that_fxmlLocations_is_used_when_controllerName_not_exists() throws Exception {
+        classUnderTest = new SkeletonFileNameProposal(LANGUAGE.JAVA);
+        URL fxmlLocation = new File("Empty.fxml").getAbsoluteFile().toURI().toURL();
+        File result = classUnderTest.create(fxmlLocation, null);
+        File expected = new File("EmptyController.java").getAbsoluteFile();
+
+        assertEquals(expected.getAbsolutePath(), result.getAbsolutePath());
+    }
+
+    @Test
+    public void that_incorrectly_named_fxml_can_be_handled() throws Exception {
+        classUnderTest = new SkeletonFileNameProposal(LANGUAGE.JAVA);
+        URL fxmlLocation = new File("EmptyFxml").getAbsoluteFile().toURI().toURL();
+        File result = classUnderTest.create(fxmlLocation, null);
+        File expected = new File("EmptyFxmlController.java").getAbsoluteFile();
+
+        assertEquals(expected.getAbsolutePath(), result.getAbsolutePath());
+    }
+
+    @Test
+    public void that_fxmllocation_is_used_when_language_specific_resource_dir_not_exists() throws Exception {
+        File resourcesDir = new File(temporaryDirectory.getRoot(), "src/main/resources");
+        File javaDir = new File(temporaryDirectory.getRoot(), "src/main/java");
+        File kotlinDir = new File(temporaryDirectory.getRoot(), "src/main/kotlin");
+        URL fxmlLocation = new File(resourcesDir.toString(), "SkeletonWindow.fxml").toURI().toURL();
+
+        Files.createDirectories(javaDir.toPath());
+        assertTrue(javaDir.exists());
+        assertFalse(kotlinDir.exists());
+        assertFalse(resourcesDir.exists());
+
+        // JAVA
+        classUnderTest = new SkeletonFileNameProposal(LANGUAGE.JAVA);
+        File result = classUnderTest.create(fxmlLocation, null);
+        File expected = new File(javaDir, "SkeletonWindowController.java");
+        assertEquals(expected.toString(), result.toString());
+
+        // KOTLIN - the kotlin folder does not exist, thus the originally used resource folder is returned
+        classUnderTest = new SkeletonFileNameProposal(LANGUAGE.KOTLIN);
+        result = classUnderTest.create(fxmlLocation, null);
+        expected = new File(resourcesDir, "SkeletonWindowController.kt");
+        assertEquals(expected.toString(), result.toString());
+    }
+}

--- a/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonFileNameProposalTest.java
+++ b/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonFileNameProposalTest.java
@@ -112,7 +112,7 @@ public class SkeletonFileNameProposalTest {
         String sourceFolder = "com/oracle/javafx/scenebuilder/kit/skeleton";
         Path resourcesDir = temporaryDirectory.getRoot().toPath().resolve("src/main/resources").resolve(sourceFolder);
         Path kotlinDir = temporaryDirectory.getRoot().toPath().resolve("src/main/kotlin").resolve(sourceFolder);
-        
+
         Files.createDirectories(resourcesDir);
         Files.createDirectories(kotlinDir);
 
@@ -125,7 +125,7 @@ public class SkeletonFileNameProposalTest {
 
         assertEquals(expected.toString(), result.toString());
     }
-  
+
     @Test
     public void that_controllerName_is_preferred_over_fxmlLocation_in_user_directory() throws Exception {
         classUnderTest = new SkeletonFileNameProposal(LANGUAGE.JAVA);

--- a/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonFileWriterTest.java
+++ b/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonFileWriterTest.java
@@ -1,0 +1,318 @@
+/*
+ * Copyright (c) 2021, Gluon and/or its affiliates.
+ * All rights reserved. Use is subject to license terms.
+ *
+ * This file is available and licensed under the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the distribution.
+ *  - Neither the name of Oracle Corporation and Gluon nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.javafx.scenebuilder.kit.skeleton;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.net.URL;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import javafx.beans.property.SimpleStringProperty;
+import javafx.stage.FileChooser;
+import javafx.stage.FileChooser.ExtensionFilter;
+import javafx.stage.Stage;
+
+public class SkeletonFileWriterTest {
+
+    private SkeletonFileWriter classUnderTest;
+    private SimpleStringProperty textProperty = new SimpleStringProperty("TheControllerCode!");
+    private Supplier<Stage> stageSupplier = () -> null;
+    private List<File> filesProposed = new ArrayList<>();
+    private List<ExtensionFilter> fileExtensionFilters = new ArrayList<>();
+
+    @Rule
+    public TemporaryFolder temporaryDirectory = new TemporaryFolder();
+
+    @Test
+    public void that_dafaults_in_public_constructor_are_correct() {
+
+        classUnderTest = new SkeletonFileWriter(stageSupplier, textProperty);
+
+        assertEquals(SkeletonFileWriterErrorAlert.class, 
+                classUnderTest.getOnError().apply(stageSupplier).getClass());
+
+        assertEquals(SkeletonFileWriterSuccessAlert.class,
+                classUnderTest.getOnSuccess().apply(stageSupplier).getClass());
+
+    }
+
+    @Test
+    public void that_alert_is_raised_in_case_of_error() {
+
+        /* GIVEN Scenario:
+         * 
+         * - The user enters a location which does not exist.
+         * - The file chooser accepts this illegal location.
+         * - It is expected, that exception and file are 
+         *   passed to the error handler
+         * 
+         */
+        String controllerName = "MyCustomControllerName";
+        SkeletonSettings.LANGUAGE language = SkeletonSettings.LANGUAGE.JAVA;
+        File fileAtIllegalLocation = new File("//notExisting/share/test.java");
+
+        Map<File, Exception> raisedErrors = new HashMap<>();
+        Function<Supplier<Stage>, BiConsumer<File, Exception>> errorHandler = stage -> (file, error) -> {
+            raisedErrors.put(file, error);
+        };
+
+        // WHEN
+        classUnderTest = new SkeletonFileWriter(stageSupplier, textProperty, 
+                                               (fc, stage) -> fileAtIllegalLocation,
+                                                onSuccess(),  errorHandler);
+
+        classUnderTest.run(null, controllerName, language);
+
+        // THEN
+        assertEquals(1, raisedErrors.size());
+    }
+
+    @Test
+    public void that_filename_is_properly_derived_from_URL() throws Exception {
+
+        /* GIVEN Scenario:
+         * 
+         * - only the FXML name is known and its URL
+         * - as no custom controller name is defined,
+         *   it is expected that the controller name is 
+         *   derived from the URL
+         * 
+         * - Test is repeated for JAVA and KOTLIN
+         *    
+         */
+        String fxmlName = "MyCustomView.fxml";
+        File fxml = new File(temporaryDirectory.getRoot().toString(), fxmlName);
+        URL url = fxml.toURI().toURL();
+
+        // WHEN
+        classUnderTest = new SkeletonFileWriter(stageSupplier, textProperty, 
+                                                rejectProposedFile(), onSuccess(), onError());
+
+        // JAVA CASE
+        SkeletonSettings.LANGUAGE language = SkeletonSettings.LANGUAGE.JAVA;
+        classUnderTest.run(url, null, language);
+
+        assertEquals("MyCustomViewController.java", filesProposed.get(0).getName());
+
+        // KOTLIN CASE
+        language = SkeletonSettings.LANGUAGE.KOTLIN;
+        classUnderTest.run(url, null, language);
+
+        assertEquals("MyCustomViewController.kt", filesProposed.get(1).getName());
+    }
+
+    @Test
+    public void that_file_for_newSkeleton_is_not_saved_but_naming_and_directory_are_correct() {
+
+        /* GIVEN Scenario:
+         * 
+         * - No file has been saved for either language.
+         * - A file name proposal will be created and the
+         *   file chooser will be configured accordingly.
+         * - The user will cancel the file save dialog.
+         *  
+         */
+        String controllerName = "CustomizedController";
+        SkeletonSettings.LANGUAGE language = SkeletonSettings.LANGUAGE.JAVA;
+
+        // WHEN
+        classUnderTest = new SkeletonFileWriter(stageSupplier, textProperty, 
+                                                rejectProposedFile(), onSuccess(), onError());
+
+        classUnderTest.run(null, controllerName, language);
+
+        // THEN
+        File expectedProposedFile = new File(System.getProperty("user.home"), "CustomizedController.java");
+
+        assertEquals(expectedProposedFile, filesProposed.get(0));
+        assertTrue(classUnderTest.getLastSavedFilesPerLanguage().isEmpty());
+        assertEquals("Java", fileExtensionFilters.get(0).getDescription());
+        assertEquals("*.java", fileExtensionFilters.get(0).getExtensions().get(0));
+    }
+
+    @Test
+    public void that_java_and_kotlin_versions_of_skeleton_are_saved_and_remembered() throws Exception {
+
+        /*
+         * GIVEN Scenario:
+         *  
+         * - the same SkeletonFileWriter instance is called multiple times but
+         *   with different language settings
+         */
+        String controllerName = "MyVeryNewController";
+        SkeletonSettings.LANGUAGE language = null;
+
+        classUnderTest = new SkeletonFileWriter(stageSupplier, textProperty, 
+                                                acceptProposedFile(), onSuccess(), onError());
+
+        /*
+         * - Language is KOTLIN
+         * - No file has been saved before.
+         * - The controller skeleton contents is supposed to be written into a *.kt file
+         *   inside the given temporary directory.
+         * - The file name is to be derived from the controller name
+         * 
+         */
+        language = SkeletonSettings.LANGUAGE.KOTLIN;
+        textProperty.setValue("SomeKotlinCode");
+        classUnderTest.run(null, controllerName, language);
+
+        // THEN
+        File expectedFile = new File(temporaryDirectory.getRoot().toString(), "MyVeryNewController.kt");
+
+        assertTrue(expectedFile.exists());
+        assertEquals(expectedFile, filesProposed.get(0));
+        assertEquals("SomeKotlinCode", Files.readString(expectedFile.toPath()));
+        assertEquals(1, classUnderTest.getLastSavedFilesPerLanguage().size());
+        assertEquals(expectedFile, classUnderTest.getLastSavedFilesPerLanguage().get(language));
+        assertEquals("Kotlin", fileExtensionFilters.get(0).getDescription());
+        assertEquals("*.kt", fileExtensionFilters.get(0).getExtensions().get(0));
+
+        /*
+         * - For the same setup, a new controller skeleton shall be saved but for JAVA
+         * - As no JAVA file has been saved previously, the name shall be derived from
+         *   controller name.
+         * - The only expected difference here is the file name extension and the 
+         *   file chooser configuration.
+         * 
+         */
+        language = SkeletonSettings.LANGUAGE.JAVA;
+        textProperty.setValue("MyJavaCode");
+        classUnderTest.run(null, controllerName, language);
+
+        // THEN
+        expectedFile = new File(temporaryDirectory.getRoot().toString(), "MyVeryNewController.java");
+
+        assertTrue(expectedFile.exists());
+        assertEquals(expectedFile, filesProposed.get(1));
+        assertEquals("MyJavaCode", Files.readString(expectedFile.toPath()));
+        assertEquals(2, classUnderTest.getLastSavedFilesPerLanguage().size());
+        assertEquals(expectedFile, classUnderTest.getLastSavedFilesPerLanguage().get(language));
+        assertEquals("Java", fileExtensionFilters.get(1).getDescription());
+        assertEquals("*.java", fileExtensionFilters.get(1).getExtensions().get(0));
+
+        /*
+         * Now, for JAVA and KOTLIN a file has been saved.
+         * After switching back to Kotlin, the expectation here is, that the 
+         * previously used and saved Kotlin file name is used again.
+         */
+
+        language = SkeletonSettings.LANGUAGE.KOTLIN;
+        textProperty.setValue("MyKotlinCode");
+        classUnderTest.run(null, controllerName, language);
+
+        // THEN:
+        expectedFile = new File(temporaryDirectory.getRoot().toString(), "MyVeryNewController.kt");
+
+        assertTrue(expectedFile.exists());
+        assertEquals(expectedFile, filesProposed.get(0));
+        assertEquals("MyKotlinCode", Files.readString(expectedFile.toPath()));
+        assertEquals(2, classUnderTest.getLastSavedFilesPerLanguage().size());
+        assertEquals(expectedFile, classUnderTest.getLastSavedFilesPerLanguage().get(language));
+        assertEquals("Kotlin", fileExtensionFilters.get(2).getDescription());
+        assertEquals("*.kt", fileExtensionFilters.get(2).getExtensions().get(0));
+    }
+
+    /**
+     * Stores the proposed file name and the selected extension filter so that
+     * assertion can be created to verify the values.
+     * 
+     * @return Simulates a user interaction, where the user cancels the file save
+     *         dialog.
+     */
+    private BiFunction<FileChooser, Stage, File> rejectProposedFile() {
+        BiFunction<FileChooser, Stage, File> saveDialogIsCancelled = (fc, stage) -> {
+            // save the proposed file name
+            filesProposed.add(new File(fc.getInitialDirectory(), fc.getInitialFileName()));
+
+            // remember the extension filer which was selected
+            if (fc.getSelectedExtensionFilter() != null) {
+                fileExtensionFilters.add(fc.getSelectedExtensionFilter());
+            }
+
+            // user cancels file save dialog
+            return null;
+        };
+        return saveDialogIsCancelled;
+    }
+
+    /**
+     * Stores the proposed file name and the selected extension filter so that
+     * assertion can be created to verify the values.
+     * 
+     * @return Simulates a user interaction, where the user accepts the file save
+     *         dialog with its defaults.
+     */
+    private BiFunction<FileChooser, Stage, File> acceptProposedFile() {
+        BiFunction<FileChooser, Stage, File> acceptingFileName = (fc, stage) -> {
+            // save the proposed file name
+            File proposedFile = new File(temporaryDirectory.getRoot().toString(), fc.getInitialFileName());
+            filesProposed.add(proposedFile);
+
+            // remember the extension filer which was selected
+            if (fc.getSelectedExtensionFilter() != null) {
+                fileExtensionFilters.add(fc.getSelectedExtensionFilter());
+            }
+
+            // user accepts proposed file name and saves to temporary directory
+            return proposedFile;
+        };
+        return acceptingFileName;
+    }
+
+    private Function<Supplier<Stage>, Consumer<File>> onSuccess() {
+        return stageSupplier -> file -> {
+            /* no handling of successful writing yet */
+        };
+    }
+
+    private Function<Supplier<Stage>, BiConsumer<File, Exception>> onError() {
+        return stageSupplier -> (file, error) -> {
+            /* no handling of error yet */
+        };
+    }
+}

--- a/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonSettingsTest.java
+++ b/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonSettingsTest.java
@@ -13,7 +13,7 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in
  *    the documentation and/or other materials provided with the distribution.
- *  - Neither the name of Oracle Corporation nor the names of its
+ *  - Neither the name of Oracle Corporation and Gluon nor the names of its
  *    contributors may be used to endorse or promote products derived
  *    from this software without specific prior written permission.
  *
@@ -31,73 +31,15 @@
  */
 package com.oracle.javafx.scenebuilder.kit.skeleton;
 
-class SkeletonSettings {
+import static org.junit.Assert.*;
 
-    private LANGUAGE language = LANGUAGE.JAVA;
-    private TEXT_TYPE textType = TEXT_TYPE.WITHOUT_COMMENTS;
-    private FORMAT_TYPE textFormat = FORMAT_TYPE.COMPACT;
+import org.junit.Test;
 
-    enum LANGUAGE {
-        JAVA("Java", ".java"), KOTLIN("Kotlin", ".kt");
+public class SkeletonSettingsTest {
 
-        private final String name;
-
-        private final String ext;
-
-        LANGUAGE(String name, String fileNameExt) {
-            this.name = name;
-            this.ext = fileNameExt;
-        }
-
-        @Override
-        public String toString() {
-            return name;
-        }
-
-        String getExtension() {
-            return ext;
-        }
-    }
-
-    enum TEXT_TYPE {
-        WITH_COMMENTS, WITHOUT_COMMENTS
-    }
-
-    enum FORMAT_TYPE {
-        COMPACT, FULL
-    }
-
-    void setLanguage(LANGUAGE language) {
-        this.language = language;
-    }
-
-    public LANGUAGE getLanguage() {
-        return language;
-    }
-
-    void setTextType(TEXT_TYPE type) {
-        this.textType = type;
-    }
-
-    SkeletonSettings withTextType(TEXT_TYPE type) {
-        this.textType = type;
-        return this;
-    }
-
-    void setFormat(FORMAT_TYPE format) {
-        this.textFormat = format;
-    }
-
-    SkeletonSettings withFormat(FORMAT_TYPE format) {
-        this.textFormat = format;
-        return this;
-    }
-
-    boolean isWithComments() {
-        return textType == TEXT_TYPE.WITH_COMMENTS;
-    }
-
-    boolean isFull() {
-        return textFormat == FORMAT_TYPE.FULL;
+    @Test
+    public void that_controller_class_file_extensions_match_language() {
+        assertEquals(".java", SkeletonSettings.LANGUAGE.JAVA.getExtension());
+        assertEquals(".kt",   SkeletonSettings.LANGUAGE.KOTLIN.getExtension());
     }
 }


### PR DESCRIPTION
<!--- Provide a brief summary of the PR -->

### Added a "save as" function for the controller skeleton preview.

The functionality is now as follows:
* The controller skeleton preview as now a "Save as" button.
* When pressed a file name is proposed.
* When confirmed with "save", the skeleton is saved to the proposed file.
* A confirmation dialog is shown, which allows to copy the file path to the clipboard.

Following use cases have been explored (the following examples refer to Java but this works with Kotlin as well):

| # | Use case | FXML status | Controller class definition | File Name Proposal |
|-|-|-|-|-|
| 1 | Fresh project | FXML not saved | not specified                           |  `~/PleaseProvideControllerClassName.java` |
| 2 | Fresh project | FXML not saved | set to `MyCustomController`  |  `~/MyCustomController.java` |
| 3 | Fresh project | FXML saved (e.g. `/Temp/SceneBuilder/Test.fxml`)  | not specified | `/Temp/SceneBuilder/TestController.java` |
| 4 | Fresh project | FXML saved (e.g. `/Temp/SceneBuilder/Test.fxml`)  | `MyFancyApp$NestedController` | `/Temp/SceneBuilder/NestedController.java` |
| 5 | Existing project | FXML opened from 'src/main/resources/.../View.fxml' | no controller specified | 'src/main/java/.../ViewController.java' |
| 6 | Active project session, a skeleton was already created and saved, SceneBuilder not stopped in between | FXML already saved to `/Temp/SceneBuilder/Test.fxml` |  set to `MyCustomController`  |  As the controller skeleton was previously saved to `/somewhere/MyControllerSkeleton.java`, the File Chooser will always propse this name until the SceneBuilder session is restarted. |

<!--- The issue this PR addresses -->
Fixes #381

### Progress

- [x] Change must not contain extraneous whitespace
- [x] License header year is updated, if required
- [x] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)