### PR TITLE
feat: Enabled loading of FXML files via drag&drop to WelcomeScreen.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
 
 env:
-  JAVA_VERSION: '22'
+  JAVA_VERSION: '23'
 
 jobs:
   verify:

--- a/.github/workflows/bundles-kit.yml
+++ b/.github/workflows/bundles-kit.yml
@@ -7,7 +7,7 @@ on:
         required: true
         type: string
       java-version:
-        default: '22'
+        default: '23'
         required: false
         type: string
 

--- a/.github/workflows/bundles-linux.yml
+++ b/.github/workflows/bundles-linux.yml
@@ -10,11 +10,11 @@ on:
         required: true
         type: string
       java-version:
-        default: '22'
+        default: '23'
         required: false
         type: string
       javafx-version:
-        default: '22'
+        default: '23'
         required: false
         type: string
       test:
@@ -38,8 +38,11 @@ jobs:
           release: ${{ inputs.java-version }}
 
       - name: Setup JavaFX
+        id: javafx
         run: |
-          wget -P /tmp https://download2.gluonhq.com/openjfx/${{ inputs.javafx-version }}/openjfx-${{ inputs.javafx-version }}_linux-x64_bin-jmods.zip
+          JAVAFX_MAJOR_VERSION=$(echo ${{ inputs.javafx-version }} | cut -d- -f1)
+          echo JAVAFX_MAJOR_VERSION=$JAVAFX_MAJOR_VERSION >> $GITHUB_OUTPUT
+          wget -P /tmp https://download2.gluonhq.com/openjfx/$JAVAFX_MAJOR_VERSION/openjfx-${{ inputs.javafx-version }}_linux-x64_bin-jmods.zip
           unzip /tmp/openjfx-${{ inputs.javafx-version }}_linux-x64_bin-jmods.zip -d /tmp
 
       - name: Cache Maven packages
@@ -89,7 +92,7 @@ jobs:
           ls ${{ env.INSTALL_DIR }}
         env:
           MAIN_CLASS: com.oracle.javafx.scenebuilder.app.SceneBuilderApp
-          JAVAFX_HOME: /tmp/javafx-jmods-${{ inputs.javafx-version }}/
+          JAVAFX_HOME: /tmp/javafx-jmods-${{ steps.javafx.outputs.JAVAFX_MAJOR_VERSION }}/
           JPACKAGE_HOME: ${{ env.JAVA_HOME }}
           PROJECT_VERSION: ${{ inputs.project-version }}
           APP_VERSION: ${{ inputs.app-version }}

--- a/.github/workflows/bundles-mac.yml
+++ b/.github/workflows/bundles-mac.yml
@@ -10,11 +10,11 @@ on:
         required: true
         type: string
       java-version:
-        default: '22'
+        default: '23'
         required: false
         type: string
       javafx-version:
-        default: '22'
+        default: '23'
         required: false
         type: string
       test:
@@ -52,8 +52,11 @@ jobs:
           p12-password: ${{ secrets.CERTIFICATES_PASSWORD }}
 
       - name: Setup JavaFX
+        id: javafx
         run: |
-          wget -P /tmp https://download2.gluonhq.com/openjfx/${{ inputs.javafx-version }}/openjfx-${{ inputs.javafx-version }}_osx-x64_bin-jmods.zip
+          JAVAFX_MAJOR_VERSION=$(echo ${{ inputs.javafx-version }} | cut -d- -f1)
+          echo JAVAFX_MAJOR_VERSION=$JAVAFX_MAJOR_VERSION >> $GITHUB_OUTPUT
+          wget -P /tmp https://download2.gluonhq.com/openjfx/$JAVAFX_MAJOR_VERSION/openjfx-${{ inputs.javafx-version }}_osx-x64_bin-jmods.zip
           unzip /tmp/openjfx-${{ inputs.javafx-version }}_osx-x64_bin-jmods.zip -d /tmp
 
       - name: Cache Maven packages
@@ -89,10 +92,10 @@ jobs:
             --mac-sign
           mv ${{ env.INSTALL_DIR }}/SceneBuilder-${{ env.APP_VERSION }}.dmg ${{ env.INSTALL_DIR }}/SceneBuilder-${{ env.PROJECT_VERSION }}-amd64.dmg
           ls ${{ env.INSTALL_DIR }}
-          echo ::set-output name=path::${{ env.INSTALL_DIR }}/SceneBuilder-${{ env.PROJECT_VERSION }}-amd64.dmg
+          echo path=${{ env.INSTALL_DIR }}/SceneBuilder-${{ env.PROJECT_VERSION }}-amd64.dmg >> $GITHUB_OUTPUT
         env:
           MAIN_CLASS: com.oracle.javafx.scenebuilder.app.SceneBuilderApp
-          JAVAFX_HOME: /tmp/javafx-jmods-${{ inputs.javafx-version }}/
+          JAVAFX_HOME: /tmp/javafx-jmods-${{ steps.javafx.outputs.JAVAFX_MAJOR_VERSION }}/
           JPACKAGE_HOME: ${{ env.JAVA_HOME }}
           MACSIGN_PREFIX: ${{ secrets.MACSIGN_PREFIX }}
           MACSIGN_USER: ${{ secrets.MACSIGN_USER }}

--- a/.github/workflows/bundles-mac_aarch64.yml
+++ b/.github/workflows/bundles-mac_aarch64.yml
@@ -10,11 +10,11 @@ on:
         required: true
         type: string
       java-version:
-        default: '22'
+        default: '23'
         required: false
         type: string
       javafx-version:
-        default: '22'
+        default: '23'
         required: false
         type: string
       test:
@@ -53,8 +53,11 @@ jobs:
           p12-password: ${{ secrets.CERTIFICATES_PASSWORD }}
 
       - name: Setup JavaFX
+        id: javafx
         run: |
-          wget -P /tmp https://download2.gluonhq.com/openjfx/${{ inputs.javafx-version }}/openjfx-${{ inputs.javafx-version }}_osx-aarch64_bin-jmods.zip
+          JAVAFX_MAJOR_VERSION=$(echo ${{ inputs.javafx-version }} | cut -d- -f1)
+          echo JAVAFX_MAJOR_VERSION=$JAVAFX_MAJOR_VERSION >> $GITHUB_OUTPUT
+          wget -P /tmp https://download2.gluonhq.com/openjfx/$JAVAFX_MAJOR_VERSION/openjfx-${{ inputs.javafx-version }}_osx-aarch64_bin-jmods.zip
           unzip /tmp/openjfx-${{ inputs.javafx-version }}_osx-aarch64_bin-jmods.zip -d /tmp
 
       - name: Cache Maven packages
@@ -90,10 +93,10 @@ jobs:
             --mac-sign
           mv ${{ env.INSTALL_DIR }}/SceneBuilder-${{ env.APP_VERSION }}.dmg ${{ env.INSTALL_DIR }}/SceneBuilder-${{ env.PROJECT_VERSION }}-aarch64.dmg
           ls ${{ env.INSTALL_DIR }}
