### PR TITLE
fix: Zoom-in/out using keyboard shortcut not working correctly

### DIFF
--- a/app/src/main/java/com/oracle/javafx/scenebuilder/app/DocumentWindowController.java
+++ b/app/src/main/java/com/oracle/javafx/scenebuilder/app/DocumentWindowController.java
@@ -316,6 +316,21 @@ public class DocumentWindowController extends AbstractFxmlWindowController {
             }
             event.consume();
         }
+
+        // Zoom actions are defined using "+" and "/" keys. Those keys
+        // may exist in standard keys and also on numpad/keypad.
+        // As each menu item can only handle one accelerator, here
+        // the standard keys are handled. The menuBarController handles
+        // KeyCode.ADD (+) and KeyCode.DIVIDE (/)
+        if (KeyCode.PLUS.equals(event.getCode()) && modifierDown) {
+            menuBarController.zoomIn();
+            event.consume();
+        }
+
+        if (KeyCode.SLASH.equals(event.getCode()) && modifierDown) {
+            menuBarController.zoomOut();
+            event.consume();
+        }
     };
     
     /*

--- a/app/src/main/java/com/oracle/javafx/scenebuilder/app/menubar/MenuBarController.java
+++ b/app/src/main/java/com/oracle/javafx/scenebuilder/app/menubar/MenuBarController.java
@@ -209,7 +209,11 @@ public class MenuBarController {
     private MenuItem showSampleControllerMenuItem;
     @FXML
     private Menu zoomMenu;
-
+    
+    private ZoomInActionController zoomInController;
+    
+    private ZoomOutActionController zoomOutController;
+    
     // Modify
     @FXML
     private MenuItem fitToParentMenuItem;
@@ -1269,17 +1273,19 @@ public class MenuBarController {
      */
     
     final static double[] scalingTable = {0.25, 0.50, 0.75, 1.00, 1.50, 2.0, 4.0};
-    
+
     private void updateZoomMenu() {
         final double[] scalingTable = {0.25, 0.50, 0.75, 1.00, 1.50, 2.0, 4.0};
 
+        zoomInController = new ZoomInActionController();
         final MenuItem zoomInMenuItem = new MenuItem(I18N.getString("menu.title.zoom.in"));
-        zoomInMenuItem.setUserData(new ZoomInActionController());
+        zoomInMenuItem.setUserData(zoomInController);
         zoomInMenuItem.setAccelerator(new KeyCodeCombination(KeyCode.ADD, modifier)); //NOI18N
         zoomMenu.getItems().add(zoomInMenuItem);
 
+        zoomOutController = new ZoomOutActionController();
         final MenuItem zoomOutMenuItem = new MenuItem(I18N.getString("menu.title.zoom.out"));
-        zoomOutMenuItem.setUserData(new ZoomOutActionController());
+        zoomOutMenuItem.setUserData(zoomOutController);
         zoomOutMenuItem.setAccelerator(new KeyCodeCombination(KeyCode.DIVIDE, modifier));  //NOI18N
         zoomMenu.getItems().add(zoomOutMenuItem);
         
@@ -1294,7 +1300,20 @@ public class MenuBarController {
         }
     }
 
+    public void zoomIn() {
+        runActionController(zoomInController);
+    }
     
+    public void zoomOut() {
+        runActionController(zoomOutController);
+    }
+    
+    private void runActionController(MenuItemController controllerToRun) {
+        if (controllerToRun.canPerform()) {
+            controllerToRun.perform();
+        }
+    }
+
     private static int findZoomScaleIndex(double zoomScale) {
         int result = -1;
         

--- a/app/src/main/java/com/oracle/javafx/scenebuilder/app/menubar/MenuBarController.java
+++ b/app/src/main/java/com/oracle/javafx/scenebuilder/app/menubar/MenuBarController.java
@@ -1275,12 +1275,12 @@ public class MenuBarController {
 
         final MenuItem zoomInMenuItem = new MenuItem(I18N.getString("menu.title.zoom.in"));
         zoomInMenuItem.setUserData(new ZoomInActionController());
-        zoomInMenuItem.setAccelerator(new KeyCharacterCombination("+", modifier)); //NOI18N
+        zoomInMenuItem.setAccelerator(new KeyCodeCombination(KeyCode.ADD, modifier)); //NOI18N
         zoomMenu.getItems().add(zoomInMenuItem);
-        
+
         final MenuItem zoomOutMenuItem = new MenuItem(I18N.getString("menu.title.zoom.out"));
         zoomOutMenuItem.setUserData(new ZoomOutActionController());
-        zoomOutMenuItem.setAccelerator(new KeyCharacterCombination("/", modifier));  //NOI18N
+        zoomOutMenuItem.setAccelerator(new KeyCodeCombination(KeyCode.DIVIDE, modifier));  //NOI18N
         zoomMenu.getItems().add(zoomOutMenuItem);
         
         zoomMenu.getItems().add(new SeparatorMenuItem());


### PR DESCRIPTION
Zoom-In/Out was supposed to work with keyboard shortcuts.
For Zoom-In `MODIFIER`+`+` and for Zoom-Out `MODIFIER`+`/` were defined.
For some reason the predefined KeyCombinations were not working.
Also, many keyboards have two keys for `+` (the PLUS key and the ADD key) and the same applies to `/`, which is mapped to SLASH and DIVIDE.

The `DocumentWindowController` offers a `mainKeyEventFilter` where those double accelerators can be tracked.
The class `MenuBarController` now handles the mappings to ADD and DIVIDE whereas PLUS and SLASH are handled by the `DocumentWindowController`.

### Issue

Fixes #424

### Progress

<!-- Please ensure you actioned and ticked each box below before requesting a review -->

- [ ] Change must not contain extraneous whitespace
- [ ] License header year is updated, if required
- [ ] The PR name must follow the [pre-defined format](https://github.com/gluonhq/scenebuilder/blob/master/CONTRIBUTING.md)
- [ ] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)