### PR TITLE
docs: Added clear community contribution guidelines

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,6 +7,9 @@ Fixes #
 
 ### Progress
 
+<!-- Please ensure you actioned and ticked each box below before requesting a review -->
+
 - [ ] Change must not contain extraneous whitespace
 - [ ] License header year is updated, if required
+- [ ] The PR name must follow the [pre-defined format](https://github.com/gluonhq/scenebuilder/blob/master/CONTRIBUTING.md)
 - [ ] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,3 @@ The project uses the following Pull Request message guidelines, based on [Conven
 * **test: message** -- change that adds new or updates existing tests and mostly affects the `test` package
 
 For concrete examples, see [latest merged requests](https://github.com/gluonhq/scenebuilder/commits/master).
-
-
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,40 @@
 ## How to Contribute to Scene Builder
 
-Contribution of any form is welcome! Please see the list below on how you can contribute to the project. Once you've decided what you would like to do, let us know about it first in the [Discussions section](https://github.com/gluonhq/scenebuilder/discussions). This is to make sure that the issue you want hasn't already been implemented or being worked on in newer versions. Any new API or changes to existing API should be discussed to avoid inconsistencies.
+Contribution of any form is welcome! Please see the list below on how you can contribute to the project. 
 
 * Provide or suggest an implementation of an issue from [GitHub Issues](https://github.com/gluonhq/scenebuilder/issues).
 * Proof read the [public documentation](https://github.com/gluonhq/scenebuilder/wiki) for errors, ambiguities and typos.
 * Create an issue or suggest a feature backed up by a use case.
 * Add missing tests.
+* Quality-test early release builds.
+
+## Contribution Workflow
+
+1. Pick an unassigned [open issue](https://github.com/gluonhq/scenebuilder/issues).
+2. Comment on it to say you would like to contribute to fixing it and propose a plan (if appropriate).
+3. A maintainer will confirm the issue is valid and can be assigned to you for a fix.
+4. You produce a Pull Request following the Standards below.
+5. Once you tick all check boxes on the Pull Request template, it will be reviewed by a maintainer or a community member.
+6. Once a Pull Request has at least one approval, it will be ready for a merge.
 
 ## Coding Standards
 
 * Any code contribution should follow [the OpenJFX guidelines](https://github.com/openjdk/jfx/blob/master/CONTRIBUTING.md#coding-style-and-testing-guidelines).
 * Any Pull Request should follow the provided template.
+
+## Pull Request Standards
+
+The project uses the following Pull Request message guidelines, based on [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/):
+
+* **build: message** -- change affects the build system, configuration files, scripts, or external dependencies
+* **docs: message** -- change affects documentation **only**, including LICENSE, CONTRIBUTING, README
+* **feat: message** -- change adds a new or modifies an existing feature
+* **fix: message** -- change fixes a bug
+* **perf: message** -- change is related to performance
+* **refactor: message** -- change cleans up or restructures code, including formatting only changes
+* **test: message** -- change that adds new or updates existing tests and mostly affects the `test` package
+
+For concrete examples, see [latest merged requests](https://github.com/gluonhq/scenebuilder/commits/master).
+
+
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Contribution of any form is welcome! Please see the list below on how you can co
 3. A maintainer will confirm the issue is valid and can be assigned to you for a fix.
 4. You produce a Pull Request following the Standards below.
 5. Once you tick all check boxes on the Pull Request template, it will be reviewed by a maintainer or a community member.
-6. Once a Pull Request has at least one approval, it will be ready for a merge.
+6. Once the Pull Request has at least one approval, it will be ready for a merge.
 
 ## Coding Standards
 


### PR DESCRIPTION
<!--- Provide a brief summary of the PR -->
This PR defines and clarifies the contribution workflow (which has been implicit so far).

Practically, the only change is that new PRs must follow the (outlined) subset of Conventional Commits to improve automated changelog generation and quality of text for users. The recently merged #458 introduced jreleaser, which is already configured to read this new format of PR names (commits to `master`).

If contributors forget or omit this, maintainers will still be able to change the PR name before the merge. Alternatively, if you do not wish to have this extra responsibility, simply ping me after a PR is approved and I'm happy to rename it as appropriate.

This PR itself is the first to follow the new workflow, so pinging all @johanvos @eugener @Oliver-Loeffler @abhinayagarwal @jperedadnr for information / comments / approval.

### Issue

<!--- The issue this PR addresses -->
Fixes #451 

### Progress

- [x] Change must not contain extraneous whitespace
- [x] License header year is updated, if required
- [x] The PR name must follow the [pre-defined format](https://github.com/gluonhq/scenebuilder/blob/master/CONTRIBUTING.md)
- [x] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)