-          echo ::set-output name=path::${{ env.INSTALL_DIR }}/SceneBuilder-${{ env.PROJECT_VERSION }}-aarch64.dmg
+          echo path=${{ env.INSTALL_DIR }}/SceneBuilder-${{ env.PROJECT_VERSION }}-aarch64.dmg >> $GITHUB_OUTPUT
         env:
           MAIN_CLASS: com.oracle.javafx.scenebuilder.app.SceneBuilderApp
-          JAVAFX_HOME: /tmp/javafx-jmods-${{ inputs.javafx-version }}/
+          JAVAFX_HOME: /tmp/javafx-jmods-${{ steps.javafx.outputs.JAVAFX_MAJOR_VERSION }}/
           JPACKAGE_HOME: ${{ env.JAVA_HOME }}
           MACSIGN_PREFIX: ${{ secrets.MACSIGN_PREFIX }}
           MACSIGN_USER: ${{ secrets.MACSIGN_USER }}

--- a/.github/workflows/bundles-windows.yml
+++ b/.github/workflows/bundles-windows.yml
@@ -10,11 +10,11 @@ on:
         required: true
         type: string
       java-version:
-        default: '22'
+        default: '23'
         required: false
         type: string
       javafx-version:
-        default: '22'
+        default: '23'
         required: false
         type: string
       test:
@@ -42,9 +42,12 @@ jobs:
           release: ${{ inputs.java-version }}
 
       - name: Setup JavaFX
+        id: javafx
         shell: pwsh
         run: |
-          Invoke-WebRequest -Uri https://download2.gluonhq.com/openjfx/${{ inputs.javafx-version }}/openjfx-${{ inputs.javafx-version }}_windows-x64_bin-jmods.zip -OutFile D:\openjfx-${{ inputs.javafx-version }}_windows-x64_bin-jmods.zip
+          $JAVAFX_MAJOR_VERSION = '${{ inputs.javafx-version }}' -split '-' | Select-Object -Index 0
+          echo "JAVAFX_MAJOR_VERSION=$JAVAFX_MAJOR_VERSION" >> $env:GITHUB_OUTPUT
+          Invoke-WebRequest -Uri https://download2.gluonhq.com/openjfx/$JAVAFX_MAJOR_VERSION/openjfx-${{ inputs.javafx-version }}_windows-x64_bin-jmods.zip -OutFile D:\openjfx-${{ inputs.javafx-version }}_windows-x64_bin-jmods.zip
           Expand-Archive -Force D:\openjfx-${{ inputs.javafx-version }}_windows-x64_bin-jmods.zip D:\
 
       - name: Cache Maven packages
@@ -75,7 +78,7 @@ jobs:
           call dir ${{ env.INSTALL_DIR }}
         env:
           MAIN_CLASS: com.oracle.javafx.scenebuilder.app.SceneBuilderApp
-          JAVAFX_HOME: D:\javafx-jmods-${{ inputs.javafx-version }}
+          JAVAFX_HOME: D:\javafx-jmods-${{ steps.javafx.outputs.JAVAFX_MAJOR_VERSION }}
           JPACKAGE_HOME: ${{ env.JAVA_HOME }}
           PROJECT_VERSION: ${{ inputs.project-version }}
           APP_VERSION: ${{ inputs.app-version }}

--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -46,7 +46,7 @@ jobs:
 
   linux-bundles:
     needs: [precheck]
-    uses: gluonhq/scenebuilder/.github/workflows/bundles-linux.yml@master
+    uses: ./.github/workflows/bundles-linux.yml
     with:
       javafx-version: ${{ needs.precheck.outputs.JAVAFX_VERSION }}
       java-version: ${{ needs.precheck.outputs.JAVA_VERSION }}
@@ -56,7 +56,7 @@ jobs:
 
   windows-bundles:
     needs: [precheck]
-    uses: gluonhq/scenebuilder/.github/workflows/bundles-windows.yml@master
+    uses: ./.github/workflows/bundles-windows.yml
     secrets:
       WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
       WINDOWS_PASSWORD: ${{ secrets.WINDOWS_PASSWORD }}
@@ -70,7 +70,7 @@ jobs:
 
   mac-bundles:
     needs: [precheck]
-    uses: gluonhq/scenebuilder/.github/workflows/bundles-mac.yml@master
+    uses: ./.github/workflows/bundles-mac.yml
     secrets:
       CERTIFICATES_FILE_BASE64: ${{ secrets.CERTIFICATES_FILE_BASE64 }}
       CERTIFICATES_PASSWORD: ${{ secrets.CERTIFICATES_PASSWORD }}
@@ -87,7 +87,7 @@ jobs:
 
   mac_aarch64-bundles:
     needs: [precheck]
-    uses: gluonhq/scenebuilder/.github/workflows/bundles-mac_aarch64.yml@master
+    uses: ./.github/workflows/bundles-mac_aarch64.yml
     secrets:
       CERTIFICATES_FILE_BASE64: ${{ secrets.CERTIFICATES_FILE_BASE64 }}
       CERTIFICATES_PASSWORD: ${{ secrets.CERTIFICATES_PASSWORD }}
@@ -104,7 +104,7 @@ jobs:
 
   kit-bundles:
     needs: [precheck]
-    uses: gluonhq/scenebuilder/.github/workflows/bundles-kit.yml@master
+    uses: ./.github/workflows/bundles-kit.yml
     with:
       java-version: ${{ needs.precheck.outputs.JAVA_VERSION }}
       project-version: ${{ needs.precheck.outputs.PROJECT_VERSION }}

--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -5,8 +5,8 @@ on:
     branches: [ master ]
 
 env:
-  JAVAFX_VERSION: '22'
-  JAVA_VERSION: '22'
+  JAVA_VERSION: '23'
+  JAVAFX_VERSION: '23-ea+27'
 
 jobs:
   precheck:
@@ -41,8 +41,8 @@ jobs:
           PROJECT_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           APP_VERSION=$PROJECT_VERSION
           APP_VERSION=${APP_VERSION%-*}
-          echo ::set-output name=APP_VERSION::$APP_VERSION
-          echo ::set-output name=PROJECT_VERSION::$PROJECT_VERSION
+          echo APP_VERSION=$APP_VERSION >> $GITHUB_OUTPUT
+          echo PROJECT_VERSION=$PROJECT_VERSION >> $GITHUB_OUTPUT
 
   linux-bundles:
     needs: [precheck]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
 
   linux-bundles:
     needs: [precheck]
-    uses: gluonhq/scenebuilder/.github/workflows/bundles-linux.yml@master
+    uses: ./.github/workflows/bundles-linux.yml
     with:
       javafx-version: ${{ needs.precheck.outputs.JAVAFX_VERSION }}
       java-version: ${{ needs.precheck.outputs.JAVA_VERSION }}
@@ -70,7 +70,7 @@ jobs:
 
   windows-bundles:
     needs: [precheck]
