### PR TITLE
build: Use Java and JavaFX 23-ea

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
 
 env:
-  JAVA_VERSION: '22'
+  JAVA_VERSION: '23'
 
 jobs:
   verify:

--- a/.github/workflows/bundles-kit.yml
+++ b/.github/workflows/bundles-kit.yml
@@ -7,7 +7,7 @@ on:
         required: true
         type: string
       java-version:
-        default: '22'
+        default: '23'
         required: false
         type: string
 

--- a/.github/workflows/bundles-linux.yml
+++ b/.github/workflows/bundles-linux.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup JavaFX
         run: |
           wget -P /tmp https://download2.gluonhq.com/openjfx/${{ inputs.javafx-version }}/openjfx-${{ env.JAVAFX_BUILD }}_linux-x64_bin-jmods.zip
-          unzip /tmp/openjfx-${{ inputs.javafx-version }}_linux-x64_bin-jmods.zip -d /tmp
+          unzip /tmp/openjfx-${{ env.JAVAFX_BUILD }}_linux-x64_bin-jmods.zip -d /tmp
         env:
           JAVAFX_BUILD: ${{ inputs.javafx-ea-build == '' && inputs.javafx-version || format('{0}-{1}', inputs.javafx-version, inputs.javafx-ea-build) }}
 

--- a/.github/workflows/bundles-linux.yml
+++ b/.github/workflows/bundles-linux.yml
@@ -10,11 +10,11 @@ on:
         required: true
         type: string
       java-version:
-        default: '22'
+        default: '23'
         required: false
         type: string
       javafx-version:
-        default: '22'
+        default: '23'
         required: false
         type: string
       test:

--- a/.github/workflows/bundles-linux.yml
+++ b/.github/workflows/bundles-linux.yml
@@ -17,6 +17,10 @@ on:
         default: '23'
         required: false
         type: string
+      javafx-ea-build:
+        default: ''
+        required: false
+        type: string
       test:
         default: false
         required: false
@@ -39,8 +43,10 @@ jobs:
 
       - name: Setup JavaFX
         run: |
-          wget -P /tmp https://download2.gluonhq.com/openjfx/${{ inputs.javafx-version }}/openjfx-${{ inputs.javafx-version }}_linux-x64_bin-jmods.zip
+          wget -P /tmp https://download2.gluonhq.com/openjfx/${{ inputs.javafx-version }}/openjfx-${{ env.JAVAFX_BUILD }}_linux-x64_bin-jmods.zip
           unzip /tmp/openjfx-${{ inputs.javafx-version }}_linux-x64_bin-jmods.zip -d /tmp
+        env:
+          JAVAFX_BUILD: ${{ inputs.javafx-ea-build == '' && '' || -inputs.javafx-ea-build }}
 
       - name: Cache Maven packages
         uses: actions/cache@v2

--- a/.github/workflows/bundles-linux.yml
+++ b/.github/workflows/bundles-linux.yml
@@ -17,10 +17,6 @@ on:
         default: '23'
         required: false
         type: string
-      javafx-ea-build:
-        default: ''
-        required: false
-        type: string
       test:
         default: false
         required: false
@@ -43,10 +39,9 @@ jobs:
 
       - name: Setup JavaFX
         run: |
-          wget -P /tmp https://download2.gluonhq.com/openjfx/${{ inputs.javafx-version }}/openjfx-${{ env.JAVAFX_BUILD }}_linux-x64_bin-jmods.zip
-          unzip /tmp/openjfx-${{ env.JAVAFX_BUILD }}_linux-x64_bin-jmods.zip -d /tmp
-        env:
-          JAVAFX_BUILD: ${{ inputs.javafx-ea-build == '' && inputs.javafx-version || format('{0}-{1}', inputs.javafx-version, inputs.javafx-ea-build) }}
+          JAVAFX_MAJOR_VERSION=$(echo ${{ inputs.javafx-version }} | cut -d- -f1)
+          wget -P /tmp https://download2.gluonhq.com/openjfx/$JAVAFX_MAJOR_VERSION/openjfx-${{ inputs.javafx-version }}_linux-x64_bin-jmods.zip
+          unzip /tmp/openjfx-${{ inputs.javafx-version }}_linux-x64_bin-jmods.zip -d /tmp
 
       - name: Cache Maven packages
         uses: actions/cache@v2

--- a/.github/workflows/bundles-linux.yml
+++ b/.github/workflows/bundles-linux.yml
@@ -38,8 +38,10 @@ jobs:
           release: ${{ inputs.java-version }}
 
       - name: Setup JavaFX
+        id: javafx
         run: |
           JAVAFX_MAJOR_VERSION=$(echo ${{ inputs.javafx-version }} | cut -d- -f1)
+          echo ::set-output name=JAVAFX_MAJOR_VERSION::$JAVAFX_MAJOR_VERSION
           wget -P /tmp https://download2.gluonhq.com/openjfx/$JAVAFX_MAJOR_VERSION/openjfx-${{ inputs.javafx-version }}_linux-x64_bin-jmods.zip
           unzip /tmp/openjfx-${{ inputs.javafx-version }}_linux-x64_bin-jmods.zip -d /tmp
 
