### PR TITLE
Adds clarification about whitespace to the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,6 +7,6 @@ Fixes #
 
 ### Progress
 
-- [ ] Change must not contain extraneous whitespace
+- [ ] Change must not contain extraneous whitespace changes
 - [ ] License header year is updated, if required
 - [ ] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)


### PR DESCRIPTION
When I made my first PR, I interpreted the first item in the list below as needing to remove extra whitespace from any changed files. However, I now think this was meant to mean "don't include a bunch of whitespace only changes".

I think this change helps to clarify that - if I am right in my new interpretation.

### Progress

- [ ] Change must not contain extraneous whitespace
- [ ] License header year is updated, if required
- [ ] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)