### PR TITLE
Fix typo in jpackage job

### DIFF
--- a/.github/workflows/bundles-mac.yml
+++ b/.github/workflows/bundles-mac.yml
@@ -98,8 +98,8 @@ jobs:
           MAIN_CLASS: com.oracle.javafx.scenebuilder.app.SceneBuilderApp
           JAVAFX_HOME: /tmp/javafx-jmods-${{ inputs.javafx-version }}/
           JPACKAGE_HOME: ${{ env.JAVA_HOME }}
-          MACSIGN_PREFIX: ${{ secrets.MACSIGN_USER }}
-          MACSIGN_USER: ${{ secrets.MACSIGN_PREFIX }}
+          MACSIGN_PREFIX: ${{ secrets.MACSIGN_PREFIX }}
+          MACSIGN_USER: ${{ secrets.MACSIGN_USER }}
           PROJECT_VERSION: ${{ inputs.project-version }}
           APP_VERSION: ${{ inputs.app-version }}
           INSTALL_DIR: app/target/install


### PR DESCRIPTION
The PR fixes the Jpackage step where it fails to find a keychain to sign the bundle.

### Issue

<!--- The issue this PR addresses -->
Fixes #499 