@@ -90,7 +92,7 @@ jobs:
           ls ${{ env.INSTALL_DIR }}
         env:
           MAIN_CLASS: com.oracle.javafx.scenebuilder.app.SceneBuilderApp
-          JAVAFX_HOME: /tmp/javafx-jmods-${{ inputs.javafx-version }}/
+          JAVAFX_HOME: /tmp/javafx-jmods-${{ steps.javafx.outputs.JAVAFX_MAJOR_VERSION }}/
           JPACKAGE_HOME: ${{ env.JAVA_HOME }}
           PROJECT_VERSION: ${{ inputs.project-version }}
           APP_VERSION: ${{ inputs.app-version }}

--- a/.github/workflows/bundles-linux.yml
+++ b/.github/workflows/bundles-linux.yml
@@ -41,7 +41,7 @@ jobs:
         id: javafx
         run: |
           JAVAFX_MAJOR_VERSION=$(echo ${{ inputs.javafx-version }} | cut -d- -f1)
-          echo ::set-output name=JAVAFX_MAJOR_VERSION::$JAVAFX_MAJOR_VERSION
+          echo JAVAFX_MAJOR_VERSION=$JAVAFX_MAJOR_VERSION >> $GITHUB_OUTPUT
           wget -P /tmp https://download2.gluonhq.com/openjfx/$JAVAFX_MAJOR_VERSION/openjfx-${{ inputs.javafx-version }}_linux-x64_bin-jmods.zip
           unzip /tmp/openjfx-${{ inputs.javafx-version }}_linux-x64_bin-jmods.zip -d /tmp
 

--- a/.github/workflows/bundles-linux.yml
+++ b/.github/workflows/bundles-linux.yml
@@ -46,7 +46,7 @@ jobs:
           wget -P /tmp https://download2.gluonhq.com/openjfx/${{ inputs.javafx-version }}/openjfx-${{ env.JAVAFX_BUILD }}_linux-x64_bin-jmods.zip
           unzip /tmp/openjfx-${{ inputs.javafx-version }}_linux-x64_bin-jmods.zip -d /tmp
         env:
-          JAVAFX_BUILD: ${{ inputs.javafx-ea-build == '' && '' || -inputs.javafx-ea-build }}
+          JAVAFX_BUILD: ${{ inputs.javafx-ea-build == '' && inputs.javafx-version || format('{0}-{1}', inputs.javafx-version, inputs.javafx-ea-build) }}
 
       - name: Cache Maven packages
         uses: actions/cache@v2

--- a/.github/workflows/bundles-mac.yml
+++ b/.github/workflows/bundles-mac.yml
@@ -17,6 +17,10 @@ on:
         default: '23'
         required: false
         type: string
+      javafx-ea-build:
+        default: ''
+        required: false
+        type: string
       test:
         default: false
         required: false

--- a/.github/workflows/bundles-mac.yml
+++ b/.github/workflows/bundles-mac.yml
@@ -55,7 +55,7 @@ jobs:
         id: javafx
         run: |
           JAVAFX_MAJOR_VERSION=$(echo ${{ inputs.javafx-version }} | cut -d- -f1)
-          echo ::set-output name=JAVAFX_MAJOR_VERSION::$JAVAFX_MAJOR_VERSION
+          echo JAVAFX_MAJOR_VERSION=$JAVAFX_MAJOR_VERSION >> $GITHUB_OUTPUT
           wget -P /tmp https://download2.gluonhq.com/openjfx/$JAVAFX_MAJOR_VERSION/openjfx-${{ inputs.javafx-version }}_osx-x64_bin-jmods.zip
           unzip /tmp/openjfx-${{ inputs.javafx-version }}_osx-x64_bin-jmods.zip -d /tmp
 
@@ -92,7 +92,7 @@ jobs:
             --mac-sign
           mv ${{ env.INSTALL_DIR }}/SceneBuilder-${{ env.APP_VERSION }}.dmg ${{ env.INSTALL_DIR }}/SceneBuilder-${{ env.PROJECT_VERSION }}-amd64.dmg
           ls ${{ env.INSTALL_DIR }}
-          echo ::set-output name=path::${{ env.INSTALL_DIR }}/SceneBuilder-${{ env.PROJECT_VERSION }}-amd64.dmg
+          echo path=${{ env.INSTALL_DIR }}/SceneBuilder-${{ env.PROJECT_VERSION }}-amd64.dmg >> $GITHUB_OUTPUT
         env:
           MAIN_CLASS: com.oracle.javafx.scenebuilder.app.SceneBuilderApp
           JAVAFX_HOME: /tmp/javafx-jmods-${{ steps.javafx.outputs.JAVAFX_MAJOR_VERSION }}/

--- a/.github/workflows/bundles-mac.yml
+++ b/.github/workflows/bundles-mac.yml
@@ -52,8 +52,10 @@ jobs:
           p12-password: ${{ secrets.CERTIFICATES_PASSWORD }}
 
       - name: Setup JavaFX
+        id: javafx
         run: |
           JAVAFX_MAJOR_VERSION=$(echo ${{ inputs.javafx-version }} | cut -d- -f1)
