### PR TITLE
build: Checkstyle is applied to test sources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,7 @@
                         <encoding>UTF-8</encoding>
                         <consoleOutput>true</consoleOutput>
                         <failsOnError>true</failsOnError>
+                        <includeTestSourceDirectory>true</includeTestSourceDirectory>
                     </configuration>
                     <dependencies>
                         <dependency>


### PR DESCRIPTION
@abhinayagarwal 

### Issue

Fixes #620 

As discussed, the Checkstyle plugin is now configured to verify test sources formatting as well.

### Progress

<!-- Please ensure you actioned and ticked each box below before requesting a review -->

- [x] Change must not contain extraneous whitespace
- [x] License header year is updated, if required
- [x] The PR name must follow the [pre-defined format](https://github.com/gluonhq/scenebuilder/blob/master/CONTRIBUTING.md)
- [x] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)