### PR TITLE
Fix app name on Ubuntu

### DIFF
--- a/.github/scripts/repackage-deb.sh
+++ b/.github/scripts/repackage-deb.sh
@@ -1,0 +1,8 @@
+mkdir -p $INSTALL_DIR/extracted_deb/DEBIAN 
+mkdir -p $INSTALL_DIR/repackaged_deb
+mkdir -p $INSTALL_DIR/jpackage_deb
+dpkg-deb -X $INSTALL_DIR/scenebuilder_$VERSION-1_amd64.deb $INSTALL_DIR/extracted_deb
+echo StartupWMClass=com.oracle.javafx.scenebuilder.app.SceneBuilderApp >> $INSTALL_DIR/extracted_deb/opt/scenebuilder/lib/scenebuilder-SceneBuilder.desktop
+dpkg-deb -e $INSTALL_DIR/scenebuilder_$VERSION-1_amd64.deb $INSTALL_DIR/extracted_deb/DEBIAN
+dpkg-deb -Z xz -b $INSTALL_DIR/extracted_deb $INSTALL_DIR/repackaged_deb
+

--- a/.github/scripts/repackage-deb.sh
+++ b/.github/scripts/repackage-deb.sh
@@ -1,8 +1,0 @@
-mkdir -p $INSTALL_DIR/extracted_deb/DEBIAN 
-mkdir -p $INSTALL_DIR/repackaged_deb
-mkdir -p $INSTALL_DIR/jpackage_deb
-dpkg-deb -X $INSTALL_DIR/scenebuilder_$VERSION-1_amd64.deb $INSTALL_DIR/extracted_deb
-echo StartupWMClass=com.oracle.javafx.scenebuilder.app.SceneBuilderApp >> $INSTALL_DIR/extracted_deb/opt/scenebuilder/lib/scenebuilder-SceneBuilder.desktop
-dpkg-deb -e $INSTALL_DIR/scenebuilder_$VERSION-1_amd64.deb $INSTALL_DIR/extracted_deb/DEBIAN
-dpkg-deb -Z xz -b $INSTALL_DIR/extracted_deb $INSTALL_DIR/repackaged_deb
-

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -49,7 +49,9 @@ jobs:
           --java-options '"--add-opens=javafx.fxml/javafx.fxml=ALL-UNNAMED"' \
           --install-dir /opt \
           --type deb
-          mv $INSTALL_DIR/*.deb $INSTALL_DIR/SceneBuilder-${{ env.TAG }}.deb
+          .github/scripts/repackage.sh
+          mv $INSTALL_DIR/*.deb $INSTALL_DIR/jpackage_deb
+          mv $INSTALL_DIR/repackaged_deb/*.deb $INSTALL_DIR/SceneBuilder-${{ env.TAG }}.deb
           # Create RPM
           .github/scripts/jpackage.sh \
           --icon app/assets/linux/icon-linux.png \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -47,16 +47,16 @@ jobs:
           --icon app/assets/linux/icon-linux.png \
           --java-options '"-Djdk.gtk.version=2"' \
           --java-options '"--add-opens=javafx.fxml/javafx.fxml=ALL-UNNAMED"' \
+          --resource-dir app/assets/linux
           --install-dir /opt \
           --type deb
-          .github/scripts/repackage.sh
-          mv $INSTALL_DIR/*.deb $INSTALL_DIR/jpackage_deb
-          mv $INSTALL_DIR/repackaged_deb/*.deb $INSTALL_DIR/SceneBuilder-${{ env.TAG }}.deb
+          mv $INSTALL_DIR/*.deb $INSTALL_DIR/SceneBuilder-${{ env.TAG }}.deb
           # Create RPM
           .github/scripts/jpackage.sh \
           --icon app/assets/linux/icon-linux.png \
           --java-options '"-Djdk.gtk.version=2"' \
           --java-options '"--add-opens=javafx.fxml/javafx.fxml=ALL-UNNAMED"' \
+          --resource-dir app/assets/linux
           --install-dir /opt \
           --type rpm
           mv $INSTALL_DIR/*.rpm $INSTALL_DIR/SceneBuilder-${{ env.TAG }}.rpm

--- a/app/assets/linux/SceneBuilder.desktop
+++ b/app/assets/linux/SceneBuilder.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Name=APPLICATION_NAME
+Comment=APPLICATION_DESCRIPTION
+Exec=APPLICATION_LAUNCHER
+Icon=APPLICATION_ICON
+Terminal=false
+Type=Application
+Categories=DEPLOY_BUNDLE_CATEGORY
+DESKTOP_MIMES
+StartupWMClass=com.oracle.javafx.scenebuilder.app.SceneBuilderApp


### PR DESCRIPTION
There is now a custom `SceneBuilder.desktop` file inside `app/assets/linux` directory and the Linux workflow provides the argument `--resource-dir app/assets/linux` to the `jpackage.sh` script.

With that, the package process will use the .desktop template which now also provides the `StartupWMClass` setting.
Unfortunately there seems to be no placeholder such as `MAIN_CLASS` at this point, hence the main class is hardcoded in the .desktop file.

This works for DEB and RPM.

```ini
[Desktop Entry]
Name=APPLICATION_NAME
Comment=APPLICATION_DESCRIPTION
Exec=APPLICATION_LAUNCHER
Icon=APPLICATION_ICON
Terminal=false
Type=Application
Categories=DEPLOY_BUNDLE_CATEGORY
DESKTOP_MIMES
StartupWMClass=com.oracle.javafx.scenebuilder.app.SceneBuilderApp
```

### Issue

Fixes #359

### Progress

- [x] Change must not contain extraneous whitespace
- [x] License header year is updated, if required
- [x] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)