+          echo ::set-output name=JAVAFX_MAJOR_VERSION::$JAVAFX_MAJOR_VERSION
           wget -P /tmp https://download2.gluonhq.com/openjfx/$JAVAFX_MAJOR_VERSION/openjfx-${{ inputs.javafx-version }}_osx-x64_bin-jmods.zip
           unzip /tmp/openjfx-${{ inputs.javafx-version }}_osx-x64_bin-jmods.zip -d /tmp
 
@@ -93,7 +95,7 @@ jobs:
           echo ::set-output name=path::${{ env.INSTALL_DIR }}/SceneBuilder-${{ env.PROJECT_VERSION }}-amd64.dmg
         env:
           MAIN_CLASS: com.oracle.javafx.scenebuilder.app.SceneBuilderApp
-          JAVAFX_HOME: /tmp/javafx-jmods-${{ inputs.javafx-version }}/
+          JAVAFX_HOME: /tmp/javafx-jmods-${{ steps.javafx.outputs.JAVAFX_MAJOR_VERSION }}/
           JPACKAGE_HOME: ${{ env.JAVA_HOME }}
           MACSIGN_PREFIX: ${{ secrets.MACSIGN_PREFIX }}
           MACSIGN_USER: ${{ secrets.MACSIGN_USER }}

--- a/.github/workflows/bundles-mac.yml
+++ b/.github/workflows/bundles-mac.yml
@@ -10,11 +10,11 @@ on:
         required: true
         type: string
       java-version:
-        default: '22'
+        default: '23'
         required: false
         type: string
       javafx-version:
-        default: '22'
+        default: '23'
         required: false
         type: string
       test:

--- a/.github/workflows/bundles-mac.yml
+++ b/.github/workflows/bundles-mac.yml
@@ -17,10 +17,6 @@ on:
         default: '23'
         required: false
         type: string
-      javafx-ea-build:
-        default: ''
-        required: false
-        type: string
       test:
         default: false
         required: false
@@ -57,7 +53,8 @@ jobs:
 
       - name: Setup JavaFX
         run: |
-          wget -P /tmp https://download2.gluonhq.com/openjfx/${{ inputs.javafx-version }}/openjfx-${{ inputs.javafx-version }}_osx-x64_bin-jmods.zip
+          JAVAFX_MAJOR_VERSION=$(echo ${{ inputs.javafx-version }} | cut -d- -f1)
+          wget -P /tmp https://download2.gluonhq.com/openjfx/$JAVAFX_MAJOR_VERSION/openjfx-${{ inputs.javafx-version }}_osx-x64_bin-jmods.zip
           unzip /tmp/openjfx-${{ inputs.javafx-version }}_osx-x64_bin-jmods.zip -d /tmp
 
       - name: Cache Maven packages

--- a/.github/workflows/bundles-mac_aarch64.yml
+++ b/.github/workflows/bundles-mac_aarch64.yml
@@ -17,6 +17,10 @@ on:
         default: '23'
         required: false
         type: string
+      javafx-ea-build:
+        default: ''
+        required: false
+        type: string
       test:
         default: false
         required: false

--- a/.github/workflows/bundles-mac_aarch64.yml
+++ b/.github/workflows/bundles-mac_aarch64.yml
@@ -53,8 +53,10 @@ jobs:
           p12-password: ${{ secrets.CERTIFICATES_PASSWORD }}
 
       - name: Setup JavaFX
+        id: javafx
         run: |
           JAVAFX_MAJOR_VERSION=$(echo ${{ inputs.javafx-version }} | cut -d- -f1)
+          echo ::set-output name=JAVAFX_MAJOR_VERSION::$JAVAFX_MAJOR_VERSION
           wget -P /tmp https://download2.gluonhq.com/openjfx/$JAVAFX_MAJOR_VERSION/openjfx-${{ inputs.javafx-version }}_osx-aarch64_bin-jmods.zip
           unzip /tmp/openjfx-${{ inputs.javafx-version }}_osx-aarch64_bin-jmods.zip -d /tmp
 
@@ -94,7 +96,7 @@ jobs:
           echo ::set-output name=path::${{ env.INSTALL_DIR }}/SceneBuilder-${{ env.PROJECT_VERSION }}-aarch64.dmg
         env:
           MAIN_CLASS: com.oracle.javafx.scenebuilder.app.SceneBuilderApp
-          JAVAFX_HOME: /tmp/javafx-jmods-${{ inputs.javafx-version }}/
+          JAVAFX_HOME: /tmp/javafx-jmods-${{ steps.javafx.outputs.JAVAFX_MAJOR_VERSION }}/
           JPACKAGE_HOME: ${{ env.JAVA_HOME }}
           MACSIGN_PREFIX: ${{ secrets.MACSIGN_PREFIX }}
           MACSIGN_USER: ${{ secrets.MACSIGN_USER }}

--- a/.github/workflows/bundles-mac_aarch64.yml
+++ b/.github/workflows/bundles-mac_aarch64.yml
@@ -56,7 +56,7 @@ jobs:
         id: javafx
         run: |
           JAVAFX_MAJOR_VERSION=$(echo ${{ inputs.javafx-version }} | cut -d- -f1)
