### PR TITLE
build: Replaced deprecated --compress 2 option with new JLink 21 compliant --compress zip-9

### DIFF
--- a/.github/scripts/jpackage.bat
+++ b/.github/scripts/jpackage.bat
@@ -8,7 +8,7 @@ REM set MODULES=java.desktop,java.logging,java.naming,java.prefs,java.security.j
 --module-path %JAVAFX_HOME% ^
 --add-modules %JDEPS_MODULES%,%JAVAFX_MODULES% ^
 --output app/target/runtime ^
---strip-debug --compress zip-9 --no-header-files --no-man-pages
+--strip-debug --compress zip-6 --no-header-files --no-man-pages
 
 %JPACKAGE_HOME%\bin\jpackage ^
 --app-version %APP_VERSION% ^

--- a/.github/scripts/jpackage.bat
+++ b/.github/scripts/jpackage.bat
@@ -8,7 +8,7 @@ REM set MODULES=java.desktop,java.logging,java.naming,java.prefs,java.security.j
 --module-path %JAVAFX_HOME% ^
 --add-modules %JDEPS_MODULES%,%JAVAFX_MODULES% ^
 --output app/target/runtime ^
---strip-debug --compress 2 --no-header-files --no-man-pages
+--strip-debug --compress zip-9 --no-header-files --no-man-pages
 
 %JPACKAGE_HOME%\bin\jpackage ^
 --app-version %APP_VERSION% ^

--- a/.github/scripts/jpackage.sh
+++ b/.github/scripts/jpackage.sh
@@ -5,7 +5,7 @@ $JAVA_HOME/bin/jlink \
 --module-path $JAVAFX_HOME \
 --add-modules $jdeps_modules,$JAVAFX_MODULES \
 --output app/target/runtime \
---strip-debug --compress 2 --no-header-files --no-man-pages
+--strip-debug --compress zip-9 --no-header-files --no-man-pages
 
 $JPACKAGE_HOME/bin/jpackage \
 --app-version $APP_VERSION \

--- a/.github/scripts/jpackage.sh
+++ b/.github/scripts/jpackage.sh
@@ -5,7 +5,7 @@ $JAVA_HOME/bin/jlink \
 --module-path $JAVAFX_HOME \
 --add-modules $jdeps_modules,$JAVAFX_MODULES \
 --output app/target/runtime \
---strip-debug --compress zip-9 --no-header-files --no-man-pages
+--strip-debug --compress zip-6 --no-header-files --no-man-pages
 
 $JPACKAGE_HOME/bin/jpackage \
 --app-version $APP_VERSION \


### PR DESCRIPTION
As with JLink 21 the option `--compress 2` is deprecated, `--compress zip-9` is used instead.

### Issue

Fixes #741

### Progress

- [x] Change must not contain extraneous whitespace
- [x] License header year is updated, if required
- [x] The PR name must follow the [pre-defined format](https://github.com/gluonhq/scenebuilder/blob/master/CONTRIBUTING.md)
- [x] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)