### PR TITLE
feat: Add JRuby controller skeleton generation

### DIFF
--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/AbstractSkeletonCreator.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/AbstractSkeletonCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Gluon and/or its affiliates.
+ * Copyright (c) 2021, 2023, Gluon and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/AbstractSkeletonCreator.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/AbstractSkeletonCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Gluon and/or its affiliates.
+ * Copyright (c) 2021, 2022, Gluon and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/AbstractSkeletonCreator.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/AbstractSkeletonCreator.java
@@ -38,13 +38,13 @@ import java.net.URL;
 import java.util.Map;
 import java.util.ResourceBundle;
 
-abstract class AbstractSkeletonCreator {
+abstract class AbstractSkeletonCreator implements SkeletonConverter {
 
     static final String NL = System.lineSeparator();
     static final String INDENT = "    "; //NOI18N
     static final String FXML_ANNOTATION = "@FXML";
 
-    String createFrom(SkeletonContext context) {
+    public String createFrom(SkeletonContext context) {
         final StringBuilder sb = new StringBuilder();
 
         appendHeaderComment(context, sb);

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonConverter.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Gluon and/or its affiliates.
+ * Copyright (c) 2023, Gluon and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonConverter.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonConverter.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2022, Gluon and/or its affiliates.
+ * All rights reserved. Use is subject to license terms.
+ *
+ * This file is available and licensed under the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the distribution.
+ *  - Neither the name of Oracle Corporation nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.javafx.scenebuilder.kit.skeleton;
+
+@FunctionalInterface
+public interface SkeletonConverter {
+    String createFrom(SkeletonContext context);
+}

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreator.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Gluon and/or its affiliates.
+ * Copyright (c) 2021, 2023, Gluon and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreator.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreator.java
@@ -35,6 +35,7 @@ class SkeletonCreator {
 
     private final SkeletonCreatorJava skeletonCreatorJava = new SkeletonCreatorJava();
     private final SkeletonCreatorKotlin skeletonCreatorKotlin = new SkeletonCreatorKotlin();
+    private final SkeletonCreatorJRuby skeletonCreatorJRuby = new SkeletonCreatorJRuby();
 
     /**
      * @return a code skeleton for the given context
@@ -45,6 +46,8 @@ class SkeletonCreator {
                 return skeletonCreatorJava.createFrom(context);
             case KOTLIN:
                 return skeletonCreatorKotlin.createFrom(context);
+            case JRUBY:
+                return skeletonCreatorJRuby.createFrom(context);
             default:
                 throw new IllegalArgumentException("Language not supported: " + context.getSettings().getLanguage());
         }

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreator.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Gluon and/or its affiliates.
+ * Copyright (c) 2021, 2022, Gluon and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreatorJRuby.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreatorJRuby.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Gluon and/or its affiliates.
+ * Copyright (c) 2023, Gluon and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreatorJRuby.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreatorJRuby.java
@@ -56,6 +56,24 @@ public class SkeletonCreatorJRuby implements SkeletonConverter {
         return sb.toString();
     }
 
+    public String createApplicationFrom(SkeletonContext context) {
+
+        return "require 'jrubyfx'\n" +
+                "\n" +
+                createFrom(context) +
+                "\n" +
+                "fxml_root File.dirname(__FILE__) # or wherever you save the fxml file to\n" +
+                "\n" +
+                "class " + makeClassName(context) + "Application < JRubyFX::Application\n" +
+                "  def start(stage)\n" +
+                "    " + makeClassName(context) + ".load_into(stage)\n" +
+                "    #stage.title = \"" + makeClassName(context) + "\"\n" +
+                "    stage.show\n" +
+                "  end\n" +
+                "  launch\n" +
+                "end\n";
+    }
+
     static Pattern importExtractor = Pattern.compile("import (([^.]+)\\..*)");
 
     void appendImports(SkeletonContext context, StringBuilder sb) {
@@ -82,21 +100,13 @@ public class SkeletonCreatorJRuby implements SkeletonConverter {
         }
 
         final String title = I18N.getString("skeleton.window.title", context.getDocumentName());
-        sb.append("#").append(NL); //NOI18N
         sb.append("# ").append(title).append(NL); //NOI18N
-        sb.append("# ").append(NL); //NOI18N
-        sb.append(NL);
     }
 
 
     void appendClass(SkeletonContext context, StringBuilder sb) {
-        sb.append(NL);
 
-        String controllerClassName = "PleaseProvideControllerClassName";
-
-        if (hasController(context)) {
-           controllerClassName = getControllerClassName(context);
-        }
+        String controllerClassName = makeClassName(context);
 
         sb.append("class ").append(controllerClassName); //NOI18N
 
@@ -129,6 +139,15 @@ public class SkeletonCreatorJRuby implements SkeletonConverter {
         appendEventHandlers(context, sb);
 
         sb.append("end").append(NL); //NOI18N
+    }
+
+    private String makeClassName(SkeletonContext context) {
+        String controllerClassName = "PleaseProvideControllerClassName";
+
+        if (hasController(context)) {
+            controllerClassName = getControllerClassName(context);
+        }
+        return controllerClassName;
     }
 
 
@@ -167,14 +186,13 @@ public class SkeletonCreatorJRuby implements SkeletonConverter {
 
         // these aren't built into JRubyFX's fxml_helper.rb, so just manually add the fields for reification
         if (context.getSettings().isWithComments()) {
-            sb.append(INDENT).append("# ResourceBundle that was given to the FXMLLoader. Access as self.resources, or @resources if instance_variable is true"); //NOI18N
+            sb.append(INDENT).append("# ResourceBundle that was given to the FXMLLoader. Access as self.resources, or @resources if instance_variable is true").append(NL); //NOI18N
         }
-        sb.append(NL).append(INDENT);
+        sb.append(INDENT);
         sb.append("java_field '@javafx.fxml.FXML java.util.ResourceBundle resources', instance_variable: true");
-        sb.append(NL);
 
         if (context.getSettings().isWithComments()) {
-            sb.append(NL).append(INDENT).append("# URL location of the FXML file that was given to the FXMLLoader. Access as self.location, or @location if instance_variable is true"); //NOI18N
+            sb.append(NL).append(NL).append(INDENT).append("# URL location of the FXML file that was given to the FXMLLoader. Access as self.location, or @location if instance_variable is true"); //NOI18N
         }
         sb.append(NL).append(INDENT);
         sb.append("java_field '@javafx.fxml.FXML java.net.URL location', instance_variable: true");
@@ -232,9 +250,10 @@ public class SkeletonCreatorJRuby implements SkeletonConverter {
     void appendAssertions(SkeletonContext context, StringBuilder sb) {
         for (String assertion : context.getAssertions()) {
             sb.append(INDENT).append(INDENT)
-                .append("raise 'fx:id=\"").append(assertion).append("\" was not injected: check your FXML file ") //NOI18N
-                .append("\"").append(context.getDocumentName()).append("\".' if ") //NOI18N
-                .append("@").append(assertion).append(".nil?").append(NL); //NOI18N
+                    .append("raise 'fx:id=\"").append(assertion).append("\" was not injected: check your FXML file ") //NOI18N
+                    .append("\"").append(context.getDocumentName()).append("\".' if ") //NOI18N
+                    .append("@").append(assertion).append(".nil?").append(NL); //NOI18N
         }
     }
+
 }

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreatorJRuby.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreatorJRuby.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Gluon and/or its affiliates.
+ * Copyright (c) 2022, Gluon and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreatorJRuby.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonCreatorJRuby.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) 2021, Gluon and/or its affiliates.
+ * All rights reserved. Use is subject to license terms.
+ *
+ * This file is available and licensed under the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the distribution.
+ *  - Neither the name of Oracle Corporation nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.javafx.scenebuilder.kit.skeleton;
+
+import com.oracle.javafx.scenebuilder.kit.i18n.I18N;
+
+import java.net.URL;
+import java.util.Map;
+import java.util.ResourceBundle;
+
+public class SkeletonCreatorJRuby extends AbstractSkeletonCreator {
+
+    @Override
+    void appendPackage(SkeletonContext context, StringBuilder sb) {
+        // Ruby supports packages... but we ignore it here because Java package != Ruby Module and
+        // equating the two can cause confusion. Let the user fix it up themselves
+    }
+
+    @Override
+    void appendImports(SkeletonContext context, StringBuilder sb) {
+        // Optional, really, as JRubyFX imports them by default
+        for (String importStatement : context.getImports()) {
+            //sb.append("java_import '").append(importStatement).append("'").append(NL);
+        }
+    }
+
+
+    void appendHeaderComment(SkeletonContext context, StringBuilder sb) {
+        if (!context.getSettings().isWithComments()) {
+            return;
+        }
+
+        final String title = I18N.getString("skeleton.window.title", context.getDocumentName());
+        sb.append("#").append(NL); //NOI18N
+        sb.append("# ").append(title).append(NL); //NOI18N
+        sb.append("# ").append(NL); //NOI18N
+        sb.append(NL);
+    }
+
+    @Override
+    void appendClassPart(SkeletonContext context, StringBuilder sb) {
+        sb.append("class "); //NOI18N
+
+        if (hasController(context)) {
+            String controllerClassName = getControllerClassName(context);
+            sb.append(controllerClassName);
+        } else {
+            sb.append("PleaseProvideControllerClassName"); //NOI18N
+        }
+    }
+
+    @Override
+    void appendClass(SkeletonContext context, StringBuilder sb) {
+        sb.append(NL);
+
+        appendClassPart(context, sb);
+
+        sb.append(NL);
+        sb.append(INDENT).append("include JRubyFX::Controller").append(NL).append(NL); //NOI18N
+
+        if (context.getSettings().isFull()) {
+            sb.append(INDENT).append("fxml '").append(context.getDocumentName()).append("'").append(NL).append(NL); //NOI18N
+        }else{
+            sb.append(INDENT).append("# fxml '").append(context.getDocumentName()).append("'").append(NL).append(NL); //NOI18N
+        }
+
+        appendFields(context, sb);
+
+        appendMethods(context, sb);
+
+        sb.append("end").append(NL); //NOI18N
+    }
+
+    private boolean hasController(SkeletonContext context) {
+        return context.getFxController() != null && !context.getFxController().isEmpty();
+    }
+
+    private boolean hasNestedController(SkeletonContext context) {
+        return hasController(context) && context.getFxController().contains("$"); //NOI18N
+    }
+
+    private String getControllerClassName(SkeletonContext context) {
+        String simpleName = context.getFxController().replace("$", "."); //NOI18N
+        int dot = simpleName.lastIndexOf('.');
+        if (dot > -1) {
+            simpleName = simpleName.substring(dot + 1);
+        }
+        return simpleName;
+    }
+
+    @Override
+    void appendField(Class<?> fieldClass, String fieldName, StringBuilder sb) {
+        sb.append("# @").append(fieldName).append(": ").append(fieldClass.getSimpleName()); //NOI18N
+        appendFieldParameters(sb, fieldClass); // just for reference
+    }
+
+    @Override
+    void appendFieldsResourcesAndLocation(SkeletonContext context, StringBuilder sb) {
+        if (!context.getSettings().isFull()) {
+            return;
+        }
+        // TODO: I don't think JRubyFX sets these?
+/*
+        if (context.getSettings().isWithComments()) {
+            sb.append(" # ResourceBundle that was given to the FXMLLoader"); //NOI18N
+        }
+        sb.append(NL);
+        sb.append(INDENT);
+        appendField(ResourceBundle.class, "resources", sb); //NOI18N
+        sb.append(NL).append(NL);
+
+        if (context.getSettings().isWithComments()) {
+            sb.append(" # URL location of the FXML file that was given to the FXMLLoader"); //NOI18N
+        }
+        sb.append(NL);
+        sb.append(INDENT);
+        appendField(URL.class, "location", sb); //NOI18N
+        sb.append(NL).append(NL);*/
+    }
+
+
+    @Override
+    void appendFieldsWithFxId(SkeletonContext context, StringBuilder sb) {
+        for (Map.Entry<String, Class<?>> variable : context.getVariables().entrySet()) {
+//            if (context.getSettings().isWithComments()) {
+//                sb.append(INDENT).append("# fx:id=\"").append(variable.getKey()).append("\""); //NOI18N
+//                sb.append(NL);
+//            }
+
+            sb.append(INDENT);
+            appendField(variable.getValue(), variable.getKey(), sb);
+
+            if (context.getSettings().isWithComments()) {
+                sb.append(" (Value injected by FXMLLoader & JRubyFX)"); //NOI18N
+            }
+            sb.append(NL);
+        }
+        sb.append(NL);
+    }
+
+    @Override
+    void appendInitialize(SkeletonContext context, StringBuilder sb) {
+        if (!context.getSettings().isFull()) {
+            return;
+        }
+        if (context.getSettings().isWithComments()) {
+            sb.append(INDENT).append("# Called by JRubyFX after FXML loading is complete. Different from Java, same as normal Ruby"); //NOI18N
+            sb.append(NL);
+        }
+
+        sb.append(INDENT);
+        appendInitializeMethodPart(sb);
+        sb.append(NL);
+        appendAssertions(context, sb);
+        sb.append(NL);
+        sb.append(INDENT);
+        sb.append("end").append(NL).append(NL); //NOI18N
+    }
+
+    @Override
+    void appendEventHandlers(SkeletonContext context, StringBuilder sb) {
+        for (Map.Entry<String, String> entry : context.getEventHandlers().entrySet()) {
+            String methodName = entry.getKey();
+            String eventClassName = entry.getValue();
+
+            final String methodNamePured = methodName.replace("#", ""); //NOI18N
+
+            sb.append(INDENT);
+            appendEventHandler(methodNamePured, eventClassName, sb);
+            sb.append(NL).append(NL);
+        }
+    }
+
+
+    @Override
+    void appendFieldParameterType(StringBuilder sb) {
+        sb.append("?"); //NOI18N
+    }
+
+    @Override
+    void appendEventHandler(String methodName, String eventClassName, StringBuilder sb) {
+        sb.append("def "); //NOI18N
+        sb.append(methodName);
+        sb.append("(").append("event) # event: ").append(eventClassName).append(NL).append(NL); //NOI18N
+        sb.append(INDENT).append("end"); //NOI18N
+    }
+
+    @Override
+    void appendInitializeMethodPart(StringBuilder sb) {
+        sb.append("def initialize()"); //NOI18N
+    }
+
+    @Override
+    void appendAssertions(SkeletonContext context, StringBuilder sb) {
+        for (String assertion : context.getAssertions()) {
+            sb.append(INDENT).append(INDENT)
+                .append("raise 'fx:id=\"").append(assertion).append("\" was not injected: check your FXML file ") //NOI18N
+                .append("\"").append(context.getDocumentName()).append("\".' if ") //NOI18N
+                .append("@").append(assertion).append(".nil?").append(NL); //NOI18N
+        }
+    }
+}

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonFileNameProposal.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonFileNameProposal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Gluon and/or its affiliates.
+ * Copyright (c) 2021, 2023, Gluon and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonFileNameProposal.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonFileNameProposal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Gluon and/or its affiliates.
+ * Copyright (c) 2021, 2022, Gluon and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonFileNameProposal.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonFileNameProposal.java
@@ -120,6 +120,9 @@ class SkeletonFileNameProposal {
                 case KOTLIN:
                     location = location.replace(resources, kotlin);
                     break;
+                case JRUBY:
+                    // use default location in "resources"
+                    break;
                 }
             }
         }

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonSettings.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Gluon and/or its affiliates.
+ * Copyright (c) 2021, 2023, Gluon and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonSettings.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Gluon and/or its affiliates.
+ * Copyright (c) 2021, 2022, Gluon and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonSettings.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonSettings.java
@@ -38,7 +38,7 @@ class SkeletonSettings {
     private FORMAT_TYPE textFormat = FORMAT_TYPE.COMPACT;
 
     enum LANGUAGE {
-        JAVA("Java", ".java"), KOTLIN("Kotlin", ".kt");
+        JAVA("Java", ".java"), KOTLIN("Kotlin", ".kt"), JRUBY("JRuby", ".rb");
 
         private final String name;
         private final String ext;

--- a/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonBufferJRubyTest.java
+++ b/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonBufferJRubyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Gluon and/or its affiliates.
+ * Copyright (c) 2023, Gluon and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:

--- a/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonBufferJRubyTest.java
+++ b/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonBufferJRubyTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2021, 2022, Gluon and/or its affiliates.
+ * All rights reserved. Use is subject to license terms.
+ *
+ * This file is available and licensed under the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the distribution.
+ *  - Neither the name of Oracle Corporation and Gluon nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.javafx.scenebuilder.kit.skeleton;
+
+import com.oracle.javafx.scenebuilder.kit.JfxInitializer;
+import com.oracle.javafx.scenebuilder.kit.editor.EditorController;
+import com.oracle.javafx.scenebuilder.kit.fxom.FXOMDocument;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class SkeletonBufferJRubyTest {
+
+    @BeforeAll
+    public static void initialize() {
+        JfxInitializer.initialize();
+    }
+
+    @Test
+    public void skeletonToString_nestedTestFxml() throws IOException {
+        // given
+        SkeletonBuffer skeletonBuffer = load("TestNested.fxml");
+
+        // when
+        String skeleton = skeletonBuffer.toString();
+
+        // then
+        assertEqualsFileContent("skeleton_ruby_nested.txt", skeleton);
+    }
+
+    @Test
+    public void skeletonToString_testFxml_full_withComments() throws IOException {
+        // given
+        SkeletonBuffer skeletonBuffer = load("Test.fxml");
+        skeletonBuffer.setFormat(SkeletonSettings.FORMAT_TYPE.FULL);
+        skeletonBuffer.setTextType(SkeletonSettings.TEXT_TYPE.WITH_COMMENTS);
+
+        // when
+        String skeleton = skeletonBuffer.toString();
+
+        // then
+        assertEqualsFileContent("skeleton_ruby_full_comments.txt", skeleton);
+    }
+
+    @Test
+    public void skeletonToString_testFxml_withComments() throws IOException {
+        // given
+        SkeletonBuffer skeletonBuffer = load("Test.fxml");
+        skeletonBuffer.setTextType(SkeletonSettings.TEXT_TYPE.WITH_COMMENTS);
+
+        // when
+        String skeleton = skeletonBuffer.toString();
+
+        // then
+        assertEqualsFileContent("skeleton_ruby_comments.txt", skeleton);
+    }
+
+    @Test
+    public void skeletonToString_testFxml_fullFormat() throws IOException {
+        // given
+        SkeletonBuffer skeletonBuffer = load("Test.fxml");
+        skeletonBuffer.setFormat(SkeletonSettings.FORMAT_TYPE.FULL);
+
+        // when
+        String skeleton = skeletonBuffer.toString();
+
+        // then
+        assertEqualsFileContent("skeleton_ruby_full.txt", skeleton);
+    }
+
+    private void assertEqualsFileContent(String fileName, String actual) {
+        URL url = this.getClass().getResource(fileName);
+        File file = new File(url.getFile());
+
+        try {
+            String expectedFileContent = Files.readString(file.toPath());
+            assertEquals(expectedFileContent, actual);
+        } catch (IOException e) {
+            fail("Unable to open file: " + fileName);
+        }
+    }
+
+    private SkeletonBuffer load(String fxmlFile) throws IOException {
+        EditorController editorController = new EditorController();
+        final URL fxmlURL = SkeletonBufferJRubyTest.class.getResource(fxmlFile);
+        final String fxmlText = FXOMDocument.readContentFromURL(fxmlURL);
+        editorController.setFxmlTextAndLocation(fxmlText, fxmlURL, false);
+
+        SkeletonBuffer skeletonBuffer = new SkeletonBuffer(editorController.getFxomDocument(), "test");
+        skeletonBuffer.setLanguage(SkeletonSettings.LANGUAGE.JRUBY);
+        return skeletonBuffer;
+    }
+}

--- a/kit/src/test/resources/com/oracle/javafx/scenebuilder/kit/skeleton/skeleton_ruby_comments.txt
+++ b/kit/src/test/resources/com/oracle/javafx/scenebuilder/kit/skeleton/skeleton_ruby_comments.txt
@@ -1,0 +1,17 @@
+# Sample Skeleton for 'test' Controller Class
+class EmptyController
+    include JRubyFX::Controller
+
+    # Marks this class as being a controller for the given fxml document
+    # This creates @instance_variables for all fx:id
+    fxml 'test.fxml'
+
+    # These @instance_variables will be injected by FXMLLoader & JRubyFX
+    # @myTableView: 	TableView<?>
+    # @myVbox: 	VBox
+
+    def onMyVboxMouseEntered(event) # event: MouseEvent
+
+    end
+
+end

--- a/kit/src/test/resources/com/oracle/javafx/scenebuilder/kit/skeleton/skeleton_ruby_full.txt
+++ b/kit/src/test/resources/com/oracle/javafx/scenebuilder/kit/skeleton/skeleton_ruby_full.txt
@@ -1,0 +1,25 @@
+class EmptyController
+    include JRubyFX::Controller
+
+    # java_import 'java.net.URL'
+    # java_import 'java.util.ResourceBundle'
+
+    fxml 'test.fxml'
+
+    # @myTableView: 	TableView<?>
+    # @myVbox: 	VBox
+
+    java_field '@javafx.fxml.FXML java.util.ResourceBundle resources', instance_variable: true
+    java_field '@javafx.fxml.FXML java.net.URL location', instance_variable: true
+
+    def initialize()
+        raise 'fx:id="myTableView" was not injected: check your FXML file "test".' if @myTableView.nil?
+        raise 'fx:id="myVbox" was not injected: check your FXML file "test".' if @myVbox.nil?
+
+    end
+
+    def onMyVboxMouseEntered(event) # event: MouseEvent
+
+    end
+
+end

--- a/kit/src/test/resources/com/oracle/javafx/scenebuilder/kit/skeleton/skeleton_ruby_full_comments.txt
+++ b/kit/src/test/resources/com/oracle/javafx/scenebuilder/kit/skeleton/skeleton_ruby_full_comments.txt
@@ -1,0 +1,33 @@
+# Sample Skeleton for 'test' Controller Class
+class EmptyController
+    include JRubyFX::Controller
+
+    # java_import 'java.net.URL'
+    # java_import 'java.util.ResourceBundle'
+
+    # Marks this class as being a controller for the given fxml document
+    # This creates @instance_variables for all fx:id
+    fxml 'test.fxml'
+
+    # These @instance_variables will be injected by FXMLLoader & JRubyFX
+    # @myTableView: 	TableView<?>
+    # @myVbox: 	VBox
+
+    # ResourceBundle that was given to the FXMLLoader. Access as self.resources, or @resources if instance_variable is true
+    java_field '@javafx.fxml.FXML java.util.ResourceBundle resources', instance_variable: true
+
+    # URL location of the FXML file that was given to the FXMLLoader. Access as self.location, or @location if instance_variable is true
+    java_field '@javafx.fxml.FXML java.net.URL location', instance_variable: true
+
+    # Called by JRubyFX after FXML loading is complete. Different from Java, same as normal Ruby
+    def initialize()
+        raise 'fx:id="myTableView" was not injected: check your FXML file "test".' if @myTableView.nil?
+        raise 'fx:id="myVbox" was not injected: check your FXML file "test".' if @myVbox.nil?
+
+    end
+
+    def onMyVboxMouseEntered(event) # event: MouseEvent
+
+    end
+
+end

--- a/kit/src/test/resources/com/oracle/javafx/scenebuilder/kit/skeleton/skeleton_ruby_nested.txt
+++ b/kit/src/test/resources/com/oracle/javafx/scenebuilder/kit/skeleton/skeleton_ruby_nested.txt
@@ -1,0 +1,13 @@
+class InnerController
+    include JRubyFX::Controller
+
+    fxml 'test.fxml'
+
+    # @myTableView: 	TableView<?>
+    # @myVbox: 	VBox
+
+    def onMyVboxMouseEntered(event) # event: MouseEvent
+
+    end
+
+end


### PR DESCRIPTION
Adds JRuby as a language to the controller skeleton dialog. Note that JRuby doesn't need the fields, as JRubyFX inserts all of them automatically, this is principally for the methods/callbacks, and field reference.

Based on discussion #595 

### Progress

- [x] Change must not contain extraneous whitespace
- [x] License header year is updated, if required
- [x] I don't understand this: The PR name must follow the [pre-defined format](https://github.com/gluonhq/scenebuilder/blob/master/CONTRIBUTING.md) 
- [x] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)