### PR TITLE
Added checkstyle plugin to main POM.xml with basic config.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,13 +36,13 @@ jobs:
           echo 123456 | vncpasswd -f > /home/runner/.vnc/passwd
           chmod -v 600 /home/runner/.vnc/passwd
           vncserver :90 -localhost -nolisten tcp
-          mvn clean verify -X
+          mvn clean verify checkstyle:checkstyle -X
           vncserver -kill :90
 
       - name: Run Tests (MacOS / Windows)
         if: runner.os != 'Linux'
         run: |
-          mvn clean verify
+          mvn clean verify checkstyle:checkstyle
 
       - name: Draft release
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,13 +36,13 @@ jobs:
           echo 123456 | vncpasswd -f > /home/runner/.vnc/passwd
           chmod -v 600 /home/runner/.vnc/passwd
           vncserver :90 -localhost -nolisten tcp
-          mvn clean verify checkstyle:checkstyle -X
+          mvn clean verify checkstyle:checkstyle --no-transfer-progress -X
           vncserver -kill :90
 
       - name: Run Tests (MacOS / Windows)
         if: runner.os != 'Linux'
         run: |
-          mvn clean verify checkstyle:checkstyle
+          mvn clean verify checkstyle:checkstyle --no-transfer-progress
 
       - name: Draft release
         if: github.ref == 'refs/heads/master'

--- a/README.md
+++ b/README.md
@@ -91,8 +91,7 @@ To ensure that new code formatting matches the requirements for Pull Requests,
 the Maven Checkstyle plugin can be used to create a report listing possibly coding 
 style violations.
 
