### PR TITLE
Fix early-access GH workflow

### DIFF
--- a/.github/workflows/bundles-kit.yml
+++ b/.github/workflows/bundles-kit.yml
@@ -7,7 +7,7 @@ on:
         required: true
         type: string
       java-version:
-        default: '17.0.2'
+        default: '17.0.1'
         required: false
         type: string
       java-distro:

--- a/.github/workflows/bundles-linux.yml
+++ b/.github/workflows/bundles-linux.yml
@@ -10,7 +10,7 @@ on:
         required: true
         type: string
       java-version:
-        default: '17.0.2'
+        default: '17.0.1'
         required: false
         type: string
       javafx-version:

--- a/.github/workflows/bundles-mac.yml
+++ b/.github/workflows/bundles-mac.yml
@@ -10,7 +10,7 @@ on:
         required: true
         type: string
       java-version:
-        default: '17.0.2'
+        default: '17.0.1'
         required: false
         type: string
       javafx-version:

--- a/.github/workflows/bundles-windows.yml
+++ b/.github/workflows/bundles-windows.yml
@@ -10,7 +10,7 @@ on:
         required: true
         type: string
       java-version:
-        default: '17.0.2'
+        default: '17.0.1'
         required: false
         type: string
       javafx-version:

--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   JAVAFX_VERSION: '17'
-  JAVA_VERSION: '17.0.2'
+  JAVA_VERSION: '17.0.1'
   JAVA_DISTRO: 'temurin'
 
 jobs:
@@ -17,7 +17,7 @@ jobs:
       JAVAFX_VERSION: ${{ env.JAVAFX_VERSION }}
       JAVA_VERSION: ${{ env.JAVA_VERSION }}
       JAVA_DISTRO: ${{ env.JAVA_DISTRO }}
-      VERSION: ${{ steps.vars.outputs.APP_VERSION }}
+      APP_VERSION: ${{ steps.vars.outputs.APP_VERSION }}
       PROJECT_VERSION: ${{ steps.vars.outputs.PROJECT_VERSION }}
     steps:
       - name: Check out repository
@@ -96,7 +96,6 @@ jobs:
     with:
       java-version: ${{ needs.precheck.outputs.JAVA_VERSION }}
       java-distro: ${{ needs.precheck.outputs.JAVA_DISTRO }}
-      app-version: ${{ needs.precheck.outputs.APP_VERSION }}
       project-version: ${{ needs.precheck.outputs.PROJECT_VERSION }}
 
   early-access:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
 
 env:
   JAVAFX_VERSION: '17'
-  JAVA_VERSION: '17.0.2'
+  JAVA_VERSION: '17.0.1'
   JAVA_DISTRO: 'temurin'
 
 jobs:


### PR DESCRIPTION
Remove app-version input from bundles-kit.yml invocation
Issue

Early-access workflow is broken due to an unrecognized input
### Progress

- [x] Change must not contain extraneous whitespace
- [ ] License header year is updated, if required
- [x] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)