### PR TITLE
fix: Filenames with underscores are rendered incorrectly on Welcome Page

### DIFF
--- a/app/src/main/java/com/oracle/javafx/scenebuilder/app/welcomedialog/WelcomeDialogWindowController.java
+++ b/app/src/main/java/com/oracle/javafx/scenebuilder/app/welcomedialog/WelcomeDialogWindowController.java
@@ -154,7 +154,8 @@ public class WelcomeDialogWindowController extends TemplatesBaseWindowController
                 recentDocument.setAlignment(Pos.BASELINE_LEFT);
                 recentDocument.setOnAction(event -> fireOpenRecentProject(event, recentItem));
                 recentDocument.setTooltip(new Tooltip(recentItem));
-
+                /* if MnemonicParsing is enabled, file names with underscores are displayed incorrectly */
+                recentDocument.setMnemonicParsing(false);
                 recentDocumentButtons.add(recentDocument);
             }
 


### PR DESCRIPTION
Disabled mnemonic parsing on RecentDocumentsButtons on Welcome Page in oder to have correct file name rendering for filenames with underscores. 

### Issue

Fixes #572 

### Progress

- [x] Change must not contain extraneous whitespace
- [x] License header year is updated, if required
- [x] The PR name must follow the [pre-defined format](https://github.com/gluonhq/scenebuilder/blob/master/CONTRIBUTING.md)
- [x] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)