### PR TITLE
Containment/fix for issue #373

### DIFF
--- a/app/src/main/java/com/oracle/javafx/scenebuilder/app/SceneBuilderApp.java
+++ b/app/src/main/java/com/oracle/javafx/scenebuilder/app/SceneBuilderApp.java
@@ -792,9 +792,7 @@ public class SceneBuilderApp extends Application implements AppPlatform.AppNotif
         }
     }
 
-    private enum ACTION {START, STOP}
-
-    ;
+    private enum ACTION {START, STOP};
 
     private void logTimestamp(ACTION type) {
         switch (type) {

--- a/app/src/main/java/com/oracle/javafx/scenebuilder/app/SceneBuilderApp.java
+++ b/app/src/main/java/com/oracle/javafx/scenebuilder/app/SceneBuilderApp.java
@@ -978,6 +978,7 @@ public class SceneBuilderApp extends Application implements AppPlatform.AppNotif
     }
 
     private void checkUpdates(DocumentWindowController source) {
+        WindowPositionRestorer restoreWindowPosition = new WindowPositionRestorer(source);
         AppSettings.getLatestVersion(latestVersion -> {
             if (latestVersion == null) {
                 Platform.runLater(() -> {
@@ -985,6 +986,7 @@ public class SceneBuilderApp extends Application implements AppPlatform.AppNotif
                     alert.setTitle(I18N.getString("check_for_updates.alert.error.title"));
                     alert.setHeaderText(I18N.getString("check_for_updates.alert.headertext"));
                     alert.setContentText(I18N.getString("check_for_updates.alert.error.message"));
+                    alert.setOnShowing(restoreWindowPosition);
                     alert.showAndWait();
                 });
             } else {
@@ -1002,6 +1004,7 @@ public class SceneBuilderApp extends Application implements AppPlatform.AppNotif
                         alert.setTitle(I18N.getString("check_for_updates.alert.up_to_date.title"));
                         alert.setHeaderText(I18N.getString("check_for_updates.alert.headertext"));
                         alert.setContentText(I18N.getString("check_for_updates.alert.up_to_date.message"));
+                        alert.setOnShowing(restoreWindowPosition);
                         alert.showAndWait();
                     }
                 } catch (NumberFormatException ex) {
@@ -1012,12 +1015,14 @@ public class SceneBuilderApp extends Application implements AppPlatform.AppNotif
     }
 
     private void showVersionNumberFormatError(DocumentWindowController dwc) {
+        WindowPositionRestorer restoreWindowPosition = new WindowPositionRestorer(dwc);
         SBAlert alert = new SBAlert(Alert.AlertType.ERROR, dwc.getStage());
         // The version number format is not supported and this is most probably only happening
         // in development so we don't localize the strings
         alert.setTitle("Error");
         alert.setHeaderText(I18N.getString("check_for_updates.alert.headertext"));
         alert.setContentText("Update check is disabled in development environment.");
+        alert.setOnShowing(restoreWindowPosition);
         alert.showAndWait();
     }
 

--- a/app/src/main/java/com/oracle/javafx/scenebuilder/app/WindowPositionRestorer.java
+++ b/app/src/main/java/com/oracle/javafx/scenebuilder/app/WindowPositionRestorer.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2021, Gluon and/or its affiliates.
+ * All rights reserved. Use is subject to license terms.
+ *
+ * This file is available and licensed under the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the distribution.
+ *  - Neither the name of Oracle Corporation nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.javafx.scenebuilder.app;
+
+import javafx.event.EventHandler;
+import javafx.scene.control.DialogEvent;
+import javafx.stage.Stage;
+
+class WindowPositionRestorer implements EventHandler<DialogEvent> {
+    
+    private final Stage stage;
+    private final double width;
+    private final double height;
+    private final double x;
+    private final double y;
+    
+    WindowPositionRestorer(DocumentWindowController dwc) {
+        stage = dwc.getStage();
+        width = stage.getWidth();
+        height = stage.getHeight();
+        x = stage.getX();
+        y = stage.getY();
+    }
+
+    @Override
+    public void handle(DialogEvent event) {
+        stage.setX(x);
+        stage.setY(y);
+        stage.setWidth(width);
+        stage.setHeight(height);
+    }
+
+}


### PR DESCRIPTION
Before a update check dialog is shown in `SceneBuilderApp`, the current location and size of the document window is memorized.
Using the `setOnShowing` hook the window size is restored in the case it has been altered by calling `SBAlert.showAndWait`.

This PR is experimental as I think, there is something else on JavaFX level not working properly. For this a separate proof-of-concept project is in works.

### Issue

Fixes #373

### Progress

- [ ] Change must not contain extraneous whitespace
- [ ] License header year is updated, if required
- [ ] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)