### PR TITLE
fix: Constructor is now public (required for instantiation via FXML, issue 731).

### DIFF
--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/util/control/paintpicker/PaintPickerController.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/util/control/paintpicker/PaintPickerController.java
@@ -80,7 +80,7 @@ public class PaintPickerController {
     public final static RadialGradient DEFAULT_RADIAL
             = new RadialGradient(0.0, 0.0, 0.5, 0.5, 0.5, true, CycleMethod.NO_CYCLE);
 
-    PaintPickerController() {
+    public PaintPickerController() {
         // no-op
     }
 


### PR DESCRIPTION
The constructor of the PaintPickerController class must be public so that construction via FXML declaration will work.

### Issue

Fixes #731 

### Progress

- [x] Change must not contain extraneous whitespace
- [x] License header year is updated, if required
- [x] The PR name must follow the [pre-defined format](https://github.com/gluonhq/scenebuilder/blob/master/CONTRIBUTING.md)
- [x] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)