### PR TITLE
build: Added OperatorWrap rule to Checkstyle

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -80,5 +80,7 @@
             <property name="tokens" value="LITERAL_WHILE"/>
             <property name="option" value="text"/>
         </module>
+        
+        <module name="OperatorWrap"/>
     </module>
 </module>


### PR DESCRIPTION
Added OperatorWrap rule to Checkstyle so that unwrapped operators are no longer an issue in PRs.

### Issue

Fixes #620

### Progress

<!-- Please ensure you actioned and ticked each box below before requesting a review -->

- [x] Change must not contain extraneous whitespace
- [x] License header year is updated, if required
- [x] The PR name must follow the [pre-defined format](https://github.com/gluonhq/scenebuilder/blob/master/CONTRIBUTING.md)
- [x] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)