### PR TITLE
docs: rename chekstyle for app from kit to app

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,5 +108,5 @@ mvn checkstyle:checkstyle
 There will be a report for each sub-project, one for `app` and one for `kit`.
 
 * Kit: `kit/target/site/checkstyle.html`
-* App: `kit/target/site/checkstyle.html`
+* App: `app/target/site/checkstyle.html`
 


### PR DESCRIPTION
<!--- Provide a brief summary of the PR -->
**Summary:**
This PR updates SceneBuilder's documentation, renaming the generated folder from 'kit' to 'app' for clarity. The changes, made in English, aim for consistency and improved user understanding. Ready for review and merging. 🚀

### Issue 

<!--- The issue this PR addresses -->
Fixes #668

### Progress

<!-- Please ensure you actioned and ticked each box below before requesting a review -->

- [x] Change must not contain extraneous whitespace
- [x] License header year is updated, if required
- [x] The PR name must follow the [pre-defined format](https://github.com/gluonhq/scenebuilder/blob/master/CONTRIBUTING.md)
- [x] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)