### PR TITLE
Scene Builder 23.0.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
 
 env:
+  JAVA_RELEASE: '23'
   JAVA_VERSION: '23.0.1'
 
 jobs:
@@ -20,7 +21,8 @@ jobs:
         uses: oracle-actions/setup-java@v1.4.0
         with:
           website: jdk.java.net
-          release: ${{ env.JAVA_VERSION }}
+          release: ${{ env.JAVA_RELEASE }}
+          version: ${{ env.JAVA_VERSION }}
 
       - name: Run Tests (Linux)
         if: runner.os == 'Linux'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
 
 env:
-  JAVA_VERSION: '23'
+  JAVA_VERSION: '23.0.1'
 
 jobs:
   verify:

--- a/.github/workflows/bundles-kit.yml
+++ b/.github/workflows/bundles-kit.yml
@@ -6,6 +6,10 @@ on:
       project-version:
         required: true
         type: string
+      java-release:
+        default: '23'
+        required: false
+        type: string
       java-version:
         default: '23.0.1'
         required: false
@@ -21,7 +25,8 @@ jobs:
         uses: oracle-actions/setup-java@v1.4.0
         with:
           website: jdk.java.net
-          release: ${{ inputs.java-version }}
+          release: ${{ inputs.java-release }}
+          version: ${{ inputs.java-version }}
 
       - name: Cache Maven packages
         uses: actions/cache@v4

--- a/.github/workflows/bundles-kit.yml
+++ b/.github/workflows/bundles-kit.yml
@@ -7,7 +7,7 @@ on:
         required: true
         type: string
       java-version:
-        default: '23'
+        default: '23.0.1'
         required: false
         type: string
 

--- a/.github/workflows/bundles-linux.yml
+++ b/.github/workflows/bundles-linux.yml
@@ -9,6 +9,10 @@ on:
       project-version:
         required: true
         type: string
+      java-release:
+        default: '23'
+        required: false
+        type: string
       java-version:
         default: '23.0.1'
         required: false
@@ -35,7 +39,8 @@ jobs:
         uses: oracle-actions/setup-java@v1.4.0
         with:
           website: jdk.java.net
-          release: ${{ inputs.java-version }}
+          release: ${{ inputs.java-release }}
+          version: ${{ inputs.java-version }}
 
       - name: Setup JavaFX
         id: javafx

--- a/.github/workflows/bundles-linux.yml
+++ b/.github/workflows/bundles-linux.yml
@@ -10,11 +10,11 @@ on:
         required: true
         type: string
       java-version:
-        default: '23'
+        default: '23.0.1'
         required: false
         type: string
       javafx-version:
-        default: '23'
+        default: '23.0.1'
         required: false
         type: string
       test:

--- a/.github/workflows/bundles-mac.yml
+++ b/.github/workflows/bundles-mac.yml
@@ -36,7 +36,7 @@ on:
         required: true
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/bundles-mac.yml
+++ b/.github/workflows/bundles-mac.yml
@@ -10,11 +10,11 @@ on:
         required: true
         type: string
       java-version:
-        default: '23'
+        default: '23.0.1'
         required: false
         type: string
       javafx-version:
-        default: '23'
+        default: '23.0.1'
         required: false
         type: string
       test:

--- a/.github/workflows/bundles-mac.yml
+++ b/.github/workflows/bundles-mac.yml
@@ -9,6 +9,10 @@ on:
       project-version:
         required: true
         type: string
+      java-release:
+        default: '23'
+        required: false
+        type: string
       java-version:
         default: '23.0.1'
         required: false
@@ -44,7 +48,8 @@ jobs:
         uses: oracle-actions/setup-java@v1.4.0
         with:
           website: jdk.java.net
-          release: ${{ inputs.java-version }}
+          release: ${{ inputs.java-release }}
+          version: ${{ inputs.java-version }}
 
       - uses: Apple-Actions/import-codesign-certs@v1
         with:

--- a/.github/workflows/bundles-mac_aarch64.yml
+++ b/.github/workflows/bundles-mac_aarch64.yml
@@ -9,6 +9,10 @@ on:
       project-version:
         required: true
         type: string
