### PR TITLE
build: Use Java and JavaFX 22

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
 
 env:
-  JAVA_VERSION: '21'
+  JAVA_VERSION: '22'
 
 jobs:
   verify:

--- a/.github/workflows/bundles-kit.yml
+++ b/.github/workflows/bundles-kit.yml
@@ -7,7 +7,7 @@ on:
         required: true
         type: string
       java-version:
-        default: '21.0.1'
+        default: '22'
         required: false
         type: string
 

--- a/.github/workflows/bundles-linux.yml
+++ b/.github/workflows/bundles-linux.yml
@@ -14,7 +14,7 @@ on:
         required: false
         type: string
       javafx-version:
-        default: '21.0.1'
+        default: '22'
         required: false
         type: string
       test:

--- a/.github/workflows/bundles-linux.yml
+++ b/.github/workflows/bundles-linux.yml
@@ -10,7 +10,7 @@ on:
         required: true
         type: string
       java-version:
-        default: '21.0.1'
+        default: '22'
         required: false
         type: string
       javafx-version:

--- a/.github/workflows/bundles-mac.yml
+++ b/.github/workflows/bundles-mac.yml
@@ -14,7 +14,7 @@ on:
         required: false
         type: string
       javafx-version:
-        default: '21.0.1'
+        default: '22'
         required: false
         type: string
       test:

--- a/.github/workflows/bundles-mac.yml
+++ b/.github/workflows/bundles-mac.yml
@@ -10,7 +10,7 @@ on:
         required: true
         type: string
       java-version:
-        default: '21.0.1'
+        default: '22'
         required: false
         type: string
       javafx-version:

--- a/.github/workflows/bundles-mac_aarch64.yml
+++ b/.github/workflows/bundles-mac_aarch64.yml
@@ -14,7 +14,7 @@ on:
         required: false
         type: string
       javafx-version:
-        default: '21.0.1'
+        default: '22'
         required: false
         type: string
       test:

--- a/.github/workflows/bundles-mac_aarch64.yml
+++ b/.github/workflows/bundles-mac_aarch64.yml
@@ -10,7 +10,7 @@ on:
         required: true
         type: string
       java-version:
-        default: '21.0.1'
+        default: '22'
         required: false
         type: string
       javafx-version:

--- a/.github/workflows/bundles-windows.yml
+++ b/.github/workflows/bundles-windows.yml
@@ -14,7 +14,7 @@ on:
         required: false
         type: string
       javafx-version:
-        default: '21.0.1'
+        default: '22'
         required: false
         type: string
       test:

--- a/.github/workflows/bundles-windows.yml
+++ b/.github/workflows/bundles-windows.yml
@@ -10,7 +10,7 @@ on:
         required: true
         type: string
       java-version:
-        default: '21.0.1'
+        default: '22'
         required: false
         type: string
       javafx-version:

--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -5,7 +5,7 @@ on:
     branches: [ master ]
 
 env:
-  JAVAFX_VERSION: '21.0.1'
+  JAVAFX_VERSION: '22'
   JAVA_VERSION: '21'
 
 jobs:

--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   JAVAFX_VERSION: '22'
-  JAVA_VERSION: '21'
+  JAVA_VERSION: '22'
 
 jobs:
   precheck:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
           - GA
 
 env:
-  JAVAFX_VERSION: '21.0.1'
+  JAVAFX_VERSION: '22'
   JAVA_VERSION: '21'
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ on:
 
 env:
   JAVAFX_VERSION: '22'
-  JAVA_VERSION: '21'
+  JAVA_VERSION: '22'
 
 jobs:
   precheck:

--- a/pom.xml
+++ b/pom.xml
@@ -16,10 +16,10 @@
     </modules>
 
     <properties>
-        <java.version>21.0.1</java.version>
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
-        <maven.compiler.release>21</maven.compiler.release>
+        <java.version>22</java.version>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
+        <maven.compiler.release>${java.version}</maven.compiler.release>
         <javafx.version>22</javafx.version>
         <aether.version>1.1.0</aether.version>
         <charm.glisten.version>6.2.2</charm.glisten.version>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <maven.compiler.release>21</maven.compiler.release>
-        <javafx.version>21.0.1</javafx.version>
+        <javafx.version>22</javafx.version>
         <aether.version>1.1.0</aether.version>
         <charm.glisten.version>6.2.2</charm.glisten.version>
         <gluon.attach.version>4.0.19</gluon.attach.version>


### PR DESCRIPTION
As OpenJFX 22 was release, SceneBuilder can use the new version.

This PR consists yet of 2 commits. 1 change include the reactor POM.xml with the latest OpenJFX version. The other one updates all Github workflows.

### Issue

Fixes #685 

### Progress

- [x] Change must not contain extraneous whitespace
- [x] License header year is updated, if required
- [x] The PR name must follow the [pre-defined format](https://github.com/gluonhq/scenebuilder/blob/master/CONTRIBUTING.md)
- [x] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)