-          echo ::set-output name=JAVAFX_MAJOR_VERSION::$JAVAFX_MAJOR_VERSION
+          echo JAVAFX_MAJOR_VERSION=$JAVAFX_MAJOR_VERSION >> $GITHUB_OUTPUT
           wget -P /tmp https://download2.gluonhq.com/openjfx/$JAVAFX_MAJOR_VERSION/openjfx-${{ inputs.javafx-version }}_osx-aarch64_bin-jmods.zip
           unzip /tmp/openjfx-${{ inputs.javafx-version }}_osx-aarch64_bin-jmods.zip -d /tmp
 
@@ -93,7 +93,7 @@ jobs:
             --mac-sign
           mv ${{ env.INSTALL_DIR }}/SceneBuilder-${{ env.APP_VERSION }}.dmg ${{ env.INSTALL_DIR }}/SceneBuilder-${{ env.PROJECT_VERSION }}-aarch64.dmg
           ls ${{ env.INSTALL_DIR }}
-          echo ::set-output name=path::${{ env.INSTALL_DIR }}/SceneBuilder-${{ env.PROJECT_VERSION }}-aarch64.dmg
+          echo path=${{ env.INSTALL_DIR }}/SceneBuilder-${{ env.PROJECT_VERSION }}-aarch64.dmg >> $GITHUB_OUTPUT
         env:
           MAIN_CLASS: com.oracle.javafx.scenebuilder.app.SceneBuilderApp
           JAVAFX_HOME: /tmp/javafx-jmods-${{ steps.javafx.outputs.JAVAFX_MAJOR_VERSION }}/

--- a/.github/workflows/bundles-mac_aarch64.yml
+++ b/.github/workflows/bundles-mac_aarch64.yml
@@ -10,11 +10,11 @@ on:
         required: true
         type: string
       java-version:
-        default: '22'
+        default: '23'
         required: false
         type: string
       javafx-version:
-        default: '22'
+        default: '23'
         required: false
         type: string
       test:

--- a/.github/workflows/bundles-mac_aarch64.yml
+++ b/.github/workflows/bundles-mac_aarch64.yml
@@ -17,10 +17,6 @@ on:
         default: '23'
         required: false
         type: string
-      javafx-ea-build:
-        default: ''
-        required: false
-        type: string
       test:
         default: false
         required: false
@@ -58,7 +54,8 @@ jobs:
 
       - name: Setup JavaFX
         run: |
-          wget -P /tmp https://download2.gluonhq.com/openjfx/${{ inputs.javafx-version }}/openjfx-${{ inputs.javafx-version }}_osx-aarch64_bin-jmods.zip
+          JAVAFX_MAJOR_VERSION=$(echo ${{ inputs.javafx-version }} | cut -d- -f1)
+          wget -P /tmp https://download2.gluonhq.com/openjfx/$JAVAFX_MAJOR_VERSION/openjfx-${{ inputs.javafx-version }}_osx-aarch64_bin-jmods.zip
           unzip /tmp/openjfx-${{ inputs.javafx-version }}_osx-aarch64_bin-jmods.zip -d /tmp
 
       - name: Cache Maven packages

--- a/.github/workflows/bundles-windows.yml
+++ b/.github/workflows/bundles-windows.yml
@@ -17,6 +17,10 @@ on:
         default: '23'
         required: false
         type: string
+      javafx-ea-build:
+        default: ''
+        required: false
+        type: string
       test:
         default: false
         required: false

--- a/.github/workflows/bundles-windows.yml
+++ b/.github/workflows/bundles-windows.yml
@@ -42,9 +42,11 @@ jobs:
           release: ${{ inputs.java-version }}
 
       - name: Setup JavaFX
+        id: javafx
         shell: pwsh
         run: |
           $JAVAFX_MAJOR_VERSION = '${{ inputs.javafx-version }}' -split '-' | Select-Object -Index 0
+          echo ::set-output name=JAVAFX_MAJOR_VERSION::$JAVAFX_MAJOR_VERSION
           Invoke-WebRequest -Uri https://download2.gluonhq.com/openjfx/$JAVAFX_MAJOR_VERSION/openjfx-${{ inputs.javafx-version }}_windows-x64_bin-jmods.zip -OutFile D:\openjfx-${{ inputs.javafx-version }}_windows-x64_bin-jmods.zip
           Expand-Archive -Force D:\openjfx-${{ inputs.javafx-version }}_windows-x64_bin-jmods.zip D:\
 
@@ -76,7 +78,7 @@ jobs:
           call dir ${{ env.INSTALL_DIR }}
         env:
           MAIN_CLASS: com.oracle.javafx.scenebuilder.app.SceneBuilderApp
-          JAVAFX_HOME: D:\javafx-jmods-${{ inputs.javafx-version }}
+          JAVAFX_HOME: D:\javafx-jmods-${{ steps.javafx.outputs.JAVAFX_MAJOR_VERSION }}
           JPACKAGE_HOME: ${{ env.JAVA_HOME }}
           PROJECT_VERSION: ${{ inputs.project-version }}
           APP_VERSION: ${{ inputs.app-version }}

--- a/.github/workflows/bundles-windows.yml
+++ b/.github/workflows/bundles-windows.yml
@@ -46,7 +46,7 @@ jobs:
         shell: pwsh
         run: |
           $JAVAFX_MAJOR_VERSION = '${{ inputs.javafx-version }}' -split '-' | Select-Object -Index 0