+      java-release:
+        default: '23'
+        required: false
+        type: string
       java-version:
         default: '23.0.1'
         required: false
@@ -45,7 +49,8 @@ jobs:
         uses: oracle-actions/setup-java@v1.4.0
         with:
           website: jdk.java.net
-          release: ${{ inputs.java-version }}
+          release: ${{ inputs.java-release }}
+          version: ${{ inputs.java-version }}
 
       - uses: Apple-Actions/import-codesign-certs@v1
         with:

--- a/.github/workflows/bundles-mac_aarch64.yml
+++ b/.github/workflows/bundles-mac_aarch64.yml
@@ -10,11 +10,11 @@ on:
         required: true
         type: string
       java-version:
-        default: '23'
+        default: '23.0.1'
         required: false
         type: string
       javafx-version:
-        default: '23'
+        default: '23.0.1'
         required: false
         type: string
       test:

--- a/.github/workflows/bundles-windows.yml
+++ b/.github/workflows/bundles-windows.yml
@@ -9,6 +9,10 @@ on:
       project-version:
         required: true
         type: string
+      java-release:
+        default: '23'
+        required: false
+        type: string
       java-version:
         default: '23.0.1'
         required: false
@@ -39,7 +43,8 @@ jobs:
         uses: oracle-actions/setup-java@v1.4.0
         with:
           website: jdk.java.net
-          release: ${{ inputs.java-version }}
+          release: ${{ inputs.java-release }}
+          version: ${{ inputs.java-version }}
 
       - name: Setup JavaFX
         id: javafx

--- a/.github/workflows/bundles-windows.yml
+++ b/.github/workflows/bundles-windows.yml
@@ -10,11 +10,11 @@ on:
         required: true
         type: string
       java-version:
-        default: '23'
+        default: '23.0.1'
         required: false
         type: string
       javafx-version:
-        default: '23'
+        default: '23.0.1'
         required: false
         type: string
       test:

--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -5,16 +5,18 @@ on:
     branches: [ master ]
 
 env:
-  JAVAFX_VERSION: '23.0.1'
+  JAVA_RELEASE: '23'
   JAVA_VERSION: '23.0.1'
+  JAVAFX_VERSION: '23.0.1'
 
 jobs:
   precheck:
     runs-on: ubuntu-20.04
     if: startsWith(github.event.head_commit.message, 'Releasing version') != true
     outputs:
-      JAVAFX_VERSION: ${{ env.JAVAFX_VERSION }}
+      JAVA_RELEASE: ${{ env.JAVA_RELEASE }}
       JAVA_VERSION: ${{ env.JAVA_VERSION }}
+      JAVAFX_VERSION: ${{ env.JAVAFX_VERSION }}
       APP_VERSION: ${{ steps.vars.outputs.APP_VERSION }}
       PROJECT_VERSION: ${{ steps.vars.outputs.PROJECT_VERSION }}
     steps:
@@ -25,7 +27,8 @@ jobs:
         uses: oracle-actions/setup-java@v1.4.0
         with:
           website: jdk.java.net
-          release: ${{ env.JAVA_VERSION }}
+          release: ${{ env.JAVA_RELEASE }}
+          version: ${{ env.JAVA_VERSION }}
 
       - name: Cache Maven packages
         uses: actions/cache@v4
@@ -129,7 +132,8 @@ jobs:
         uses: oracle-actions/setup-java@v1.4.0
         with:
           website: jdk.java.net
-          release: ${{ needs.precheck.outputs.JAVA_VERSION }}
+          release: ${{ needs.precheck.outputs.JAVA_RELEASE }}
+          version: ${{ needs.precheck.outputs.JAVA_VERSION }}
 
       - name: Cache Maven packages
         uses: actions/cache@v4

--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -5,8 +5,8 @@ on:
     branches: [ master ]
 
 env:
-  JAVAFX_VERSION: '23'
-  JAVA_VERSION: '23'
+  JAVAFX_VERSION: '23.0.1'
+  JAVA_VERSION: '23.0.1'
 
 jobs:
   precheck:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,8 @@ on:
           - GA
 
 env:
-  JAVAFX_VERSION: '23'
-  JAVA_VERSION: '23'
+  JAVAFX_VERSION: '23.0.1'
+  JAVA_VERSION: '23.0.1'
 
 jobs:
   precheck:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,15 +11,17 @@ on:
           - GA
 
 env:
-  JAVAFX_VERSION: '23.0.1'
+  JAVA_RELEASE: '23'
   JAVA_VERSION: '23.0.1'
+  JAVAFX_VERSION: '23.0.1'
 
 jobs:
   precheck:
     runs-on: ubuntu-20.04
     outputs:
-      JAVAFX_VERSION: ${{ env.JAVAFX_VERSION }}
+      JAVA_RELEASE: ${{ env.JAVA_RELEASE }}
       JAVA_VERSION: ${{ env.JAVA_VERSION }}
+      JAVAFX_VERSION: ${{ env.JAVAFX_VERSION }}
       APP_VERSION: ${{ steps.vars.outputs.APP_VERSION }}
       PROJECT_VERSION: ${{ steps.vars.outputs.PROJECT_VERSION }}
       S3_PATH: ${{ steps.vars.outputs.S3_PATH }}
@@ -31,7 +33,8 @@ jobs:
         uses: oracle-actions/setup-java@v1.4.0
         with:
           website: jdk.java.net
-          release: ${{ env.JAVA_VERSION }}
+          release: ${{ env.JAVA_RELEASE }}
+          version: ${{ env.JAVA_VERSION }}
 
       - name: Cache Maven packages
         uses: actions/cache@v4
@@ -136,7 +139,8 @@ jobs:
         uses: oracle-actions/setup-java@v1.4.0
         with:
           website: jdk.java.net
-          release: ${{ needs.precheck.outputs.JAVA_VERSION }}
+          release: ${{ needs.precheck.outputs.JAVA_RELEASE }}
+          version: ${{ needs.precheck.outputs.JAVA_VERSION }}
 
       - name: Cache Maven packages
         uses: actions/cache@v4

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.gluonhq.scenebuilder</groupId>
         <artifactId>parent</artifactId>
-        <version>23.0.0-SNAPSHOT</version>
+        <version>23.0.1-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/kit/pom.xml
+++ b/kit/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.gluonhq.scenebuilder</groupId>
         <artifactId>parent</artifactId>
-        <version>23.0.0-SNAPSHOT</version>
+        <version>23.0.1-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.gluonhq.scenebuilder</groupId>
     <artifactId>parent</artifactId>
     <packaging>pom</packaging>
-    <version>23.0.0-SNAPSHOT</version>
+    <version>23.0.1-SNAPSHOT</version>
     <name>Scene Builder</name>
     <description>Scene Builder is a visual, drag n drop, layout tool for designing JavaFX application user interfaces</description>
     <inceptionYear>2012</inceptionYear>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <maven.compiler.release>${java.version}</maven.compiler.release>
-        <javafx.version>23</javafx.version>
+        <javafx.version>23.0.1</javafx.version>
         <aether.version>1.1.0</aether.version>
         <charm.glisten.version>6.2.2</charm.glisten.version>
         <gluon.attach.version>4.0.19</gluon.attach.version>


### PR DESCRIPTION
<!--- Provide a brief summary of the PR -->

### Issue
After quarterly release of Java and JavaFX 23.0.1, build Scene Builder 23.0.1, branching out from 23 tag, including workflow fix to build Scene Builder for macOS Intel.

 
<!--- The issue this PR addresses -->

### Progress

<!-- Please ensure you actioned and ticked each box below before requesting a review -->

- [ ] Change must not contain extraneous whitespace
- [ ] License header year is updated, if required
- [ ] The PR name must follow the [pre-defined format](https://github.com/gluonhq/scenebuilder/blob/master/CONTRIBUTING.md)
- [ ] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)