### PR TITLE
Update use of secret keys in GH workflows

### DIFF
--- a/.github/workflows/bundles-mac.yml
+++ b/.github/workflows/bundles-mac.yml
@@ -26,17 +26,17 @@ on:
         required: false
         type: boolean
     secrets:
-      CERTIFICATES_FILE_BASE64:
+      certificates-file-base64:
         required: true
-      CERTIFICATES_PASSWORD:
+      certificates-password:
         required: true
-      NOTARIZATION_USERNAME:
+      notarization-username:
         required: true
-      NOTARIZATION_PASSWORD:
+      notarization-password:
         required: true
-      MACSIGN_USER:
+      macsign-user:
         required: true
-      MACSIGN_PREFIX:
+      macsign-prefix:
         required: true
 jobs:
   build:
@@ -52,8 +52,8 @@ jobs:
 
       - uses: Apple-Actions/import-codesign-certs@v1
         with:
-          p12-file-base64: ${{ secrets.CERTIFICATES_FILE_BASE64 }}
-          p12-password: ${{ secrets.CERTIFICATES_PASSWORD }}
+          p12-file-base64: ${{ secrets.certificates-file-base64 }}
+          p12-password: ${{ secrets.certificates-password }}
 
       - name: Setup JavaFX
         run: |
@@ -98,8 +98,8 @@ jobs:
           MAIN_CLASS: com.oracle.javafx.scenebuilder.app.SceneBuilderApp
           JAVAFX_HOME: /tmp/javafx-jmods-${{ inputs.javafx-version }}/
           JPACKAGE_HOME: ${{ env.JAVA_HOME }}
-          MACSIGN_PREFIX: ${{ secrets.MACSIGN_USER }}
-          MACSIGN_USER: ${{ secrets.MACSIGN_PREFIX }}
+          MACSIGN_PREFIX: ${{ secrets.macsign-user }}
+          MACSIGN_USER: ${{ secrets.macsign-prefix }}
           PROJECT_VERSION: ${{ inputs.project-version }}
           APP_VERSION: ${{ inputs.app-version }}
           INSTALL_DIR: app/target/install
@@ -108,10 +108,10 @@ jobs:
         uses: erwin1/xcode-notarize@main
         with:
           product-path: ${{ steps.outputfile.outputs.path }}
-          appstore-connect-username: ${{ secrets.NOTARIZATION_USERNAME }}
-          appstore-connect-password: ${{ secrets.NOTARIZATION_PASSWORD }}
+          appstore-connect-username: ${{ secrets.notarization-username }}
+          appstore-connect-password: ${{ secrets.notarization-password }}
           primary-bundle-id: com.gluonhq.scenebuilder
-          asc-provider: ${{ secrets.MACSIGN_PREFIX }}
+          asc-provider: ${{ secrets.macsign-prefix }}
           verbose: true
 
       - name: Upload Artifact

--- a/.github/workflows/bundles-windows.yml
+++ b/.github/workflows/bundles-windows.yml
@@ -26,11 +26,11 @@ on:
         required: false
         type: boolean
     secrets:
-      WINDOWS_CERTIFICATE:
+      windows-certificate:
         required: true
-      WINDOWS_PASSWORD:
+      windows-password:
         required: true
-      WINDOWS_CERTNAME:
+      windows-certname:
         required: true
 
 jobs:
@@ -88,10 +88,10 @@ jobs:
       - name: Codesign
         uses: erwin1/code-sign-action@master
         with:
-          certificate: '${{ secrets.WINDOWS_CERTIFICATE }}'
-          password: '${{ secrets.WINDOWS_PASSWORD }}'
-          certificatename: '${{ secrets.WINDOWS_CERTNAME }}'
-          folder: 'app/target/install'
+          certificate: ${{ secrets.windows-certificate }}
+          password: ${{ secrets.windows-password }}
+          certificatename: ${{ secrets.windows-certname }}
+          folder: app/target/install
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -61,9 +61,9 @@ jobs:
     needs: [precheck]
     uses: gluonhq/scenebuilder/.github/workflows/bundles-windows.yml@master
     secrets:
-      WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
-      WINDOWS_PASSWORD: ${{ secrets.WINDOWS_PASSWORD }}
-      WINDOWS_CERTNAME: ${{ secrets.WINDOWS_CERTNAME }}
+      windows-certificate: ${{ secrets.WINDOWS_CERTIFICATE }}
+      windows-password: ${{ secrets.WINDOWS_PASSWORD }}
+      windows-certname: ${{ secrets.WINDOWS_CERTNAME }}
     with:
       javafx-version: ${{ needs.precheck.outputs.JAVAFX_VERSION }}
       java-version: ${{ needs.precheck.outputs.JAVA_VERSION }}