-          echo ::set-output name=JAVAFX_MAJOR_VERSION::$JAVAFX_MAJOR_VERSION
+          echo "JAVAFX_MAJOR_VERSION=$JAVAFX_MAJOR_VERSION" >> $env:GITHUB_OUTPUT
           Invoke-WebRequest -Uri https://download2.gluonhq.com/openjfx/$JAVAFX_MAJOR_VERSION/openjfx-${{ inputs.javafx-version }}_windows-x64_bin-jmods.zip -OutFile D:\openjfx-${{ inputs.javafx-version }}_windows-x64_bin-jmods.zip
           Expand-Archive -Force D:\openjfx-${{ inputs.javafx-version }}_windows-x64_bin-jmods.zip D:\
 

--- a/.github/workflows/bundles-windows.yml
+++ b/.github/workflows/bundles-windows.yml
@@ -10,11 +10,11 @@ on:
         required: true
         type: string
       java-version:
-        default: '22'
+        default: '23'
         required: false
         type: string
       javafx-version:
-        default: '22'
+        default: '23'
         required: false
         type: string
       test:

--- a/.github/workflows/bundles-windows.yml
+++ b/.github/workflows/bundles-windows.yml
@@ -17,10 +17,6 @@ on:
         default: '23'
         required: false
         type: string
-      javafx-ea-build:
-        default: ''
-        required: false
-        type: string
       test:
         default: false
         required: false
@@ -48,7 +44,8 @@ jobs:
       - name: Setup JavaFX
         shell: pwsh
         run: |
-          Invoke-WebRequest -Uri https://download2.gluonhq.com/openjfx/${{ inputs.javafx-version }}/openjfx-${{ inputs.javafx-version }}_windows-x64_bin-jmods.zip -OutFile D:\openjfx-${{ inputs.javafx-version }}_windows-x64_bin-jmods.zip
+          $JAVAFX_MAJOR_VERSION = ${{ inputs.javafx-version }} -split '-' | Select-Object -Index 0
+          Invoke-WebRequest -Uri https://download2.gluonhq.com/openjfx/$JAVAFX_MAJOR_VERSION/openjfx-${{ inputs.javafx-version }}_windows-x64_bin-jmods.zip -OutFile D:\openjfx-${{ inputs.javafx-version }}_windows-x64_bin-jmods.zip
           Expand-Archive -Force D:\openjfx-${{ inputs.javafx-version }}_windows-x64_bin-jmods.zip D:\
 
       - name: Cache Maven packages

--- a/.github/workflows/bundles-windows.yml
+++ b/.github/workflows/bundles-windows.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup JavaFX
         shell: pwsh
         run: |
-          $JAVAFX_MAJOR_VERSION = ${{ inputs.javafx-version }} -split '-' | Select-Object -Index 0
+          $JAVAFX_MAJOR_VERSION = '${{ inputs.javafx-version }}' -split '-' | Select-Object -Index 0
           Invoke-WebRequest -Uri https://download2.gluonhq.com/openjfx/$JAVAFX_MAJOR_VERSION/openjfx-${{ inputs.javafx-version }}_windows-x64_bin-jmods.zip -OutFile D:\openjfx-${{ inputs.javafx-version }}_windows-x64_bin-jmods.zip
           Expand-Archive -Force D:\openjfx-${{ inputs.javafx-version }}_windows-x64_bin-jmods.zip D:\
 

--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -2,10 +2,11 @@ name: Early Access
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, java-23-ea ]
 
 env:
   JAVAFX_VERSION: '23'
+  JAVAFX_EA_BUILD: 'ea+27'
   JAVA_VERSION: '23'
 
 jobs:
@@ -49,6 +50,7 @@ jobs:
     uses: ./.github/workflows/bundles-linux.yml
     with:
       javafx-version: ${{ needs.precheck.outputs.JAVAFX_VERSION }}
+      javafx-ea-build: ${{ needs.precheck.outputs.JAVAFX_EA_BUILD }}
       java-version: ${{ needs.precheck.outputs.JAVA_VERSION }}
       app-version: ${{ needs.precheck.outputs.APP_VERSION }}
       project-version: ${{ needs.precheck.outputs.PROJECT_VERSION }}
@@ -63,6 +65,7 @@ jobs:
       WINDOWS_CERTNAME: ${{ secrets.WINDOWS_CERTNAME }}
     with:
       javafx-version: ${{ needs.precheck.outputs.JAVAFX_VERSION }}
+      javafx-ea-build: ${{ needs.precheck.outputs.JAVAFX_EA_BUILD }}
       java-version: ${{ needs.precheck.outputs.JAVA_VERSION }}
       app-version: ${{ needs.precheck.outputs.APP_VERSION }}
       project-version: ${{ needs.precheck.outputs.PROJECT_VERSION }}
@@ -80,6 +83,7 @@ jobs:
       MACSIGN_PREFIX: ${{ secrets.GLUON_MACSIGN_PREFIX }}
     with:
       javafx-version: ${{ needs.precheck.outputs.JAVAFX_VERSION }}
