### PR TITLE
build: Added WhitespaceAround and WhitespaceAfter rules to Checkstyle config

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -20,11 +20,11 @@
 
     <module name="TreeWalker">
         <property name="tabWidth" value="4"/>
-        
+
         <module name="GenericWhitespace"/>
         <module name="EmptyForInitializerPad"/>
         <module name="EmptyForIteratorPad"/>
-        
+
         <module name="NoWhitespaceBefore"/>
         <module name="NoWhitespaceBeforeCaseDefaultColon"/>
         <module name="NoWhitespaceBefore">
@@ -41,10 +41,10 @@
         <module name="EmptyLineSeparator">
             <property name="tokens" value="IMPORT"/>
             <property name="tokens" value="STATIC_IMPORT"/>
-			<property name="tokens" value="INTERFACE_DEF"/>
-			<property name="tokens" value="INSTANCE_INIT"/>
-			<property name="tokens" value="RECORD_DEF"/>
-			<property name="allowNoEmptyLineBetweenFields" value="false"/>
+            <property name="tokens" value="INTERFACE_DEF"/>
+            <property name="tokens" value="INSTANCE_INIT"/>
+            <property name="tokens" value="RECORD_DEF"/>
+            <property name="allowNoEmptyLineBetweenFields" value="false"/>
             <property name="allowMultipleEmptyLinesInsideClassMembers" value="true"/>
         </module>
 
@@ -62,7 +62,7 @@
             <property name="tokens" value="INDEX_OP"/>
             <property name="tokens" value="METHOD_REF"/>
         </module>    
-        
+
         <module name="EmptyBlock">
             <property name="tokens" value="LITERAL_CATCH"/>
             <property name="tokens" value="LITERAL_DEFAULT"/>
@@ -80,7 +80,7 @@
             <property name="tokens" value="LITERAL_WHILE"/>
             <property name="option" value="text"/>
         </module>
-        
+
         <module name="OperatorWrap"/>
         <module name="WhitespaceAfter"/>
         <module name="WhitespaceAround"/>


### PR DESCRIPTION
### Issue

Actually I was wrong with adding the OperatorWrap check as solution to test for leading/trailing spaces around operators.
OperatorWrap only ensures that we get the following pattern when line wraps are needed: The proper solution here is to use `WhitespaceAround` and `WhitespaceAfter`.

Checkstyle will complain this one using OperatorWrap:

```java
        int d = c +
                10;
```

It will permit:

```java
        int d = c
                + 10;
```

To check if e.g. spaces are placed around operators or lambdas or behind a comma, following 2 rules apply.
Please test so we can find a suitable configuration.

```xml
        <module name="WhitespaceAfter"/>
        <module name="WhitespaceAround"/>
```

This setup ensures that we actually get the whitespaces around lambdas, around operators `+`, `||`, etc and it ensures that e.g. missing whitespace after `,` or `{` is detected. 

WhitespaceAround: https://checkstyle.org/config_whitespace.html#WhitespaceAround
WhitespaceAfter: https://checkstyle.org/config_whitespace.html#WhitespaceAfter

Fixes #620

### Progress

<!-- Please ensure you actioned and ticked each box below before requesting a review -->

- [x] Change must not contain extraneous whitespace
- [x] License header year is updated, if required
- [x] The PR name must follow the [pre-defined format](https://github.com/gluonhq/scenebuilder/blob/master/CONTRIBUTING.md)
- [x] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)