### PR TITLE
build: Use Java and JavaFX 20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         uses: oracle-actions/setup-java@v1
         with:
           website: jdk.java.net
-          release: 19
+          release: 20
 
       - name: Run Tests (Linux)
         if: runner.os == 'Linux'

--- a/.github/workflows/bundles-kit.yml
+++ b/.github/workflows/bundles-kit.yml
@@ -7,7 +7,7 @@ on:
         required: true
         type: string
       java-version:
-        default: '19'
+        default: '20'
         required: false
         type: string
 

--- a/.github/workflows/bundles-linux.yml
+++ b/.github/workflows/bundles-linux.yml
@@ -10,11 +10,11 @@ on:
         required: true
         type: string
       java-version:
-        default: '19'
+        default: '20'
         required: false
         type: string
       javafx-version:
-        default: '19'
+        default: '20'
         required: false
         type: string
       test:

--- a/.github/workflows/bundles-mac.yml
+++ b/.github/workflows/bundles-mac.yml
@@ -10,11 +10,11 @@ on:
         required: true
         type: string
       java-version:
-        default: '19'
+        default: '20'
         required: false
         type: string
       javafx-version:
-        default: '19'
+        default: '20'
         required: false
         type: string
       test:

--- a/.github/workflows/bundles-mac_aarch64.yml
+++ b/.github/workflows/bundles-mac_aarch64.yml
@@ -10,11 +10,11 @@ on:
         required: true
         type: string
       java-version:
-        default: '19'
+        default: '20'
         required: false
         type: string
       javafx-version:
-        default: '19'
+        default: '20'
         required: false
         type: string
       test:

--- a/.github/workflows/bundles-windows.yml
+++ b/.github/workflows/bundles-windows.yml
@@ -10,11 +10,11 @@ on:
         required: true
         type: string
       java-version:
-        default: '19'
+        default: '20'
         required: false
         type: string
       javafx-version:
-        default: '19'
+        default: '20'
         required: false
         type: string
       test:

--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -5,8 +5,8 @@ on:
     branches: [ master ]
 
 env:
-  JAVAFX_VERSION: '19'
-  JAVA_VERSION: '19'
+  JAVAFX_VERSION: '20'
+  JAVA_VERSION: '20'
 
 jobs:
   precheck:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,8 @@ on:
   workflow_dispatch:
 
 env:
-  JAVAFX_VERSION: '19'
-  JAVA_VERSION: '19'
+  JAVAFX_VERSION: '20'
+  JAVA_VERSION: '20'
 
 jobs:
   precheck:

--- a/kit/src/test/resources/com/oracle/javafx/scenebuilder/kit/fxom/HeaderWithNotOnlyImports.fxml
+++ b/kit/src/test/resources/com/oracle/javafx/scenebuilder/kit/fxom/HeaderWithNotOnlyImports.fxml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?language javascript?>
+<?language nameOfScriptLanguage?>
 
 <!-- This could be a license header -->
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <maven.compiler.release>${java.version}</maven.compiler.release>
-        <javafx.version>19</javafx.version>
+        <javafx.version>20</javafx.version>
         <aether.version>1.1.0</aether.version>
         <charm.glisten.version>6.2.0</charm.glisten.version>
         <gluon.attach.version>4.0.15</gluon.attach.version>


### PR DESCRIPTION
Updated Github Actions Workflows to use JavaFX 20 and Java 20.

### Issue

<!--- The issue this PR addresses -->
Fixes #617

### Progress

The workflows did not run yet, so it can happen that for the one or other workflows errors occur. I will run tests locally on Ubuntu and Windows accordingly, Mac test only for x86.

- [x] Change must not contain extraneous whitespace
- [x] License header year is updated, if required
- [x] The PR name must follow the [pre-defined format](https://github.com/gluonhq/scenebuilder/blob/master/CONTRIBUTING.md)
- [x] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)