-    uses: gluonhq/scenebuilder/.github/workflows/bundles-windows.yml@master
+    uses: ./.github/workflows/bundles-windows.yml
     secrets:
       WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
       WINDOWS_PASSWORD: ${{ secrets.WINDOWS_PASSWORD }}
@@ -84,7 +84,7 @@ jobs:
 
   mac-bundles:
     needs: [precheck]
-    uses: gluonhq/scenebuilder/.github/workflows/bundles-mac.yml@master
+    uses: ./.github/workflows/bundles-mac.yml
     secrets:
       CERTIFICATES_FILE_BASE64: ${{ secrets.CERTIFICATES_FILE_BASE64 }}
       CERTIFICATES_PASSWORD: ${{ secrets.CERTIFICATES_PASSWORD }}
@@ -101,7 +101,7 @@ jobs:
 
   mac_aarch64-bundles:
     needs: [precheck]
-    uses: gluonhq/scenebuilder/.github/workflows/bundles-mac_aarch64.yml@master
+    uses: ./.github/workflows/bundles-mac_aarch64.yml
     secrets:
       CERTIFICATES_FILE_BASE64: ${{ secrets.CERTIFICATES_FILE_BASE64 }}
       CERTIFICATES_PASSWORD: ${{ secrets.CERTIFICATES_PASSWORD }}
@@ -118,7 +118,7 @@ jobs:
 
   kit-bundles:
     needs: [precheck]