+      javafx-ea-build: ${{ needs.precheck.outputs.JAVAFX_EA_BUILD }}
       java-version: ${{ needs.precheck.outputs.JAVA_VERSION }}
       app-version: ${{ needs.precheck.outputs.APP_VERSION }}
       project-version: ${{ needs.precheck.outputs.PROJECT_VERSION }}
@@ -97,6 +101,7 @@ jobs:
       MACSIGN_PREFIX: ${{ secrets.GLUON_MACSIGN_PREFIX }}
     with:
       javafx-version: ${{ needs.precheck.outputs.JAVAFX_VERSION }}
+      javafx-ea-build: ${{ needs.precheck.outputs.JAVAFX_EA_BUILD }}
       java-version: ${{ needs.precheck.outputs.JAVA_VERSION }}
       app-version: ${{ needs.precheck.outputs.APP_VERSION }}
       project-version: ${{ needs.precheck.outputs.PROJECT_VERSION }}

--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -16,7 +16,7 @@ jobs:
     outputs:
       JAVA_VERSION: ${{ env.JAVA_VERSION }}
       JAVAFX_VERSION: ${{ env.JAVAFX_VERSION }}
-      JAVAFX_EA_BUILD: ${{ env.JAVAFX_VERSION }}
+      JAVAFX_EA_BUILD: ${{ env.JAVAFX_EA_BUILD }}
       APP_VERSION: ${{ steps.vars.outputs.APP_VERSION }}
       PROJECT_VERSION: ${{ steps.vars.outputs.PROJECT_VERSION }}
     steps:

--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -41,8 +41,8 @@ jobs:
           PROJECT_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           APP_VERSION=$PROJECT_VERSION
           APP_VERSION=${APP_VERSION%-*}
-          echo ::set-output name=APP_VERSION::$APP_VERSION
-          echo ::set-output name=PROJECT_VERSION::$PROJECT_VERSION
+          echo APP_VERSION=$APP_VERSION >> $GITHUB_OUTPUT
+          echo PROJECT_VERSION=$PROJECT_VERSION >> $GITHUB_OUTPUT
 
   linux-bundles:
     needs: [precheck]

--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ubuntu-20.04
     if: startsWith(github.event.head_commit.message, 'Releasing version') != true
     outputs:
+      JAVAFX_VERSION: ${{ env.JAVAFX_VERSION }}
       JAVA_VERSION: ${{ env.JAVA_VERSION }}
-      JAVAFX_VERSION: ${{ inputs.javafx-version }}
       APP_VERSION: ${{ steps.vars.outputs.APP_VERSION }}
       PROJECT_VERSION: ${{ steps.vars.outputs.PROJECT_VERSION }}
     steps:
@@ -48,8 +48,8 @@ jobs:
     needs: [precheck]
     uses: ./.github/workflows/bundles-linux.yml
     with:
-      java-version: ${{ needs.precheck.outputs.JAVA_VERSION }}
       javafx-version: ${{ needs.precheck.outputs.JAVAFX_VERSION }}
+      java-version: ${{ needs.precheck.outputs.JAVA_VERSION }}
       app-version: ${{ needs.precheck.outputs.APP_VERSION }}
       project-version: ${{ needs.precheck.outputs.PROJECT_VERSION }}
       test: true
@@ -62,8 +62,8 @@ jobs:
       WINDOWS_PASSWORD: ${{ secrets.WINDOWS_PASSWORD }}
       WINDOWS_CERTNAME: ${{ secrets.WINDOWS_CERTNAME }}
     with:
-      java-version: ${{ needs.precheck.outputs.JAVA_VERSION }}
       javafx-version: ${{ needs.precheck.outputs.JAVAFX_VERSION }}
+      java-version: ${{ needs.precheck.outputs.JAVA_VERSION }}
       app-version: ${{ needs.precheck.outputs.APP_VERSION }}
       project-version: ${{ needs.precheck.outputs.PROJECT_VERSION }}
       test: true
@@ -79,8 +79,8 @@ jobs:
       MACSIGN_USER: ${{ secrets.GLUON_MACSIGN_USER }}
       MACSIGN_PREFIX: ${{ secrets.GLUON_MACSIGN_PREFIX }}
     with:
-      java-version: ${{ needs.precheck.outputs.JAVA_VERSION }}
       javafx-version: ${{ needs.precheck.outputs.JAVAFX_VERSION }}
+      java-version: ${{ needs.precheck.outputs.JAVA_VERSION }}
       app-version: ${{ needs.precheck.outputs.APP_VERSION }}
       project-version: ${{ needs.precheck.outputs.PROJECT_VERSION }}
       test: true
@@ -96,8 +96,8 @@ jobs:
       MACSIGN_USER: ${{ secrets.GLUON_MACSIGN_USER }}
       MACSIGN_PREFIX: ${{ secrets.GLUON_MACSIGN_PREFIX }}
     with:
-      java-version: ${{ needs.precheck.outputs.JAVA_VERSION }}
       javafx-version: ${{ needs.precheck.outputs.JAVAFX_VERSION }}
+      java-version: ${{ needs.precheck.outputs.JAVA_VERSION }}
       app-version: ${{ needs.precheck.outputs.APP_VERSION }}
       project-version: ${{ needs.precheck.outputs.PROJECT_VERSION }}
       test: true

