### PR TITLE
fix: Removed FX8 qualifier in built-in library

### DIFF
--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/LibraryListCell.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/LibraryListCell.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2022, Gluon and/or its affiliates.
  * Copyright (c) 2012, 2014, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
@@ -127,11 +128,8 @@ class LibraryListCell extends ListCell<LibraryListItem> {
             if (item.getLibItem() != null) {
                 // A qualifier needed to discriminate items is kept in the ID:
                 // this applies to orientation as well as empty qualifiers.
-                // FX8 qualifier is not kept as there's no ambiguity there.
                 String id = item.getLibItem().getName();
-                if (id.contains(BuiltinLibrary.getFX8Qualifier())) {
-                    id = id.substring(0, id.indexOf(BuiltinLibrary.getFX8Qualifier()));
-                }
+
                 // If QE were about to test a localized version the ID should
                 // remain unchanged.
                 if (id.contains(BuiltinLibrary.getEmptyQualifier())) {

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/library/BuiltinLibrary.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/library/BuiltinLibrary.java
@@ -66,8 +66,6 @@ public class BuiltinLibrary extends Library {
     private final BuiltinSectionComparator sectionComparator
             = new BuiltinSectionComparator();
     
-    private static final String FX8_QUALIFIER = " (FX8)"; //NOI18N
-    
     // This qualifier is for use to provide a flavor of a component that has no
     // children, in addition to the one having children. Typical use is for
     // Accordion, ScrollPane, SplitPane, TabPane, TitledPane (see DTL-6274).
@@ -89,11 +87,7 @@ public class BuiltinLibrary extends Library {
         }
         return library;
     }
-    
-    public static String getFX8Qualifier() {
-        return FX8_QUALIFIER;
-    }
-    
+
     public static String getEmptyQualifier() {
         return EMPTY_QUALIFIER;
     }
@@ -186,9 +180,9 @@ public class BuiltinLibrary extends Library {
                 "AccordionEmpty", "Accordion", EMPTY_QUALIFIER); //NOI18N
         addRegionItem200x200(javafx.scene.layout.AnchorPane.class, TAG_CONTAINERS);
         addRegionItem200x200(javafx.scene.layout.BorderPane.class, TAG_CONTAINERS);
-        addCustomizedItem(javafx.scene.control.ButtonBar.class, TAG_CONTAINERS, FX8_QUALIFIER);
-        addCustomizedItem(javafx.scene.control.DialogPane.class, TAG_CONTAINERS, FX8_QUALIFIER);
-        addDefaultItem(javafx.scene.control.DialogPane.class, TAG_CONTAINERS, EMPTY_QUALIFIER, FX8_QUALIFIER);
+        addCustomizedItem(javafx.scene.control.ButtonBar.class, TAG_CONTAINERS);
+        addCustomizedItem(javafx.scene.control.DialogPane.class, TAG_CONTAINERS);
+        addDefaultItem(javafx.scene.control.DialogPane.class, TAG_CONTAINERS, EMPTY_QUALIFIER);
         addRegionItem200x200(javafx.scene.layout.FlowPane.class, TAG_CONTAINERS);
         addCustomizedItem(javafx.scene.layout.GridPane.class, TAG_CONTAINERS);
         addRegionItem200x100(javafx.scene.layout.HBox.class, TAG_CONTAINERS);
@@ -206,7 +200,7 @@ public class BuiltinLibrary extends Library {
         addCustomizedItem(javafx.scene.control.TabPane.class, TAG_CONTAINERS);
         addCustomizedItem(javafx.scene.control.TabPane.class, TAG_CONTAINERS,
                 "TabPaneEmpty", "TabPane", EMPTY_QUALIFIER); //NOI18N
-        addRegionItem200x200(javafx.scene.text.TextFlow.class, TAG_CONTAINERS, FX8_QUALIFIER);
+        addRegionItem200x200(javafx.scene.text.TextFlow.class, TAG_CONTAINERS);
         addRegionItem200x200(javafx.scene.layout.TilePane.class, TAG_CONTAINERS);
         addCustomizedItem(javafx.scene.control.TitledPane.class, TAG_CONTAINERS);
         addRegionItem200x200(javafx.scene.control.TitledPane.class, TAG_CONTAINERS, EMPTY_QUALIFIER);
@@ -219,7 +213,7 @@ public class BuiltinLibrary extends Library {
         addCustomizedItem(javafx.scene.control.ChoiceBox.class, TAG_CONTROLS);
         addDefaultItem(javafx.scene.control.ColorPicker.class, TAG_CONTROLS);
         addCustomizedItem(javafx.scene.control.ComboBox.class, TAG_CONTROLS);
-        addDefaultItem(javafx.scene.control.DatePicker.class, TAG_CONTROLS, FX8_QUALIFIER);
+        addDefaultItem(javafx.scene.control.DatePicker.class, TAG_CONTROLS);
         addCustomizedItem(javafx.scene.web.HTMLEditor.class, TAG_CONTROLS);
         addCustomizedItem(javafx.scene.control.Hyperlink.class, TAG_CONTROLS);
         addCustomizedItem(javafx.scene.image.ImageView.class, TAG_CONTROLS);
@@ -245,15 +239,15 @@ public class BuiltinLibrary extends Library {
                 "SliderH", "Slider-h", HORIZONTAL_QUALIFIER); //NOI18N
         addCustomizedItem(javafx.scene.control.Slider.class, TAG_CONTROLS,
                 "SliderV", "Slider-v", VERTICAL_QUALIFIER); //NOI18N
-        addDefaultItem(javafx.scene.control.Spinner.class, TAG_CONTROLS, FX8_QUALIFIER);
+        addDefaultItem(javafx.scene.control.Spinner.class, TAG_CONTROLS);
         addCustomizedItem(javafx.scene.control.SplitMenuButton.class, TAG_CONTROLS);
         addCustomizedItem(javafx.scene.control.TableColumn.class, TAG_CONTROLS);
         addCustomizedItem(javafx.scene.control.TableView.class, TAG_CONTROLS);
         addRegionItem200x200(javafx.scene.control.TextArea.class, TAG_CONTROLS);
         addDefaultItem(javafx.scene.control.TextField.class, TAG_CONTROLS);
         addCustomizedItem(javafx.scene.control.ToggleButton.class, TAG_CONTROLS);
-        addCustomizedItem(javafx.scene.control.TreeTableColumn.class, TAG_CONTROLS, FX8_QUALIFIER);
-        addCustomizedItem(javafx.scene.control.TreeTableView.class, TAG_CONTROLS, FX8_QUALIFIER);
+        addCustomizedItem(javafx.scene.control.TreeTableColumn.class, TAG_CONTROLS);
+        addCustomizedItem(javafx.scene.control.TreeTableView.class, TAG_CONTROLS);
         addRegionItem200x200(javafx.scene.control.TreeView.class, TAG_CONTROLS);
         addCustomizedItem(javafx.scene.web.WebView.class, TAG_CONTROLS);
         
@@ -272,24 +266,24 @@ public class BuiltinLibrary extends Library {
         addRegionItem200x200(javafx.scene.layout.Region.class, TAG_MISCELLANEOUS);
         addCustomizedItem(javafx.scene.Scene.class, TAG_MISCELLANEOUS);
         addCustomizedItem(javafx.stage.Stage.class, TAG_MISCELLANEOUS);
-        addCustomizedItem(javafx.scene.SubScene.class, TAG_MISCELLANEOUS, FX8_QUALIFIER);
-        addDefaultItem(javafx.embed.swing.SwingNode.class, TAG_MISCELLANEOUS, FX8_QUALIFIER);
+        addCustomizedItem(javafx.scene.SubScene.class, TAG_MISCELLANEOUS);
+        addDefaultItem(javafx.embed.swing.SwingNode.class, TAG_MISCELLANEOUS);
         addCustomizedItem(javafx.scene.control.Tooltip.class, TAG_MISCELLANEOUS);
 
         // Shapes
         addCustomizedItem(javafx.scene.shape.Arc.class, TAG_SHAPES);
         addDefaultItem(javafx.scene.shape.ArcTo.class, TAG_SHAPES);
-        addCustomizedItem(javafx.scene.shape.Box.class, TAG_SHAPES, FX8_QUALIFIER);
+        addCustomizedItem(javafx.scene.shape.Box.class, TAG_SHAPES);
         addCustomizedItem(javafx.scene.shape.Circle.class, TAG_SHAPES);
         addDefaultItem(javafx.scene.shape.ClosePath.class, TAG_SHAPES);
         addCustomizedItem(javafx.scene.shape.CubicCurve.class, TAG_SHAPES);
         addDefaultItem(javafx.scene.shape.CubicCurveTo.class, TAG_SHAPES);
-        addCustomizedItem(javafx.scene.shape.Cylinder.class, TAG_SHAPES, FX8_QUALIFIER);
+        addCustomizedItem(javafx.scene.shape.Cylinder.class, TAG_SHAPES);
         addCustomizedItem(javafx.scene.shape.Ellipse.class, TAG_SHAPES);
         addDefaultItem(javafx.scene.shape.HLineTo.class, TAG_SHAPES);
         addCustomizedItem(javafx.scene.shape.Line.class, TAG_SHAPES);
         addDefaultItem(javafx.scene.shape.LineTo.class, TAG_SHAPES);
-        addDefaultItem(javafx.scene.shape.MeshView.class, TAG_SHAPES, FX8_QUALIFIER);
+        addDefaultItem(javafx.scene.shape.MeshView.class, TAG_SHAPES);
         addDefaultItem(javafx.scene.shape.MoveTo.class, TAG_SHAPES);
         addCustomizedItem(javafx.scene.shape.Path.class, TAG_SHAPES);
         addCustomizedItem(javafx.scene.shape.Polygon.class, TAG_SHAPES);
@@ -297,7 +291,7 @@ public class BuiltinLibrary extends Library {
         addCustomizedItem(javafx.scene.shape.QuadCurve.class, TAG_SHAPES);
         addDefaultItem(javafx.scene.shape.QuadCurveTo.class, TAG_SHAPES);
         addCustomizedItem(javafx.scene.shape.Rectangle.class, TAG_SHAPES);
-        addCustomizedItem(javafx.scene.shape.Sphere.class, TAG_SHAPES, FX8_QUALIFIER);
+        addCustomizedItem(javafx.scene.shape.Sphere.class, TAG_SHAPES);
         addCustomizedItem(javafx.scene.shape.SVGPath.class, TAG_SHAPES);
         addCustomizedItem(javafx.scene.text.Text.class, TAG_SHAPES);
         addDefaultItem(javafx.scene.shape.VLineTo.class, TAG_SHAPES);
@@ -313,10 +307,10 @@ public class BuiltinLibrary extends Library {
         addCustomizedItem(javafx.scene.chart.StackedBarChart.class, TAG_CHARTS);
         
         // 3D
-        addCustomizedItem(javafx.scene.AmbientLight.class, TAG_3D, FX8_QUALIFIER);
-        addDefaultItem(javafx.scene.ParallelCamera.class, TAG_3D, FX8_QUALIFIER);
-        addDefaultItem(javafx.scene.PerspectiveCamera.class, TAG_3D, FX8_QUALIFIER);
-        addCustomizedItem(javafx.scene.PointLight.class, TAG_3D, FX8_QUALIFIER);
+        addCustomizedItem(javafx.scene.AmbientLight.class, TAG_3D);
+        addDefaultItem(javafx.scene.ParallelCamera.class, TAG_3D);
+        addDefaultItem(javafx.scene.PerspectiveCamera.class, TAG_3D);
+        addCustomizedItem(javafx.scene.PointLight.class, TAG_3D);
     }
     
     


### PR DESCRIPTION
There is a FX8 qualifier for controls in the built-in library.
All these FX8 controls are unique, there are no FX2 or other derivatives.

### Issue

Fixes #586

### Progress

<!-- Please ensure you actioned and ticked each box below before requesting a review -->

- [x] Change must not contain extraneous whitespace
- [x] License header year is updated, if required
- [x] The PR name must follow the [pre-defined format](https://github.com/gluonhq/scenebuilder/blob/master/CONTRIBUTING.md)
- [x] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)