### PR TITLE
Build: Bumped OpenJFX/JavaFX version to 20.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <maven.compiler.release>${java.version}</maven.compiler.release>
-        <javafx.version>19</javafx.version>
+        <javafx.version>20</javafx.version>
         <aether.version>1.1.0</aether.version>
         <charm.glisten.version>6.2.0</charm.glisten.version>
         <gluon.attach.version>4.0.15</gluon.attach.version>


### PR DESCRIPTION
### Issue

Fixes #617

### Progress

POM updated to make use of JavaFX 20.

- [ ] Change must not contain extraneous whitespace
- [ ] License header year is updated, if required
- [ ] The PR name must follow the [pre-defined format](https://github.com/gluonhq/scenebuilder/blob/master/CONTRIBUTING.md)
- [ ] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)