### PR TITLE
build: Checkstyle now verifies line length of Java files (<=120 char)

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -8,6 +8,11 @@
     <property name="severity" value="warning" />
     <property name="fileExtensions" value="java, properties, xml, fxml" />
 
+    <module name="LineLength">
+        <property name="fileExtensions" value="java" />
+        <property name="max" value="120"/>
+    </module>
+
     <!-- BeforeExecutionFileFilters is required for sources that are based on java9 -->
     <module name="BeforeExecutionExclusionFileFilter">
         <property name="fileNamePattern"


### PR DESCRIPTION
Added rule to check that line length in Java files not exceeds 120 chars.

### Issue

Fixes #690 

With the new checkstyle rule, one will now get warnings on overly long lines:

```
> mvn checkstyle:checkstyle
...
[WARN] PreferencesRecordDocument.java:134: Zeile ist 121 Zeichen lang (Obergrenze ist 120). [LineLength]
[WARN] PreferencesRecordDocument.java:156: Zeile ist 148 Zeichen lang (Obergrenze ist 120). [LineLength]
[WARN] PreferencesRecordGlobal.java:418: Zeile ist 125 Zeichen lang (Obergrenze ist 120). [LineLength]
[WARN] PreferencesRecordGlobal.java:423: Zeile ist 129 Zeichen lang (Obergrenze ist 120). [LineLength]
...
```

### Progress

- [x] Change must not contain extraneous whitespace
- [x] License header year is updated, if required
- [x] The PR name must follow the [pre-defined format](https://github.com/gluonhq/scenebuilder/blob/master/CONTRIBUTING.md)
- [x] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)