### PR TITLE
build: Use JavaFX 18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <maven.compiler.release>${java.version}</maven.compiler.release>
-        <javafx.version>18-ea+12</javafx.version>
+        <javafx.version>18</javafx.version>
         <aether.version>1.1.0</aether.version>
         <charm.glisten.version>6.1.0</charm.glisten.version>
         <gluon.attach.version>4.0.13</gluon.attach.version>


### PR DESCRIPTION
Use JavaFX 18 instead of 18-ea+12

This closes #529


### Issue

We are still using JavaFX 18-ea+12

### Progress

<!-- Please ensure you actioned and ticked each box below before requesting a review -->

- [ ] Change must not contain extraneous whitespace
- [ ] License header year is updated, if required
- [ ] The PR name must follow the [pre-defined format](https://github.com/gluonhq/scenebuilder/blob/master/CONTRIBUTING.md)
- [ ] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)