--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -5,17 +5,18 @@ on:
     branches: [ master, java-23-ea ]
 
 env:
+  JAVA_VERSION: '23'
   JAVAFX_VERSION: '23'
   JAVAFX_EA_BUILD: 'ea+27'
-  JAVA_VERSION: '23'
 
 jobs:
   precheck:
     runs-on: ubuntu-20.04
     if: startsWith(github.event.head_commit.message, 'Releasing version') != true
     outputs:
-      JAVAFX_VERSION: ${{ env.JAVAFX_VERSION }}
       JAVA_VERSION: ${{ env.JAVA_VERSION }}
+      JAVAFX_VERSION: ${{ env.JAVAFX_VERSION }}
+      JAVAFX_EA_BUILD: ${{ env.JAVAFX_VERSION }}
       APP_VERSION: ${{ steps.vars.outputs.APP_VERSION }}
       PROJECT_VERSION: ${{ steps.vars.outputs.PROJECT_VERSION }}
     steps:
@@ -49,9 +50,9 @@ jobs:
     needs: [precheck]
     uses: ./.github/workflows/bundles-linux.yml
     with:
+      java-version: ${{ needs.precheck.outputs.JAVA_VERSION }}
       javafx-version: ${{ needs.precheck.outputs.JAVAFX_VERSION }}
       javafx-ea-build: ${{ needs.precheck.outputs.JAVAFX_EA_BUILD }}
-      java-version: ${{ needs.precheck.outputs.JAVA_VERSION }}
       app-version: ${{ needs.precheck.outputs.APP_VERSION }}
       project-version: ${{ needs.precheck.outputs.PROJECT_VERSION }}
       test: true
@@ -64,9 +65,9 @@ jobs:
       WINDOWS_PASSWORD: ${{ secrets.WINDOWS_PASSWORD }}
       WINDOWS_CERTNAME: ${{ secrets.WINDOWS_CERTNAME }}
     with:
+      java-version: ${{ needs.precheck.outputs.JAVA_VERSION }}
       javafx-version: ${{ needs.precheck.outputs.JAVAFX_VERSION }}
       javafx-ea-build: ${{ needs.precheck.outputs.JAVAFX_EA_BUILD }}
-      java-version: ${{ needs.precheck.outputs.JAVA_VERSION }}
       app-version: ${{ needs.precheck.outputs.APP_VERSION }}
       project-version: ${{ needs.precheck.outputs.PROJECT_VERSION }}
       test: true
@@ -82,9 +83,9 @@ jobs:
       MACSIGN_USER: ${{ secrets.GLUON_MACSIGN_USER }}
       MACSIGN_PREFIX: ${{ secrets.GLUON_MACSIGN_PREFIX }}
     with:
+      java-version: ${{ needs.precheck.outputs.JAVA_VERSION }}
       javafx-version: ${{ needs.precheck.outputs.JAVAFX_VERSION }}
       javafx-ea-build: ${{ needs.precheck.outputs.JAVAFX_EA_BUILD }}
-      java-version: ${{ needs.precheck.outputs.JAVA_VERSION }}
       app-version: ${{ needs.precheck.outputs.APP_VERSION }}
       project-version: ${{ needs.precheck.outputs.PROJECT_VERSION }}
       test: true
@@ -100,9 +101,9 @@ jobs:
       MACSIGN_USER: ${{ secrets.GLUON_MACSIGN_USER }}
       MACSIGN_PREFIX: ${{ secrets.GLUON_MACSIGN_PREFIX }}
     with:
+      java-version: ${{ needs.precheck.outputs.JAVA_VERSION }}
       javafx-version: ${{ needs.precheck.outputs.JAVAFX_VERSION }}
       javafx-ea-build: ${{ needs.precheck.outputs.JAVAFX_EA_BUILD }}
-      java-version: ${{ needs.precheck.outputs.JAVA_VERSION }}
       app-version: ${{ needs.precheck.outputs.APP_VERSION }}
       project-version: ${{ needs.precheck.outputs.PROJECT_VERSION }}
       test: true

--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -6,8 +6,7 @@ on:
 
 env:
   JAVA_VERSION: '23'
-  JAVAFX_VERSION: '23'
-  JAVAFX_EA_BUILD: 'ea+27'
+  JAVAFX_VERSION: '23-ea+27'
 
 jobs:
   precheck:
@@ -15,8 +14,7 @@ jobs:
     if: startsWith(github.event.head_commit.message, 'Releasing version') != true
     outputs:
       JAVA_VERSION: ${{ env.JAVA_VERSION }}
-      JAVAFX_VERSION: ${{ env.JAVAFX_VERSION }}
-      JAVAFX_EA_BUILD: ${{ env.JAVAFX_EA_BUILD }}
+      JAVAFX_VERSION: ${{ inputs.javafx-version }}
       APP_VERSION: ${{ steps.vars.outputs.APP_VERSION }}
       PROJECT_VERSION: ${{ steps.vars.outputs.PROJECT_VERSION }}
     steps:
@@ -52,7 +50,6 @@ jobs:
     with:
       java-version: ${{ needs.precheck.outputs.JAVA_VERSION }}
       javafx-version: ${{ needs.precheck.outputs.JAVAFX_VERSION }}
