### PR TITLE
docs: Updated license copyright year to 2024

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 
-Copyright (c) 2016, 2023, Gluon and/or its affiliates.
+Copyright (c) 2016, 2024, Gluon and/or its affiliates.
 Copyright (c) 2012, 2014, Oracle and/or its affiliates.
 All rights reserved. Use is subject to license terms.
 


### PR DESCRIPTION
Copyright year of license.txt is outdated.

### Issue

Fixes #740 

### Progress
- [x] Change must not contain extraneous whitespace
- [x] License header year is updated, if required
- [x] The PR name must follow the [pre-defined format](https://github.com/gluonhq/scenebuilder/blob/master/CONTRIBUTING.md)
- [x] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)