-    uses: gluonhq/scenebuilder/.github/workflows/bundles-kit.yml@master
+    uses: ./.github/workflows/bundles-kit.yml
     with:
       java-version: ${{ needs.precheck.outputs.JAVA_VERSION }}
       project-version: ${{ needs.precheck.outputs.PROJECT_VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,8 @@ on:
           - GA
 
 env:
-  JAVAFX_VERSION: '22'
-  JAVA_VERSION: '22'
+  JAVAFX_VERSION: '23'
+  JAVA_VERSION: '23'
 
 jobs:
   precheck:
@@ -54,9 +54,9 @@ jobs:
               S3_PATH=RC/$PROJECT_VERSION
           fi
           echo "Releasing.. "$PROJECT_VERSION
-          echo ::set-output name=APP_VERSION::$APP_VERSION
-          echo ::set-output name=PROJECT_VERSION::$PROJECT_VERSION
-          echo ::set-output name=S3_PATH::$S3_PATH
+          echo APP_VERSION=$APP_VERSION >> $GITHUB_OUTPUT
+          echo PROJECT_VERSION=$PROJECT_VERSION >> $GITHUB_OUTPUT
+          echo S3_PATH=$S3_PATH >> $GITHUB_OUTPUT
 
   linux-bundles:
     needs: [precheck]

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.gluonhq.scenebuilder</groupId>
         <artifactId>parent</artifactId>
-        <version>22.0.1-SNAPSHOT</version>
+        <version>23.0.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/app/src/main/java/com/oracle/javafx/scenebuilder/app/welcomedialog/WelcomeDialogFilesDropHandler.java
+++ b/app/src/main/java/com/oracle/javafx/scenebuilder/app/welcomedialog/WelcomeDialogFilesDropHandler.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2024, Gluon and/or its affiliates.
+ * All rights reserved. Use is subject to license terms.
+ *
+ * This file is available and licensed under the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the distribution.
+ *  - Neither the name of Oracle Corporation and Gluon nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.oracle.javafx.scenebuilder.app.welcomedialog;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+final class WelcomeDialogFilesDropHandler {
+
+    private static final Logger LOGGER = Logger.getLogger(WelcomeDialogFilesDropHandler.class.getName());
+
+    private final List<File> droppedFiles;
+    private final List<String> toOpen;
+    private final List<String> unsupportedItems;
+    private Consumer<List<String>> openFiles;
+    private Consumer<List<String>> handleUnsupported;
+
+    WelcomeDialogFilesDropHandler(List<File> droppedFiles) {
+        this.droppedFiles = Objects.requireNonNull(droppedFiles);
+        this.toOpen = new ArrayList<>(droppedFiles.size());
+        this.unsupportedItems = new ArrayList<>(droppedFiles.size());
+    }
+
+    final WelcomeDialogFilesDropHandler withSupportedFiles(Consumer<List<String>> handleOpen) {
+        this.openFiles = handleOpen;
+        return this;
+    }
+
+    final WelcomeDialogFilesDropHandler withUnsupportedFiles(Consumer<List<String>> unsupportedHandler) {
+        this.handleUnsupported = unsupportedHandler;
+        return this;
+    }
+
+    final void run() {
+        analyzeDroppedItems();
+        handleDropResult();
+    }
+
+    final void handleDropResult() {
+        if (this.openFiles == null) {
+            throw new IllegalStateException("Please configure a dropped file handling action using the withSupportedFiles(...) method.");
+        }
+        if (this.handleUnsupported == null) {
+            throw new IllegalStateException("Please configure an action for handling of unsupported files using withUnsupportedFiles(...) method.");
+        }
+        
+        if (!toOpen.isEmpty()) {
+            LOGGER.log(Level.INFO, "Received drop event to open files...");
+            openFiles.accept(toOpen);
+        } else {
+            LOGGER.log(Level.INFO, "Dropped object does not contain any loadable FXML files.");
+            handleUnsupported.accept(unsupportedItems);
+        }
+    }
+
+    final void analyzeDroppedItems() {
+        if (droppedFiles.isEmpty()) {
+            return;
+        }
+
+        for (var file : droppedFiles) {
+            if (file.isDirectory()) {
+                File[] children = file.listFiles();
+                List<String> inDir = new ArrayList<>(children.length);
+                for (var child : children) {
+                    if (isFxml(child)) {
+                        inDir.add(child.getAbsolutePath());
+                    }
+                }
+                if (inDir.isEmpty()) {
+                    unsupportedItems.add(file.getAbsolutePath());
+                } else {
+                    toOpen.addAll(inDir);
+                }
+            } else {
+                if (isFxml(file)) {
+                    toOpen.add(file.getAbsolutePath());
+                } else {
+                    unsupportedItems.add(file.getAbsolutePath());
+                }
+            }
+        }
+    }
+
+    final boolean isFxml(File file) {
+        if (file.isDirectory()) {
+            return false;
+        }
+        return file.toString()
+                   .toLowerCase()
+                   .endsWith(".fxml");
+    }
+}

--- a/app/src/main/java/com/oracle/javafx/scenebuilder/app/welcomedialog/WelcomeDialogWindowController.java
+++ b/app/src/main/java/com/oracle/javafx/scenebuilder/app/welcomedialog/WelcomeDialogWindowController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Gluon and/or its affiliates.
+ * Copyright (c) 2017, 2024, Gluon and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -32,14 +32,27 @@
 
 package com.oracle.javafx.scenebuilder.app.welcomedialog;
 
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
 import com.oracle.javafx.scenebuilder.app.SceneBuilderApp;
 import com.oracle.javafx.scenebuilder.app.i18n.I18N;
 import com.oracle.javafx.scenebuilder.app.preferences.PreferencesController;
 import com.oracle.javafx.scenebuilder.app.preferences.PreferencesRecordGlobal;
 import com.oracle.javafx.scenebuilder.app.util.AppSettings;
 import com.oracle.javafx.scenebuilder.kit.editor.EditorController;
+import com.oracle.javafx.scenebuilder.kit.editor.panel.util.dialog.AlertDialog;
+import com.oracle.javafx.scenebuilder.kit.editor.panel.util.dialog.AbstractModalDialog.ButtonID;
 import com.oracle.javafx.scenebuilder.kit.template.Template;
 import com.oracle.javafx.scenebuilder.kit.template.TemplatesBaseWindowController;
+
 import javafx.application.Platform;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
@@ -52,14 +65,12 @@ import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.VBox;
 import javafx.stage.FileChooser;
 import javafx.stage.Modality;
+import javafx.stage.Stage;
 import javafx.stage.WindowEvent;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
-
 public class WelcomeDialogWindowController extends TemplatesBaseWindowController {
+
+    private static final Logger LOGGER = Logger.getLogger(WelcomeDialogWindowController.class.getName());
 
     @FXML
     private BorderPane contentPane;
@@ -80,7 +91,7 @@ public class WelcomeDialogWindowController extends TemplatesBaseWindowController
 
     private final SceneBuilderApp sceneBuilderApp;
 
-    private WelcomeDialogWindowController() {
+    WelcomeDialogWindowController() {
         super(WelcomeDialogWindowController.class.getResource("WelcomeWindow.fxml"), //NOI18N
                 I18N.getBundle(),
                 null); // We want it to be a top level window so we're setting the owner to null.
@@ -168,7 +179,7 @@ public class WelcomeDialogWindowController extends TemplatesBaseWindowController
     }
 
     public static WelcomeDialogWindowController getInstance() {
-        if (instance == null){
+        if (instance == null) {
             instance = new WelcomeDialogWindowController();
             var stage = instance.getStage();
             stage.setMinWidth(800);
@@ -201,7 +212,6 @@ public class WelcomeDialogWindowController extends TemplatesBaseWindowController
                 new FileChooser.ExtensionFilter(I18N.getString("file.filter.label.fxml"), "*.fxml")
         );
         fileChooser.setInitialDirectory(EditorController.getNextInitialDirectory());
-
         List<File> fxmlFiles = fileChooser.showOpenMultipleDialog(getStage());
 
         // no file was selected, so nothing to do
@@ -215,17 +225,101 @@ public class WelcomeDialogWindowController extends TemplatesBaseWindowController
 
         handleOpen(paths);
     }
+    
+    protected static AlertDialog questionMissingFilesCleanup(Stage stage, List<String> missingFiles) {
+        String withPath = missingFiles.stream()
+                                      .collect(Collectors.joining(System.lineSeparator()));
+        
+        AlertDialog question = new AlertDialog(stage);
+        question.setDefaultButtonID(ButtonID.CANCEL);
+        question.setShowDefaultButton(true);
+        question.setOKButtonTitle(I18N.getString("alert.welcome.file.not.found.okay"));
+        question.setTitle(I18N.getString("alert.welcome.file.not.found.title"));
+        question.setMessage(I18N.getString("alert.welcome.file.not.found.question"));
+        question.setCancelButtonTitle(I18N.getString("alert.welcome.file.not.found.no"));
+        question.setDetails(I18N.getString("alert.welcome.file.not.found.message") + withPath);
+        return question;
+    }
+    
+    boolean filePathExists(String filePath) {
+        return Files.exists(Path.of(filePath));
+    }
 
-    private void handleOpen(List<String> paths) {
-        if (sceneBuilderApp.startupTasksFinishedBinding().get()) {
-            sceneBuilderApp.handleOpenFilesAction(paths);
-            getStage().hide();
-        } else {
-            showMasker(() -> {
-                sceneBuilderApp.handleOpenFilesAction(paths);
-                getStage().hide();
-            });
+    /**
+     * Attempts to open files in filePaths. Scene Builder will only attempt to load
+     * files which exist. If a file does not exist, Scene Builder will ask the user
+     * to remove this file from recent files.
+     * 
+     * @param filePaths List of file paths to project files to be opened by Scene
+     *                  Builder.
+     */
+    private void handleOpen(List<String> filePaths) {
+        handleOpen(filePaths, 
+                   this::askUserToRemoveMissingRecentFiles,
+                   this::attemptOpenExistingFiles);
+    }
+
+    private void askUserToRemoveMissingRecentFiles(List<String> missingFiles) {
+        if (!missingFiles.isEmpty()) {
+            var questionDialog = questionMissingFilesCleanup(getStage(), missingFiles);
+            if (questionDialog.showAndWait() == AlertDialog.ButtonID.OK) {
+                removeMissingFilesFromPrefs(missingFiles);
+                loadAndPopulateRecentItemsInBackground();
+            }
         }
+    }
+
+    private void attemptOpenExistingFiles(List<String> paths) {
+        if (sceneBuilderApp.startupTasksFinishedBinding().get()) {
+            openFilesAndHideStage(paths);
+        } else {
+            showMasker(() -> openFilesAndHideStage(paths));
+        }
+    }
+
+    private void openFilesAndHideStage(List<String> files) {
+        sceneBuilderApp.handleOpenFilesAction(files, () -> getStage().hide());
+    }
+
+    /**
+     * Attempts to open files in filePaths.
+     * In case of files are missing, a special procedure is applied to handle missing files.
+     *  
+     * @param filePaths List of file paths to project files to be opened by Scene Builder.
+     * @param missingFilesHandler Determines how missing files are handled.
+     * @param fileLoader Determines how files are loaded.
+     */
+    void handleOpen(List<String> filePaths, 
+                    Consumer<List<String>> missingFilesHandler,
+                    Consumer<List<String>> fileLoader) {
+
+        if (filePaths.isEmpty()) {
+            return;
+        }
+
+        List<String> existingFiles = new ArrayList<>();
+        List<String> missingFiles = new ArrayList<>();
+        filePaths.forEach(file -> {
+            if (filePathExists(file)) {
+                existingFiles.add(file);
+            } else {
+                missingFiles.add(file);
+            }
+        });
+        
+        missingFilesHandler.accept(missingFiles);
+
+        if (existingFiles.isEmpty()) {
+            return;
+        }
+
+        fileLoader.accept(existingFiles);
+    }
+
+    private void removeMissingFilesFromPrefs(List<String> missingFiles) {
+        missingFiles.forEach(fxmlFileName -> LOGGER.log(Level.INFO, "Removing missing file from recent items: {0}", fxmlFileName));
+        PreferencesRecordGlobal preferencesRecordGlobal = PreferencesController.getSingleton().getRecordGlobal();
+        preferencesRecordGlobal.removeRecentItems(missingFiles);
     }
 
     private void showMasker(Runnable onEndAction) {
@@ -239,7 +333,6 @@ public class WelcomeDialogWindowController extends TemplatesBaseWindowController
             if (isFinished) {
                 Platform.runLater(() -> {
                     onEndAction.run();
-
                     // restore state in case welcome dialog is opened again
                     contentPane.setDisable(false);
                     masker.setVisible(false);

--- a/app/src/main/java/com/oracle/javafx/scenebuilder/app/welcomedialog/WelcomeDialogWindowController.java
+++ b/app/src/main/java/com/oracle/javafx/scenebuilder/app/welcomedialog/WelcomeDialogWindowController.java
@@ -50,6 +50,7 @@ import com.oracle.javafx.scenebuilder.app.util.AppSettings;
 import com.oracle.javafx.scenebuilder.kit.editor.EditorController;
 import com.oracle.javafx.scenebuilder.kit.editor.panel.util.dialog.AlertDialog;
 import com.oracle.javafx.scenebuilder.kit.editor.panel.util.dialog.AbstractModalDialog.ButtonID;
+import com.oracle.javafx.scenebuilder.kit.editor.panel.util.dialog.ErrorDialog;
 import com.oracle.javafx.scenebuilder.kit.template.Template;
 import com.oracle.javafx.scenebuilder.kit.template.TemplatesBaseWindowController;
 
@@ -61,6 +62,8 @@ import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.control.ProgressIndicator;
 import javafx.scene.control.Tooltip;
+import javafx.scene.input.DragEvent;
+import javafx.scene.input.TransferMode;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.VBox;
 import javafx.stage.FileChooser;
@@ -115,6 +118,33 @@ public class WelcomeDialogWindowController extends TemplatesBaseWindowController
 
         getStage().setTitle(I18N.getString("welcome.title"));
         getStage().initModality(Modality.APPLICATION_MODAL);
+    }
+    
+    @FXML
+    void handleFileDraggedOver(DragEvent event) {
+        if (event.getDragboard().hasFiles()) {
+            event.acceptTransferModes(TransferMode.ANY);
+        }
+    }
+
+    @FXML
+    void handleDroppedFiles(DragEvent event) {
+        if (event.getDragboard().hasFiles()) {
+            new WelcomeDialogFilesDropHandler(event.getDragboard().getFiles())
+                .withSupportedFiles(fileNames->Platform.runLater(()->handleOpen(fileNames)))
+                .withUnsupportedFiles(unsupported->notifyUserWhenDroppedUnsupportedFiles(unsupported))
+                .run();
+        }
+    }
+
+    private void notifyUserWhenDroppedUnsupportedFiles(List<String> unsupported) {
+        ErrorDialog dialog = new ErrorDialog(getStage());
+        dialog.setTitle(I18N.getString("welcome.loading.when.dropped.error.title"));
+        dialog.setMessage(I18N.getString("welcome.loading.when.dropped.error.message"));
+        String detail = unsupported.stream()
+                                   .collect(Collectors.joining(System.lineSeparator()));
+        dialog.setDetails(detail);
+        Platform.runLater(()->dialog.showAndWait());
     }
 
     @Override
@@ -292,7 +322,7 @@ public class WelcomeDialogWindowController extends TemplatesBaseWindowController
     void handleOpen(List<String> filePaths, 
                     Consumer<List<String>> missingFilesHandler,
                     Consumer<List<String>> fileLoader) {
-
+        LOGGER.log(Level.INFO, "Attempting to open files: {0}", filePaths);
         if (filePaths.isEmpty()) {
             return;
         }

--- a/app/src/main/resources/com/oracle/javafx/scenebuilder/app/i18n/SceneBuilderApp.properties
+++ b/app/src/main/resources/com/oracle/javafx/scenebuilder/app/i18n/SceneBuilderApp.properties
@@ -511,6 +511,9 @@ welcome.recent.items.loading = Loading recent projects...
 welcome.recent.items.no.recent.items = no recent projects
 welcome.open.project.label = Open Project
 welcome.loading.label = Loading Components...
+welcome.loading.when.dropped.error.title=Unsupported file format or empty directory
+welcome.loading.when.dropped.error.message=The dropped object is either not a JavaFX FXML file or does not contain any FXML files to be loaded.
+
 # -- Template (this keys are replicated from SceneBuilderKit.properties)
 template.new.project.label = New Project from Template
 template.title.header.desktop = Desktop

--- a/app/src/main/resources/com/oracle/javafx/scenebuilder/app/i18n/SceneBuilderApp.properties
+++ b/app/src/main/resources/com/oracle/javafx/scenebuilder/app/i18n/SceneBuilderApp.properties
@@ -1,4 +1,4 @@
-# Copyright (c) 2016, 2023, Gluon and/or its affiliates.
+# Copyright (c) 2016, 2024, Gluon and/or its affiliates.
 # Copyright (c) 2012, 2014, Oracle and/or its affiliates.
 # All rights reserved. Use is subject to license terms.
 #
@@ -397,12 +397,9 @@ alert.title.copy = Copy
 alert.title.start = Startup
 alert.title.messagebox = External Open
 
+alert.open.failure.title = File Open Error
 alert.open.failure1.message = Could not open ''{0}''
 alert.open.failure1.details = Open operation has failed. Make sure that the chosen file is a valid FXML document.
-alert.open.failureN.message = Could not open the specified files
-alert.open.failureN.details = Open operation has failed. Make sure that those files are valid FXML documents.
-alert.open.failureMofN.message = Could not open {0} files
-alert.open.failureMofN.details = Open operation has failed for some files. Make sure that those files are valid FXML documents.
 alert.review.question.message = {0} of your documents contain unsaved changes. Do you want to review them before exiting ?
 alert.review.question.details = Your changes will be lost if you don't review them.
 alert.overwrite.message = The file ''{0}'' was modified externally. Do you want to overwrite it ?
@@ -436,7 +433,12 @@ alert.save.noextension.savewith = Save with '.fxml'
 alert.save.noextension.savewithout = Save without '.fxml'
 alert.open.failure.charset.not.found = The given charset could not be set.
 alert.open.failure.charset.not.found.details = It may be due to the encoding in your document.
-
+alert.welcome.file.not.found.question = One or more project files were not found.
+alert.welcome.file.not.found.message = If those are located on a removable or network drive, please make sure the drive is connected.\n\n
+alert.welcome.file.not.found.title = Project file(s) not found
+alert.welcome.file.not.found.okay  = Remove From List
+alert.welcome.file.not.found.no = OK
+  
 # -----------------------------------------------------------------------------
 # Log Messages
 # -----------------------------------------------------------------------------

--- a/app/src/main/resources/com/oracle/javafx/scenebuilder/app/i18n/SceneBuilderApp_ja.properties
+++ b/app/src/main/resources/com/oracle/javafx/scenebuilder/app/i18n/SceneBuilderApp_ja.properties
@@ -394,10 +394,6 @@ alert.title.messagebox = 外部プログラムで開く
 
 alert.open.failure1.message = ''{0}''を開けませんでした
 alert.open.failure1.details = 開くのに失敗しました。選択されたファイルが有効なFXMLドキュメントであることを確認してください。
-alert.open.failureN.message = 指定されたファイルを開けませんでした
-alert.open.failureN.details = 開くのに失敗しました。それらのファイルが有効なFXMLドキュメントであることを確認してください。
-alert.open.failureMofN.message = {0}個のファイルを開けませんでした
-alert.open.failureMofN.details = いくつかのファイルを開くのに失敗しました。それらのファイルが有効なFXMLドキュメントであることを確認してください。
 alert.review.question.message = ドキュメントのうち{0}個に未保存の変更があります。終了する前にそれらをレビューしますか。
 alert.review.question.details = レビューしないと、変更は失われます。
 alert.overwrite.message = ファイル''{0}''は外部で変更されました。上書きしますか。

--- a/app/src/main/resources/com/oracle/javafx/scenebuilder/app/i18n/SceneBuilderApp_zh_CN.properties
+++ b/app/src/main/resources/com/oracle/javafx/scenebuilder/app/i18n/SceneBuilderApp_zh_CN.properties
@@ -399,10 +399,6 @@ alert.title.messagebox = 外部打开
 
 alert.open.failure1.message = 无法打开 ''{0}''
 alert.open.failure1.details = 打开操作失败。确保所选文件是有效的 FXML 文档。
-alert.open.failureN.message = 无法打开指定的文件
-alert.open.failureN.details = 打开操作失败。请确保这些文件是有效的 FXML 文档。
-alert.open.failureMofN.message = 无法打开 {0} 文件
-alert.open.failureMofN.details = 某些文件的打开操作失败。请确保这些文件是有效的 FXML 文档。
 alert.review.question.message = {0} 文档包含未保存的更改。您想在退出之前查看它们吗？
 alert.review.question.details = 如果您不查看更改，则更改将丢失。
 alert.overwrite.message = 文件 ''{0}'' 已在外部修改。你想覆盖它吗？

--- a/app/src/main/resources/com/oracle/javafx/scenebuilder/app/welcomedialog/WelcomeWindow.fxml
+++ b/app/src/main/resources/com/oracle/javafx/scenebuilder/app/welcomedialog/WelcomeWindow.fxml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-    Copyright (c) 2017, 2022, Gluon and/or its affiliates.
+    Copyright (c) 2017, 2024, Gluon and/or its affiliates.
     All rights reserved. Use is subject to license terms.
 
     This file is available and licensed under the following license:
@@ -43,7 +43,7 @@
 <?import javafx.scene.text.Font?>
 
 <StackPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="650.0" prefWidth="1024.0" stylesheets="@WelcomeWindow.css" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
-   <BorderPane fx:id="contentPane">
+   <BorderPane fx:id="contentPane" onDragDropped="#handleDroppedFiles" onDragOver="#handleFileDraggedOver">
       <left>
          <VBox styleClass="left-pane">
             <children>

--- a/app/src/test/java/com/oracle/javafx/scenebuilder/app/JfxInitializer.java
+++ b/app/src/test/java/com/oracle/javafx/scenebuilder/app/JfxInitializer.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2024, Gluon and/or its affiliates.
+ * All rights reserved. Use is subject to license terms.
+ *
+ * This file is available and licensed under the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the distribution.
+ *  - Neither the name of Oracle Corporation and Gluon nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.javafx.scenebuilder.app;
+
+import javafx.application.Application;
+import javafx.stage.Stage;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class JfxInitializer {
+
+    private static final AtomicBoolean initialized = new AtomicBoolean(false);
+
+    public static void initialize() {
+        if (initialized.compareAndSet(false, true)) {
+            Thread t = new Thread("JavaFX Init Thread") {
+
+                @Override
+                public void run() {
+                    Application.launch(DummyApp.class);
+                }
+            };
+            t.setDaemon(true);
+            t.start();
+        }
+    }
+
+    public static class DummyApp extends Application {
+
+        @Override
+        public void start(Stage primaryStage) {
+            // noop
+        }
+    }
+}

--- a/app/src/test/java/com/oracle/javafx/scenebuilder/app/welcomedialog/WelcomeDialogFilesDropHandlerTest.java
+++ b/app/src/test/java/com/oracle/javafx/scenebuilder/app/welcomedialog/WelcomeDialogFilesDropHandlerTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2022, Gluon and/or its affiliates.
+ * All rights reserved. Use is subject to license terms.
+ *
+ * This file is available and licensed under the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the distribution.
+ *  - Neither the name of Oracle Corporation and Gluon nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.oracle.javafx.scenebuilder.app.welcomedialog;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class WelcomeDialogFilesDropHandlerTest {
+
+    private WelcomeDialogFilesDropHandler classUnderTest;
+
+    @Test
+    void that_fxml_file_is_detected_properly(@TempDir Path directory) {
+        List<File> droppedFiles = List.of();
+        classUnderTest = new WelcomeDialogFilesDropHandler(droppedFiles);
+
+        assertFalse(classUnderTest.isFxml(directory.toFile()), "directories are not FXML");
+        assertFalse(classUnderTest.isFxml(new File("SomeImage.png")), "FXML files must have fxml file name extension");
+        assertTrue(classUnderTest.isFxml(new File("View.fxml")), "FXML files must have fxml file name extension");
+        assertTrue(classUnderTest.isFxml(new File("View.FxMl")), "FXML extension detection must not be case sensitive");
+    }
+
+    @Test
+    void that_exception_is_raised_with_incomplete_configuration() {
+        classUnderTest = new WelcomeDialogFilesDropHandler(List.of());
+        assertThrows(IllegalStateException.class, ()->classUnderTest.run());
+
+        classUnderTest.withSupportedFiles(files->System.out.println(files));
+        assertThrows(IllegalStateException.class, ()->classUnderTest.run());
+        
+        classUnderTest.withUnsupportedFiles(unsupported->System.out.println(unsupported));
+        assertDoesNotThrow(()->classUnderTest.run());
+    }
+
+    @Test
+    void that_list_of_fxml_files_will_passed_to_open_action() {
+        List<File> droppedFiles = List.of(new File("MainView.fxml"), new File("SubView.fxml"));
+        
+        // Action handler for opening files
+        List<String> fileOpenResults = new ArrayList<>();
+        Consumer<List<String>> openFilesAction = files->{
+            for (String file : files) {
+                fileOpenResults.add("opened " + new File(file).getName());
+            }
+        };
+        
+        // Action handler to notify user on unsupported items
+        List<String> unsupportedFiles = new ArrayList<>();
+        Consumer<List<String>> unsupportedFileHandling = unsupported->unsupportedFiles.addAll(unsupported);
+        
+        classUnderTest = new WelcomeDialogFilesDropHandler(droppedFiles)
+                    .withSupportedFiles(openFilesAction)
+                    .withUnsupportedFiles(unsupportedFileHandling);
+        
+        assertDoesNotThrow(()->classUnderTest.run());
+        assertEquals(2, fileOpenResults.size());
+        assertEquals("opened MainView.fxml", fileOpenResults.get(0));
+        assertTrue(unsupportedFiles.isEmpty());
+    }
+
+    @Test
+    void that_an_attempt_to_handle_unsupported_files_triggers_appropriate_action(@TempDir Path emptyDir) throws Exception {
+        List<File> droppedFiles = List.of(new File("Image.png"), emptyDir.toFile());
+
+        // Action handler for opening files
+        List<String> fileOpenResults = new ArrayList<>();
+        Consumer<List<String>> openFilesAction = files->fileOpenResults.addAll(files);
+        
+        // Action handler to notify user on unsupported items
+        List<String> unsupportedFiles = new ArrayList<>();
+        Consumer<List<String>> unsupportedFileHandling = unsupported->{
+            for (String file : unsupported) {
+                var item = new File(file);
+                if (item.isDirectory()) {
+                    unsupportedFiles.add(new File(file).getName() + "(dir is empty)");
+                } else {
+                    unsupportedFiles.add(new File(file).getName());
+                }
+            }
+        };
+
+        classUnderTest = new WelcomeDialogFilesDropHandler(droppedFiles)
+                .withSupportedFiles(openFilesAction)
+                .withUnsupportedFiles(unsupportedFileHandling);
+        classUnderTest.run();
+
+        assertTrue(fileOpenResults.isEmpty());
+        assertEquals(2, unsupportedFiles.size());
+        assertEquals("Image.png", unsupportedFiles.get(0));
+        assertTrue(unsupportedFiles.get(1).endsWith("(dir is empty)"));
+    }
+
+    @Test
+    void that_dropped_subdirectories_are_searched_for_fxml_in_first_level(@TempDir Path fxmlDir) {
+        List<File> droppedFiles = List.of(new File("src/main/resources/com/oracle/javafx/scenebuilder/app/welcomedialog"),
+                                          new File("src/main/resources/com/oracle/javafx/scenebuilder/app/DocumentWindow.fxml"),
+                                          new File("src/main/resources/com/oracle/javafx/scenebuilder/app/SceneBuilderLogo_32.png"));
+
+        // Action handler for opening files
+        Set<String> fileOpenResults = new HashSet<>();
+        Consumer<List<String>> openFilesAction = files->{
+            for (String file : files) {
+                fileOpenResults.add("opened " + new File(file).getName());
+            }
+        };
+
+        // Action handler to notify user on unsupported items
+        List<String> unsupportedFiles = new ArrayList<>();
+        Consumer<List<String>> unsupportedFileHandling = unsupported->unsupportedFiles.addAll(unsupported);
+
+        classUnderTest = new WelcomeDialogFilesDropHandler(droppedFiles)
+                    .withSupportedFiles(openFilesAction)
+                    .withUnsupportedFiles(unsupportedFileHandling);
+        
+        classUnderTest.run();
+        assertTrue(fileOpenResults.contains("opened WelcomeWindow.fxml"), "FXML from dropped directory");
+        assertTrue(fileOpenResults.contains("opened DocumentWindow.fxml"), "FXML file dropped");
+        assertTrue(unsupportedFiles.isEmpty());
+    }
+
+}

--- a/app/src/test/java/com/oracle/javafx/scenebuilder/app/welcomedialog/WelcomeDialogWindowControllerTest.java
+++ b/app/src/test/java/com/oracle/javafx/scenebuilder/app/welcomedialog/WelcomeDialogWindowControllerTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2024, Gluon and/or its affiliates.
+ * All rights reserved. Use is subject to license terms.
+ *
+ * This file is available and licensed under the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the distribution.
+ *  - Neither the name of Oracle Corporation and Gluon nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.javafx.scenebuilder.app.welcomedialog;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import com.oracle.javafx.scenebuilder.app.JfxInitializer;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class WelcomeDialogWindowControllerTest {
+    
+    private final WelcomeDialogWindowController classUnderTest = new WelcomeDialogWindowController();
+    
+    @BeforeAll
+    public static void initialize() {
+        JfxInitializer.initialize();
+    }
+    
+    @Test
+    void that_missing_files_are_detected_and_handled_and_existing_files_are_loaded() throws Exception {
+        String expectedExistingFile = getResource("WelcomeWindow.fxml").toString();
+        List<String> filesToLoad = List.of(
+                    "k:/folder/test/notExisting.fxml",
+                    expectedExistingFile);
+        
+        List<String> filesMissing = new ArrayList<>();
+        List<String> filesLoaded = new ArrayList<>();
+        
+        Consumer<List<String>> missingFilesHandler = missing -> filesMissing.addAll(missing);
+        Consumer<List<String>> existingFilesHandler = existing -> filesLoaded.addAll(existing);
+        
+        assertDoesNotThrow(() -> classUnderTest.handleOpen(filesToLoad, 
+                                                         missingFilesHandler, 
+                                                         existingFilesHandler));
+        
+        assertEquals(1, filesMissing.size());
+        assertEquals(1, filesLoaded.size());
+        assertTrue(filesLoaded.contains(expectedExistingFile));
+    }
+    
+    @Test
+    void that_no_actions_are_performed_on_empty_list() {
+        List<String> filesToLoad = Collections.emptyList();
+        
+        Set<String> actionsPerformed = new HashSet<>();
+        Consumer<List<String>> filesHandler = listOffiles -> actionsPerformed.add("some action performed");
+        classUnderTest.handleOpen(filesToLoad, filesHandler, filesHandler);
+        
+        assertTrue(actionsPerformed.isEmpty());
+    }
+    
+    @Test
+    void that_file_loader_is_not_called_when_all_files_are_missing() {
+        List<String> filesToLoad = List.of(
+                "k:/folder/test/notExisting.fxml",
+                "o:\\otherLocation\\another_missing.fxml");
+        
+        List<String> filesMissing = new ArrayList<>();
+        List<String> filesLoaded = new ArrayList<>();
+        
+        Consumer<List<String>> missingFilesHandler = missing -> filesMissing.addAll(missing);
+        Consumer<List<String>> existingFilesHandler = existing -> filesLoaded.addAll(existing);
+        classUnderTest.handleOpen(filesToLoad, missingFilesHandler, existingFilesHandler);
+        
+        assertTrue(filesLoaded.isEmpty());
+        assertEquals(2, filesMissing.size());
+    }
+    
+    private Path getResource(String resourceName) throws Exception {
+        return Path.of(getClass().getResource(resourceName).toURI());
+    }
+}

--- a/kit/pom.xml
+++ b/kit/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.gluonhq.scenebuilder</groupId>
         <artifactId>parent</artifactId>
-        <version>22.0.1-SNAPSHOT</version>
+        <version>23.0.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/kit/pom.xml
+++ b/kit/pom.xml
@@ -91,14 +91,6 @@
             <version>1.0.4</version>
             <scope>runtime</scope>
         </dependency>
-
-        <!-- Test -->
-        <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-            <version>3.19.0</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
     
     <build>
@@ -115,15 +107,6 @@
                             <Automatic-Module-Name>com.gluonhq.scenebuilder.kit</Automatic-Module-Name>
                         </manifestEntries>
                     </archive>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M5</version>
-                <configuration>
-                    <reuseForks>false</reuseForks>
-                    <forkCount>1</forkCount>
                 </configuration>
             </plugin>
         </plugins>

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/util/dialog/ErrorDialog.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/util/dialog/ErrorDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2014, Oracle and/or its affiliates.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -43,6 +43,7 @@ import javafx.stage.Window;
 public class ErrorDialog extends AlertDialog {
     
     private String debugInfo;
+    private String detailsTitle;
     
     public ErrorDialog(Window owner) {
         super(owner);
@@ -80,7 +81,10 @@ public class ErrorDialog extends AlertDialog {
         setDebugInfo(info);
     }
     
-    
+    public void setDetailsTitle(String detailsTitle) {
+        this.detailsTitle = detailsTitle;
+    }
+
     /*
      * Private
      */
@@ -90,8 +94,11 @@ public class ErrorDialog extends AlertDialog {
     }
     
     private void showDetailsDialog() {
-        final TextViewDialog detailDialog = new TextViewDialog(null);
+        final TextViewDialog detailDialog = new TextViewDialog(this.getStage());
         detailDialog.setText(debugInfo);
+        if (detailsTitle != null) {
+            detailDialog.setTitle(detailsTitle);
+        }
         detailDialog.showAndWait();
     }
 }

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/library/util/ExplorerBase.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/library/util/ExplorerBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Gluon and/or its affiliates.
+ * Copyright (c) 2020, 2024, Gluon and/or its affiliates.
  * Copyright (c) 2012, 2014, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
@@ -102,8 +102,10 @@ abstract class ExplorerBase {
                 // http://stackoverflow.com/questions/8100376/class-forname-vs-classloader-loadclass-which-to-use-for-dynamic-loading
                 entryClass = classLoader.loadClass(className); // Note: static intializers of entryClass are not run, this doesn't seem to be an issue
 
-                if (Modifier.isAbstract(entryClass.getModifiers())
-                        || !Node.class.isAssignableFrom(entryClass)) {
+                final int modifiers = entryClass.getModifiers();
+                if (Modifier.isAbstract(modifiers)
+                        || !Node.class.isAssignableFrom(entryClass)
+                        || !(Modifier.isPublic(modifiers) || Modifier.isProtected(modifiers))) {
                     status = JarReportEntry.Status.IGNORED;
                     entryClass = null;
                     entryException = null;

--- a/kit/src/main/resources/com/oracle/javafx/scenebuilder/kit/editor/panel/util/dialog/AbstractModalDialogW.fxml
+++ b/kit/src/main/resources/com/oracle/javafx/scenebuilder/kit/editor/panel/util/dialog/AbstractModalDialogW.fxml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   Copyright (c) 2017, 2019, Gluon and/or its affiliates.
   Copyright (c) 2012, 2014, Oracle and/or its affiliates.
@@ -40,7 +41,8 @@
 <?import javafx.scene.layout.VBox?>
 
 <!-- TODO textAlignement should be JUSTIFY for detailsLabel and messageLabel once RT-23231 is fixed -->
-<VBox maxHeight="+Infinity" maxWidth="+Infinity" minHeight="-Infinity" prefWidth="400.0" spacing="7.0" xmlns:fx="http://javafx.com/fxml">
+
+<VBox maxHeight="+Infinity" maxWidth="+Infinity" minHeight="-Infinity" prefWidth="400.0" spacing="7.0" xmlns:fx="http://javafx.com/fxml/1" xmlns="http://javafx.com/javafx/21.0.1">
   <children>
     <HBox id="HBox" alignment="TOP_LEFT" spacing="7.0" VBox.vgrow="ALWAYS">
       <children>
@@ -55,7 +57,7 @@
         <Insets left="10.0" right="10.0" top="10.0" />
       </padding>
     </HBox>
-    <HBox alignment="CENTER" maxHeight="-Infinity" maxWidth="+Infinity" minHeight="-Infinity" minWidth="-Infinity" style="-fx-background-color: rgb(229,229,229)&#10;" VBox.vgrow="NEVER">
+    <HBox alignment="CENTER_RIGHT" maxHeight="-Infinity" maxWidth="+Infinity" minHeight="-Infinity" minWidth="-Infinity" style="-fx-background-color: rgb(229,229,229)&#10;" VBox.vgrow="NEVER">
       <children>
         <HBox fx:id="okParent" alignment="CENTER" spacing="5.0">
           <children>

--- a/pom.xml
+++ b/pom.xml
@@ -16,11 +16,11 @@
     </modules>
 
     <properties>
-        <java.version>22</java.version>
+        <java.version>23</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <maven.compiler.release>${java.version}</maven.compiler.release>
-        <javafx.version>22</javafx.version>
+        <javafx.version>23-ea+27</javafx.version>
         <aether.version>1.1.0</aether.version>
         <charm.glisten.version>6.2.2</charm.glisten.version>
         <gluon.attach.version>4.0.19</gluon.attach.version>

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,12 @@
             <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.19.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -133,6 +139,17 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-resources-plugin</artifactId>
                     <version>3.2.0</version>
+                </plugin>
+
+                <!-- Ensure that available tests are executed -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>3.0.0-M5</version>
+                    <configuration>
+                        <reuseForks>false</reuseForks>
+                        <forkCount>1</forkCount>
+                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.gluonhq.scenebuilder</groupId>
     <artifactId>parent</artifactId>
     <packaging>pom</packaging>
-    <version>22.0.1-SNAPSHOT</version>
+    <version>23.0.0-SNAPSHOT</version>
     <name>Scene Builder</name>
     <description>Scene Builder is a visual, drag n drop, layout tool for designing JavaFX application user interfaces</description>
     <inceptionYear>2012</inceptionYear>


### PR DESCRIPTION
This feature PR introduces drag&drop to the welcome page.
One now can select a group of files and directories and drag them over the welcome page. On drop, the files are filtered to be FXML files and dropped subdirectories are searched for FXML files in first level.

All FXML files found will be passed to the file open process of Scene Builder.
For unsupported files or empty directories no message will be displayed as long as at least one file can be loaded.

If no file can be loaded at all, a message is displayed to the user that there were either unsupported files and/or the selected directories did not contain any supported file.

### Issue

Fixes #584

### Progress

<!-- Please ensure you actioned and ticked each box below before requesting a review -->

- [x] Change must not contain extraneous whitespace
- [x] License header year is updated, if required
- [x] The PR name must follow the [pre-defined format](https://github.com/gluonhq/scenebuilder/blob/master/CONTRIBUTING.md)
- [x] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)