-The [Checkstyle](https://checkstyle.org) configuration is currently in a very early stage and so at present
-it checks for empty blocks, extra white space, padding and empty lines. 
+Contributors can check for code-style violations in their code by running the Checkstyle Maven goal. The checkstyle configuration is currently in a very early stage and only checks for empty blocks, extra white space, padding and empty lines.
 
 To run the plugin:
 

--- a/README.md
+++ b/README.md
@@ -84,3 +84,24 @@ You can add it as a regular dependency to the build of your app:
   <version>$version</version>
 </dependency>
 ```
+
+## Code Style
+
+To ensure that new code formatting matches the requirements for Pull Requests,
+the Maven Checkstyle plugin can be used to create a report listing possibly coding 
+style violations.
+
+The [Checkstyle](https://checkstyle.org) configuration is currently in a very early stage and so at present
+it checks for empty blocks, extra white space, padding and empty lines. 
+
+To run the plugin:
+
+```
+mvn checkstyle:checkstyle
+```
+
+There will be a report for each sub-project, one for `app` and one for `kit`.
+
+* Kit: `kit/target/site/checkstyle.html`
+* App: `kit/target/site/checkstyle.html`
+

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -80,42 +80,5 @@
             <property name="tokens" value="LITERAL_WHILE"/>
             <property name="option" value="text"/>
         </module>
- 
-        <!-- 
-        <module name="LeftCurly"/>
-        <module name="NeedBraces"/>
-        <module name="NeedBraces">
-            <property name="tokens" value="LAMBDA"/>
-            <property name="allowSingleLineStatement" value="true"/>
-        </module>
-        <module name="RightCurly">
-            <property name="tokens" value="METHOD_DEF"/>
-            <property name="tokens" value="CTOR_DEF"/>
-            <property name="tokens" value="CLASS_DEF"/>
-            <property name="tokens" value="INSTANCE_INIT"/>
-            <property name="tokens" value="LITERAL_FOR"/>
-            <property name="tokens" value="STATIC_INIT"/>
-            <property name="tokens" value="LITERAL_WHILE"/>
-            <property name="tokens" value="LITERAL_CATCH"/>
-            <property name="tokens" value="LITERAL_ELSE"/>
-            <property name="tokens" value="LITERAL_FINALLY"/>
-            <property name="tokens" value="LITERAL_IF"/>
-            <property name="tokens" value="LITERAL_TRY"/>
-            <property name="tokens" value="ANNOTATION_DEF"/>
-            <property name="tokens" value="ENUM_DEF"/>
-            <property name="tokens" value="RECORD_DEF"/>
-            <property name="tokens" value="COMPACT_CTOR_DEF"/>
-            <property name="option" value="alone"/>
-        </module>
-        <module name="RightCurly">
-            <property name="tokens" value="LITERAL_DO"/>
-            <property name="option" value="same"/>
-        </module>
-        <module name="RightCurly">
-            <property name="tokens" value="INTERFACE_DEF"/>
-            <property name="option" value="alone_or_singleline"/>
-        </module>
-        -->
     </module>
-        
 </module>

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
+<module name="Checker">
+    <property name="cacheFile" value="${checkstyle.cache.file}" />
+
+    <property name="severity" value="warning" />
+
+    <property name="fileExtensions" value="java, properties, xml, fxml" />
+
+    <!-- BeforeExecutionFileFilters is required for sources that are based on java9 -->
+    
+    <module name="BeforeExecutionExclusionFileFilter">
+        <property name="fileNamePattern"
+            value="module\-info\.java$" />
+    </module>
+
+    <module name="FileTabCharacter">
+        <property name="eachLine" value="false" />
+    </module>
+
+    <module name="TreeWalker">
+        <property name="tabWidth" value="4"/>
+        
+        <module name="GenericWhitespace"/>
+        <module name="EmptyForInitializerPad"/>
+        <module name="EmptyForIteratorPad"/>
+        
+        <module name="NoWhitespaceBefore"/>
+        <module name="NoWhitespaceBeforeCaseDefaultColon"/>
+        <module name="NoWhitespaceBefore">
+            <property name="tokens" value="DOT"/>
+            <property name="tokens" value="METHOD_REF"/>
+            <property name="allowLineBreaks" value="true"/>
+        </module>
+
+        <module name="SingleSpaceSeparator">
+            <property name="validateComments" value="false"/>
+        </module>
+        <module name="TypecastParenPad"/>
+        
+        <module name="EmptyLineSeparator">
+            <property name="tokens" value="IMPORT, STATIC_IMPORT, INTERFACE_DEF, INSTANCE_INIT, RECORD_DEF"/>
+            <property name="allowNoEmptyLineBetweenFields" value="false"/>
+            <property name="allowMultipleEmptyLinesInsideClassMembers" value="true"/>
+        </module>
+
+        <!-- 
+        <module name="NoWhitespaceAfter">
+            <property name="tokens" value="ARRAY_INIT"/>
+            <property name="tokens" value="AT"/>
+            <property name="tokens" value="BNOT"/>
+            <property name="tokens" value="DEC"/>
+            <property name="tokens" value="DOT"/>
+            <property name="tokens" value="INC"/>
+            <property name="tokens" value="LNOT"/>
+            <property name="tokens" value="UNARY_MINUS"/>
+            <property name="tokens" value="UNARY_PLUS"/>
+            <property name="tokens" value="ARRAY_DECLARATOR"/>
+            <property name="tokens" value="INDEX_OP"/>
+            <property name="tokens" value="METHOD_REF"/>
+        </module>
+        -->        
+        
+        <module name="EmptyBlock">
+            <property name="tokens" value="LITERAL_CATCH"/>
+            <property name="tokens" value="LITERAL_DEFAULT"/>
+            <property name="tokens" value="LITERAL_CASE"/>
+            <property name="tokens" value="INSTANCE_INIT"/>
+            <property name="tokens" value="STATIC_INIT"/>
+            <property name="tokens" value="LITERAL_DO"/>
+            <property name="tokens" value="LITERAL_ELSE"/>
+            <property name="tokens" value="LITERAL_FINALLY"/>
+            <property name="tokens" value="LITERAL_FOR"/>
+            <property name="tokens" value="LITERAL_IF"/>
+            <property name="tokens" value="LITERAL_SWITCH"/>
+            <property name="tokens" value="LITERAL_TRY"/>
+            <property name="tokens" value="LITERAL_SYNCHRONIZED"/>
+            <property name="tokens" value="LITERAL_WHILE"/>
+            <property name="option" value="text"/>
+        </module>
+ 
+        <!-- 
+        <module name="LeftCurly"/>
+        <module name="NeedBraces"/>
+        <module name="NeedBraces">
+            <property name="tokens" value="LAMBDA"/>
+            <property name="allowSingleLineStatement" value="true"/>
+        </module>
+        <module name="RightCurly">
+            <property name="tokens" value="METHOD_DEF"/>
+            <property name="tokens" value="CTOR_DEF"/>
+            <property name="tokens" value="CLASS_DEF"/>
+            <property name="tokens" value="INSTANCE_INIT"/>
+            <property name="tokens" value="LITERAL_FOR"/>
+            <property name="tokens" value="STATIC_INIT"/>
+            <property name="tokens" value="LITERAL_WHILE"/>
+            <property name="tokens" value="LITERAL_CATCH"/>
+            <property name="tokens" value="LITERAL_ELSE"/>
+            <property name="tokens" value="LITERAL_FINALLY"/>
+            <property name="tokens" value="LITERAL_IF"/>
+            <property name="tokens" value="LITERAL_TRY"/>
+            <property name="tokens" value="ANNOTATION_DEF"/>
+            <property name="tokens" value="ENUM_DEF"/>
+            <property name="tokens" value="RECORD_DEF"/>
+            <property name="tokens" value="COMPACT_CTOR_DEF"/>
+            <property name="option" value="alone"/>
+        </module>
+        <module name="RightCurly">
+            <property name="tokens" value="LITERAL_DO"/>
+            <property name="option" value="same"/>
+        </module>
+        <module name="RightCurly">
+            <property name="tokens" value="INTERFACE_DEF"/>
+            <property name="option" value="alone_or_singleline"/>
+        </module>
+        -->
+    </module>
+        
+</module>

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -5,13 +5,10 @@
 
 <module name="Checker">
     <property name="cacheFile" value="${checkstyle.cache.file}" />
-
     <property name="severity" value="warning" />
-
     <property name="fileExtensions" value="java, properties, xml, fxml" />
 
     <!-- BeforeExecutionFileFilters is required for sources that are based on java9 -->
-    
     <module name="BeforeExecutionExclusionFileFilter">
         <property name="fileNamePattern"
             value="module\-info\.java$" />
@@ -42,12 +39,15 @@
         <module name="TypecastParenPad"/>
         
         <module name="EmptyLineSeparator">
-            <property name="tokens" value="IMPORT, STATIC_IMPORT, INTERFACE_DEF, INSTANCE_INIT, RECORD_DEF"/>
-            <property name="allowNoEmptyLineBetweenFields" value="false"/>
+            <property name="tokens" value="IMPORT"/>
+            <property name="tokens" value="STATIC_IMPORT"/>
+			<property name="tokens" value="INTERFACE_DEF"/>
+			<property name="tokens" value="INSTANCE_INIT"/>
+			<property name="tokens" value="RECORD_DEF"/>
+			<property name="allowNoEmptyLineBetweenFields" value="false"/>
             <property name="allowMultipleEmptyLinesInsideClassMembers" value="true"/>
         </module>
 
-        <!-- 
         <module name="NoWhitespaceAfter">
             <property name="tokens" value="ARRAY_INIT"/>
             <property name="tokens" value="AT"/>
@@ -61,8 +61,7 @@
             <property name="tokens" value="ARRAY_DECLARATOR"/>
             <property name="tokens" value="INDEX_OP"/>
             <property name="tokens" value="METHOD_REF"/>
-        </module>
-        -->        
+        </module>    
         
         <module name="EmptyBlock">
             <property name="tokens" value="LITERAL_CATCH"/>

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,23 @@
                     </configuration>
                     <inherited>false</inherited>
                 </plugin>
+                
+                <!-- Enforce code formatting and style -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-checkstyle-plugin</artifactId>
+                    <version>3.1.2</version>
+                    <configuration>
+                        <configLocation>checkstyle.xml</configLocation>
+                    </configuration>
+                    <dependencies>
+                        <dependency>
+                            <groupId>com.puppycrawl.tools</groupId>
+                            <artifactId>checkstyle</artifactId>
+                            <version>8.45.1</version>
+                        </dependency>
+                    </dependencies>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>
@@ -129,4 +146,13 @@
         </repository>
     </distributionManagement>
 
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>3.1.2</version>
+            </plugin>
+        </plugins>
+    </reporting>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,9 @@
                     <version>3.1.2</version>
                     <configuration>
                         <configLocation>checkstyle.xml</configLocation>
+                        <encoding>UTF-8</encoding>
+                        <consoleOutput>true</consoleOutput>
+                        <failsOnError>true</failsOnError>
                     </configuration>
                     <dependencies>
                         <dependency>


### PR DESCRIPTION
The [Checkstyle](https://checkstyle.org) [Maven Plugin](https://maven.apache.org/plugins/maven-checkstyle-plugin/index.html) has been added to the main `POM.xml` to enable creation of a code style report.

A very basic configuration is provided as well, which primarily checks for extra whitespace, empty lines and empty blocks.
This plugin is not yet executed during build.

### Issue

Fixes #397 

### Progress

- [ ] Change must not contain extraneous whitespace
- [ ] License header year is updated, if required
- [x] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)