@@ -76,12 +76,12 @@ jobs:
     needs: [precheck]
     uses: gluonhq/scenebuilder/.github/workflows/bundles-mac.yml@master
     secrets:
-      CERTIFICATES_FILE_BASE64: ${{ secrets.CERTIFICATES_FILE_BASE64 }}
-      CERTIFICATES_PASSWORD: ${{ secrets.CERTIFICATES_PASSWORD }}
-      NOTARIZATION_USERNAME: ${{ secrets.NOTARIZATION_USERNAME }}
-      NOTARIZATION_PASSWORD: ${{ secrets.NOTARIZATION_PASSWORD }}
-      MACSIGN_USER: ${{ secrets.GLUON_MACSIGN_USER }}
-      MACSIGN_PREFIX: ${{ secrets.GLUON_MACSIGN_PREFIX }}
+      certificates-file-base64: ${{ secrets.CERTIFICATES_FILE_BASE64 }}
+      certificates-password: ${{ secrets.CERTIFICATES_PASSWORD }}
+      notarization-username: ${{ secrets.NOTARIZATION_USERNAME }}
+      notarization-password: ${{ secrets.NOTARIZATION_PASSWORD }}
+      macsign-user: ${{ secrets.GLUON_MACSIGN_USER }}
+      macsign-prefix: ${{ secrets.GLUON_MACSIGN_PREFIX }}
     with:
       javafx-version: ${{ needs.precheck.outputs.JAVAFX_VERSION }}
       java-version: ${{ needs.precheck.outputs.JAVA_VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,9 +66,9 @@ jobs:
     needs: [precheck]
     uses: gluonhq/scenebuilder/.github/workflows/bundles-windows.yml@master
     secrets:
-      WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
-      WINDOWS_PASSWORD: ${{ secrets.WINDOWS_PASSWORD }}
-      WINDOWS_CERTNAME: ${{ secrets.WINDOWS_CERTNAME }}
+      windows-certificate: ${{ secrets.WINDOWS_CERTIFICATE }}
+      windows-password: ${{ secrets.WINDOWS_PASSWORD }}
+      windows-certname: ${{ secrets.WINDOWS_CERTNAME }}
     with:
       javafx-version: ${{ needs.precheck.outputs.JAVAFX_VERSION }}
       java-version: ${{ needs.precheck.outputs.JAVA_VERSION }}
@@ -81,12 +81,12 @@ jobs:
     needs: [precheck]
     uses: gluonhq/scenebuilder/.github/workflows/bundles-mac.yml@master
     secrets:
-      CERTIFICATES_FILE_BASE64: ${{ secrets.CERTIFICATES_FILE_BASE64 }}
-      CERTIFICATES_PASSWORD: ${{ secrets.CERTIFICATES_PASSWORD }}
-      NOTARIZATION_USERNAME: ${{ secrets.NOTARIZATION_USERNAME }}
-      NOTARIZATION_PASSWORD: ${{ secrets.NOTARIZATION_PASSWORD }}
-      MACSIGN_USER: ${{ secrets.GLUON_MACSIGN_USER }}
-      MACSIGN_PREFIX: ${{ secrets.GLUON_MACSIGN_PREFIX }}
+      certificates-file-base64: ${{ secrets.CERTIFICATES_FILE_BASE64 }}
+      certificates-password: ${{ secrets.CERTIFICATES_PASSWORD }}
+      notarization-username: ${{ secrets.NOTARIZATION_USERNAME }}
+      notarization-password: ${{ secrets.NOTARIZATION_PASSWORD }}
+      macsign-user: ${{ secrets.GLUON_MACSIGN_USER }}
+      macsign-prefix: ${{ secrets.GLUON_MACSIGN_PREFIX }}
     with:
       javafx-version: ${{ needs.precheck.outputs.JAVAFX_VERSION }}
       java-version: ${{ needs.precheck.outputs.JAVA_VERSION }}


### PR DESCRIPTION
<!--- Provide a brief summary of the PR -->

### Issue
Early access workflow breaks because signing does not work.

<!--- The issue this PR addresses -->
Fixes #499

### Progress

- [x] Change must not contain extraneous whitespace
- [ ] License header year is updated, if required
- [x] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)