-      javafx-ea-build: ${{ needs.precheck.outputs.JAVAFX_EA_BUILD }}
       app-version: ${{ needs.precheck.outputs.APP_VERSION }}
       project-version: ${{ needs.precheck.outputs.PROJECT_VERSION }}
       test: true
@@ -67,7 +64,6 @@ jobs:
     with:
       java-version: ${{ needs.precheck.outputs.JAVA_VERSION }}
       javafx-version: ${{ needs.precheck.outputs.JAVAFX_VERSION }}
-      javafx-ea-build: ${{ needs.precheck.outputs.JAVAFX_EA_BUILD }}
       app-version: ${{ needs.precheck.outputs.APP_VERSION }}
       project-version: ${{ needs.precheck.outputs.PROJECT_VERSION }}
       test: true
@@ -85,7 +81,6 @@ jobs:
     with:
       java-version: ${{ needs.precheck.outputs.JAVA_VERSION }}
       javafx-version: ${{ needs.precheck.outputs.JAVAFX_VERSION }}
-      javafx-ea-build: ${{ needs.precheck.outputs.JAVAFX_EA_BUILD }}
       app-version: ${{ needs.precheck.outputs.APP_VERSION }}
       project-version: ${{ needs.precheck.outputs.PROJECT_VERSION }}
       test: true
@@ -103,7 +98,6 @@ jobs:
     with:
       java-version: ${{ needs.precheck.outputs.JAVA_VERSION }}
       javafx-version: ${{ needs.precheck.outputs.JAVAFX_VERSION }}
-      javafx-ea-build: ${{ needs.precheck.outputs.JAVAFX_EA_BUILD }}
       app-version: ${{ needs.precheck.outputs.APP_VERSION }}
       project-version: ${{ needs.precheck.outputs.PROJECT_VERSION }}
       test: true

--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -5,8 +5,8 @@ on:
     branches: [ master ]
 
 env:
-  JAVAFX_VERSION: '22'
-  JAVA_VERSION: '22'
+  JAVAFX_VERSION: '23'
+  JAVA_VERSION: '23'
 
 jobs:
   precheck:

--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -2,7 +2,7 @@ name: Early Access
 
 on:
   push:
-    branches: [ master, java-23-ea ]
+    branches: [ master ]
 
 env:
   JAVA_VERSION: '23'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,8 @@ on:
           - GA
 
 env:
-  JAVAFX_VERSION: '23'
   JAVA_VERSION: '23'
+  JAVAFX_VERSION: '23'
 
 jobs:
   precheck:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,8 @@ on:
           - GA
 
 env:
-  JAVAFX_VERSION: '22'
-  JAVA_VERSION: '22'
+  JAVAFX_VERSION: '23'
+  JAVA_VERSION: '23'
 
 jobs:
   precheck:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,9 +54,9 @@ jobs:
               S3_PATH=RC/$PROJECT_VERSION
           fi
           echo "Releasing.. "$PROJECT_VERSION
-          echo ::set-output name=APP_VERSION::$APP_VERSION
-          echo ::set-output name=PROJECT_VERSION::$PROJECT_VERSION
-          echo ::set-output name=S3_PATH::$S3_PATH
+          echo APP_VERSION=$APP_VERSION >> $GITHUB_OUTPUT
+          echo PROJECT_VERSION=$PROJECT_VERSION >> $GITHUB_OUTPUT
+          echo S3_PATH=$S3_PATH >> $GITHUB_OUTPUT
 
   linux-bundles:
     needs: [precheck]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,8 @@ on:
           - GA
 
 env:
-  JAVA_VERSION: '23'
   JAVAFX_VERSION: '23'
+  JAVA_VERSION: '23'
 
 jobs:
   precheck:

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <maven.compiler.release>${java.version}</maven.compiler.release>
-        <javafx.version>23</javafx.version>
+        <javafx.version>23-ea+27</javafx.version>
         <aether.version>1.1.0</aether.version>
         <charm.glisten.version>6.2.2</charm.glisten.version>
         <gluon.attach.version>4.0.19</gluon.attach.version>

--- a/pom.xml
+++ b/pom.xml
@@ -16,11 +16,11 @@
     </modules>
 
     <properties>
-        <java.version>22</java.version>
+        <java.version>23</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <maven.compiler.release>${java.version}</maven.compiler.release>
-        <javafx.version>22</javafx.version>
+        <javafx.version>23</javafx.version>
         <aether.version>1.1.0</aether.version>
         <charm.glisten.version>6.2.2</charm.glisten.version>
         <gluon.attach.version>4.0.19</gluon.attach.version>


### PR DESCRIPTION
<!--- Provide a brief summary of the PR -->
Scene Builder EA should be able to use EA version of Java/FX.

Also update build to use 23-ea

### Issue

<!--- The issue this PR addresses -->
Fixes #706

### Progress

<!-- Please ensure you actioned and ticked each box below before requesting a review -->

- [x] Change must not contain extraneous whitespace
- [x] License header year is updated, if required
- [x] The PR name must follow the [pre-defined format](https://github.com/gluonhq/scenebuilder/blob/master/CONTRIBUTING.md)
- [x] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)