### PR TITLE
release-drafter: categorize changes

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,12 @@
 exclude-labels:
   - 'housekeeping'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'bug'
 template: |
   ## What’s Changed
   $CHANGES


### PR DESCRIPTION
Release drafter is used to automatically create release notes for Scene Builder. Since we have quite a few changes for 17, it is a good idea to categorize them.

All PRs are now labelled as either 'enhancement' or 'bug' . We use these labels against these PRs to group them into 'Features' and 'Bug Fixes' in the release notes.