### PR TITLE
feat: Remove/Update Kit third-party dependencies

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -31,6 +31,13 @@
             <artifactId>gluon-plugin</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>jakarta.json</artifactId>
+            <version>2.0.1</version>
+            <classifier>module</classifier>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
     
     <build>

--- a/app/src/main/java/com/oracle/javafx/scenebuilder/app/DocumentWindowController.java
+++ b/app/src/main/java/com/oracle/javafx/scenebuilder/app/DocumentWindowController.java
@@ -1405,7 +1405,7 @@ public class DocumentWindowController extends AbstractFxmlWindowController {
     public void onManageJarFxml(ActionEvent event) {
         if(libraryDialogController==null){
             libraryDialogController = new LibraryDialogController(editorController, AppSettings.getUserM2Repository(),
-                    AppSettings.getTempM2Repository(), PreferencesController.getSingleton(), getStage());
+                    PreferencesController.getSingleton(), getStage());
             libraryDialogController.setOnAddJar(() -> onImportJarFxml(libraryDialogController.getStage()));
             libraryDialogController.setOnEditFXML(fxmlPath -> {
                     if (SceneBuilderApp.getSingleton().findFirstUnusedDocumentWindowController().isPresent()) {

--- a/app/src/main/java/com/oracle/javafx/scenebuilder/app/util/AppSettings.java
+++ b/app/src/main/java/com/oracle/javafx/scenebuilder/app/util/AppSettings.java
@@ -78,10 +78,10 @@ public class AppSettings {
     private static final JsonReaderFactory readerFactory = Json.createReaderFactory(null);
 
     static {
-        initSceneBuiderVersion();
+        initSceneBuilderVersion();
     }
 
-    private static void initSceneBuiderVersion() {
+    private static void initSceneBuilderVersion() {
         try (InputStream in = AboutWindowController.class.getResourceAsStream("about.properties")) {
             if (in != null) {
                 Properties sbProps = new Properties();
@@ -206,11 +206,4 @@ public class AppSettings {
         return m2Path;
     }
 
-    public static String getTempM2Repository() {
-        String m2Path = System.getProperty("java.io.tmpdir") + File.separator + "m2Tmp"; //NOI18N
-
-        assert m2Path != null;
-
-        return m2Path;
-    }
 }

--- a/app/src/main/java/com/oracle/javafx/scenebuilder/app/util/AppSettings.java
+++ b/app/src/main/java/com/oracle/javafx/scenebuilder/app/util/AppSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Gluon and/or its affiliates.
+ * Copyright (c) 2016, 2024, Gluon and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -40,10 +40,10 @@ import javafx.scene.control.Alert;
 import javafx.scene.image.Image;
 import javafx.stage.Stage;
 
-import javax.json.Json;
-import javax.json.JsonObject;
-import javax.json.JsonReader;
-import javax.json.JsonReaderFactory;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
+import jakarta.json.JsonReaderFactory;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;

--- a/app/src/main/java/module-info.java
+++ b/app/src/main/java/module-info.java
@@ -39,7 +39,7 @@ module com.gluonhq.scenebuilder.app {
     requires transitive com.gluonhq.scenebuilder.gluon.plugin;
     requires java.logging;
     requires java.prefs;
-    requires javax.json.api;
+    requires jakarta.json;
 
     opens com.oracle.javafx.scenebuilder.app to javafx.fxml;
     opens com.oracle.javafx.scenebuilder.app.about to javafx.fxml;

--- a/kit/pom.xml
+++ b/kit/pom.xml
@@ -28,36 +28,11 @@
             <version>${javafx.version}</version>
         </dependency>
 
-        <!-- Eclipse Aether -->
+        <!-- Maven Resolver -->
         <dependency>
-            <groupId>org.eclipse.aether</groupId>
-            <artifactId>aether-api</artifactId>
-            <version>${aether.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.aether</groupId>
-            <artifactId>aether-impl</artifactId>
-            <version>${aether.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.aether</groupId>
-            <artifactId>aether-connector-basic</artifactId>
-            <version>${aether.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.aether</groupId>
-            <artifactId>aether-transport-file</artifactId>
-            <version>${aether.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.aether</groupId>
-            <artifactId>aether-transport-http</artifactId>
-            <version>${aether.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-aether-provider</artifactId>
-            <version>3.3.9</version>
+            <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-supplier</artifactId>
+            <version>${maven.resolver.version}</version>
         </dependency>
 
         <dependency>

--- a/kit/pom.xml
+++ b/kit/pom.xml
@@ -60,22 +60,10 @@
             <version>3.3.9</version>
         </dependency>
 
-        <!-- Rest API -->
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.5.13</version>
-        </dependency>
-        <dependency>
-            <groupId>javax.json</groupId>
-            <artifactId>javax.json-api</artifactId>
-            <version>1.0</version>
-        </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.json</artifactId>
-            <version>1.0.4</version>
-            <scope>runtime</scope>
+            <artifactId>jakarta.json</artifactId>
+            <version>2.0.1</version>
         </dependency>
     </dependencies>
     

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/manager/LibraryDialogController.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/manager/LibraryDialogController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Gluon and/or its affiliates.
+ * Copyright (c) 2016, 2024, Gluon and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -95,19 +95,17 @@ public class LibraryDialogController extends AbstractFxmlWindowController {
     private Runnable onAddFolder;
     private Consumer<Path> onEditFXML;
 
-    private String userM2Repository;
-    private String tempM2Repository;
+    private final String userM2Repository;
 
     private final PreferencesControllerBase preferencesControllerBase;
     
-    public LibraryDialogController(EditorController editorController, String userM2Repository, String tempM2Repository,
+    public LibraryDialogController(EditorController editorController, String userM2Repository,
                                    PreferencesControllerBase preferencesController, Stage owner) {
         super(LibraryPanelController.class.getResource("LibraryDialog.fxml"), I18N.getBundle(), owner); //NOI18N
         this.owner = owner;
         this.editorController = editorController;
         this.userLibrary = (UserLibrary) editorController.getLibrary();
         this.userM2Repository = userM2Repository;
-        this.tempM2Repository = tempM2Repository;
         this.preferencesControllerBase = preferencesController;
     }
 
@@ -192,7 +190,7 @@ public class LibraryDialogController extends AbstractFxmlWindowController {
     @FXML
     private void manage() {
         RepositoryManagerController repositoryDialogController = new RepositoryManagerController(editorController,
-                userM2Repository, tempM2Repository, preferencesControllerBase, getStage());
+                userM2Repository, preferencesControllerBase, getStage());
         repositoryDialogController.openWindow();
     }
     
@@ -216,7 +214,7 @@ public class LibraryDialogController extends AbstractFxmlWindowController {
     @FXML
     private void addRelease() {
         SearchMavenDialogController mavenDialogController = new SearchMavenDialogController(editorController,
-                userM2Repository, tempM2Repository, preferencesControllerBase, getStage());
+                userM2Repository, preferencesControllerBase, getStage());
         mavenDialogController.openWindow();
         mavenDialogController.getStage().showingProperty().addListener(new InvalidationListener() {
             @Override
@@ -232,7 +230,7 @@ public class LibraryDialogController extends AbstractFxmlWindowController {
     @FXML
     private void addManually() {
         MavenDialogController mavenDialogController = new MavenDialogController(editorController, userM2Repository,
-                tempM2Repository, preferencesControllerBase, getStage());
+                preferencesControllerBase, getStage());
         mavenDialogController.openWindow();
         mavenDialogController.getStage().showingProperty().addListener(new InvalidationListener() {
             @Override

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/maven/MavenDialogController.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/maven/MavenDialogController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017 Gluon and/or its affiliates.
+ * Copyright (c) 2016, 2024, Gluon and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -111,14 +111,14 @@ public class MavenDialogController extends AbstractFxmlWindowController {
     private final PreferencesControllerBase preferencesControllerBase;
     
     public MavenDialogController(EditorController editorController, String userM2Repository,
-            String tempM2Repository, PreferencesControllerBase preferencesControllerBase, Stage owner) {
+            PreferencesControllerBase preferencesControllerBase, Stage owner) {
         super(LibraryPanelController.class.getResource("MavenDialog.fxml"), I18N.getBundle(), owner); //NOI18N
         this.userLibrary = (UserLibrary) editorController.getLibrary();
         this.owner = owner;
         this.editorController = editorController;
         this.preferencesControllerBase = preferencesControllerBase;
         
-        maven = new MavenRepositorySystem(false, userM2Repository, tempM2Repository,
+        maven = new MavenRepositorySystem(false, userM2Repository,
                 preferencesControllerBase.getRepositoryPreferences());
         
         versionsService = new Service<ObservableList<Version>>() {

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/maven/MavenRepositorySystem.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/maven/MavenRepositorySystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Gluon and/or its affiliates.
+ * Copyright (c) 2016, 2024, Gluon and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -105,14 +105,12 @@ public class MavenRepositorySystem {
     private BasicRepositoryConnectorFactory basicRepositoryConnectorFactory;
 
     private final String userM2Repository;
-    private final String tempM2Repository;
     private final RepositoryPreferences repositoryPreferences;
     
-    public MavenRepositorySystem(boolean onlyReleases, String userM2Repository, String tempM2Repository,
+    public MavenRepositorySystem(boolean onlyReleases, String userM2Repository,
                                  RepositoryPreferences repositoryPreferences) {
         this.onlyReleases = onlyReleases;
         this.userM2Repository = userM2Repository;
-        this.tempM2Repository = tempM2Repository;
         this.repositoryPreferences = repositoryPreferences;
         initRepositorySystem();
     }
@@ -251,10 +249,9 @@ public class MavenRepositorySystem {
     }
         
     public String resolveArtifacts(RemoteRepository remoteRepository, Artifact... artifact) {
-        
-        LocalRepository localTmpRepo = new LocalRepository(tempM2Repository);
-        session.setLocalRepositoryManager(system.newLocalRepositoryManager(session, localTmpRepo));
-        
+
+        session.setLocalRepositoryManager(system.newLocalRepositoryManager(session, localRepo));
+
         List<Artifact> artifacts = Stream.of(artifact)
                 .map(a -> {
                     ArtifactRequest artifactRequest = new ArtifactRequest();
@@ -272,9 +269,7 @@ public class MavenRepositorySystem {
                 })
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList()); 
-        
-        session.setLocalRepositoryManager(system.newLocalRepositoryManager(session, localRepo));
-        
+
         List<File> sha1Files = null;
         if (artifacts != null && !artifacts.isEmpty()) {
             sha1Files = artifacts.stream()
@@ -305,11 +300,7 @@ public class MavenRepositorySystem {
                     });
             }
         } catch (ArtifactResolutionException ex) { }
-        
-        try {
-            FileUtils.deleteDirectory(tempM2Repository);
-        } catch (IOException ex) { }
-        
+
         return absolutePath;
     }
         

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/maven/MavenRepositorySystem.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/maven/MavenRepositorySystem.java
@@ -34,32 +34,29 @@ package com.oracle.javafx.scenebuilder.kit.editor.panel.library.maven;
 import com.oracle.javafx.scenebuilder.kit.editor.panel.library.maven.repository.Repository;
 import com.oracle.javafx.scenebuilder.kit.editor.panel.library.maven.preset.MavenPresets;
 import java.io.File;
+import java.nio.file.Path;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.oracle.javafx.scenebuilder.kit.preferences.RepositoryPreferences;
-import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
-import org.codehaus.plexus.util.FileUtils;
 import org.eclipse.aether.AbstractRepositoryListener;
-import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositoryEvent;
 import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.collection.CollectRequest;
-import org.eclipse.aether.connector.basic.BasicRepositoryConnectorFactory;
+import org.eclipse.aether.collection.DependencySelector;
 import org.eclipse.aether.graph.Dependency;
-import org.eclipse.aether.graph.DependencyFilter;
-import org.eclipse.aether.impl.DefaultServiceLocator;
 import org.eclipse.aether.installation.InstallRequest;
 import org.eclipse.aether.installation.InstallationException;
 import org.eclipse.aether.metadata.DefaultMetadata;
@@ -73,37 +70,38 @@ import org.eclipse.aether.resolution.ArtifactResolutionException;
 import org.eclipse.aether.resolution.ArtifactResult;
 import org.eclipse.aether.resolution.DependencyRequest;
 import org.eclipse.aether.resolution.DependencyResolutionException;
+import org.eclipse.aether.resolution.DependencyResult;
 import org.eclipse.aether.resolution.VersionRangeRequest;
 import org.eclipse.aether.resolution.VersionRangeResolutionException;
 import org.eclipse.aether.resolution.VersionRangeResult;
-import org.eclipse.aether.spi.connector.RepositoryConnectorFactory;
-import org.eclipse.aether.spi.connector.transport.TransporterFactory;
+import org.eclipse.aether.supplier.RepositorySystemSupplier;
 import org.eclipse.aether.transfer.AbstractTransferListener;
 import org.eclipse.aether.transfer.TransferEvent;
-import org.eclipse.aether.transport.file.FileTransporterFactory;
-import org.eclipse.aether.transport.http.HttpTransporterFactory;
-import org.eclipse.aether.util.artifact.JavaScopes;
-import org.eclipse.aether.util.filter.DependencyFilterUtils;
+import org.eclipse.aether.util.graph.selector.AndDependencySelector;
+import org.eclipse.aether.util.graph.selector.ExclusionDependencySelector;
+import org.eclipse.aether.util.graph.selector.OptionalDependencySelector;
+import org.eclipse.aether.util.graph.selector.ScopeDependencySelector;
 import org.eclipse.aether.util.repository.AuthenticationBuilder;
 import org.eclipse.aether.version.Version;
 
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+
 public class MavenRepositorySystem {
+
+    private static final Logger LOG = Logger.getLogger(MavenRepositorySystem.class.getName());
 
     // TODO: Manage List of Repositories
     // TODO: Manage private repositories and credentials
     
     private RepositorySystem system;
-    
-    private DefaultRepositorySystemSession session;
-    
+
+    private RepositorySystemSession session;
+
     private LocalRepository localRepo;
     
     private VersionRangeResult rangeResult;
     
     private final boolean onlyReleases;
-    
-    private BasicRepositoryConnectorFactory basicRepositoryConnectorFactory;
-
     private final String userM2Repository;
     private final RepositoryPreferences repositoryPreferences;
     
@@ -116,63 +114,48 @@ public class MavenRepositorySystem {
     }
     
     private void initRepositorySystem() {
-        DefaultServiceLocator locator = MavenRepositorySystemUtils.newServiceLocator();
-        locator.addService(RepositoryConnectorFactory.class, BasicRepositoryConnectorFactory.class);
-        locator.addService(TransporterFactory.class, FileTransporterFactory.class);
-        locator.addService(TransporterFactory.class, HttpTransporterFactory.class);
-        locator.setErrorHandler(new DefaultServiceLocator.ErrorHandler() {
-            @Override
-            public void serviceCreationFailed(Class<?> type, Class<?> impl, Throwable exception) {
-                throw new RuntimeException(exception);
-            }
-        });
-        
-        basicRepositoryConnectorFactory = new BasicRepositoryConnectorFactory();
-        basicRepositoryConnectorFactory.initService(locator);
-        
-        system = locator.getService(RepositorySystem.class);
+        system = new RepositorySystemSupplier().get();
+        if (system == null) {
+            throw new RuntimeException("Error initializing repository system");
+        }
+        localRepo = new LocalRepository(Path.of(userM2Repository));
 
-        session = MavenRepositorySystemUtils.newSession();
-
-        localRepo = new LocalRepository(new File(userM2Repository));
-        session.setLocalRepositoryManager(system.newLocalRepositoryManager(session, localRepo));
-
-        // TODO: log file transfers
-        session.setTransferListener(new AbstractTransferListener() {
-            @Override
-            public void transferSucceeded(TransferEvent event) { }
-
-            @Override
-            public void transferFailed(TransferEvent event) { }
-        });
-        
-        // TODO: Log repository changes
-        session.setRepositoryListener(new AbstractRepositoryListener() {
-            @Override
-            public void artifactResolved(RepositoryEvent event) { }
-        });
-        
+        // Exclude test and provided dependencies
+        DependencySelector dependencySelector = new AndDependencySelector(
+            new ScopeDependencySelector("test", "provided"),
+            new OptionalDependencySelector(), new ExclusionDependencySelector()
+        );
+        session = system.createSessionBuilder()
+            .withTransferListener(new AbstractTransferListener() {
+                @Override
+                public void transferSucceeded(TransferEvent event) {
+                    LOG.finest("Transfer succeeded: " + event);
+                }
+                @Override
+                public void transferFailed(TransferEvent event) {
+                    LOG.finest("Transfer failed: " + event);
+                }
+            })
+            .withRepositoryListener(new AbstractRepositoryListener() {
+                @Override
+                public void artifactResolved(RepositoryEvent event) {
+                    LOG.finest("Artifact resolved: " + event);
+                }
+            })
+            .withLocalRepositories(localRepo)
+            .setDependencySelector(dependencySelector)
+            .build();
     }
 
-    public RepositorySystem getRepositorySystem() {
-        return system;
-    }
-    
-    public DefaultRepositorySystemSession getRepositorySession() {
-        return session;
-    }
-    
     public List<RemoteRepository> getRepositories() {
         final List<RemoteRepository> list = MavenPresets.getPresetRepositories().stream()
-                .filter(r -> !onlyReleases ||
-                        (onlyReleases && !r.getId().toUpperCase(Locale.ROOT).contains("SNAPSHOT")))
+                .filter(r -> !onlyReleases || !r.getId().toUpperCase(Locale.ROOT).contains("SNAPSHOT"))
                 .map(this::createRepository)
                 .collect(Collectors.toList());
         list.addAll(repositoryPreferences.getRepositories().stream()
-                .filter(r -> !onlyReleases ||
-                        (onlyReleases && !r.getId().toUpperCase(Locale.ROOT).contains("SNAPSHOT")))
+                .filter(r -> !onlyReleases || !r.getId().toUpperCase(Locale.ROOT).contains("SNAPSHOT"))
                 .map(this::createRepository)
-                .collect(Collectors.toList()));
+                .toList());
         return list;
     }
     
@@ -185,17 +168,7 @@ public class MavenRepositorySystem {
                 .filter(r -> r.getId().equals(rangeResult.getRepository(version).getId()))
                 .findFirst()
                 .orElse(new RemoteRepository
-                        .Builder(MavenPresets.LOCAL, "default", session.getLocalRepository().getBasedir().getAbsolutePath())
-                        .build());
-    }
-    
-    public RemoteRepository getRemoteRepository(String name) {
-        return getRepositories()
-                .stream()
-                .filter(r -> r.getId().equals(name))
-                .findFirst()
-                .orElse(new RemoteRepository
-                        .Builder(MavenPresets.LOCAL, "default", session.getLocalRepository().getBasedir().getAbsolutePath())
+                        .Builder(MavenPresets.LOCAL, "default", session.getLocalRepository().getBasePath().toAbsolutePath().toString())
                         .build());
     }
     
@@ -208,7 +181,9 @@ public class MavenRepositorySystem {
             cleanMetadata(artifact);
             
             return rangeResult.getVersions();
-        } catch (VersionRangeResolutionException ex) { } 
+        } catch (VersionRangeResolutionException ex) {
+            LOG.finer("VersionRangeResolutionException finding version for artifact " + artifact + ": " + ex);
+        }
         return new ArrayList<>();
     }
     
@@ -219,69 +194,72 @@ public class MavenRepositorySystem {
         try {
             rangeResult = system.resolveVersionRange(session, rangeRequest);
             cleanMetadata(artifact);
-            return rangeResult.getVersions()
-                    .stream()
-                    .filter(v -> !v.toString().toLowerCase(Locale.ROOT).contains("snapshot"))
-                    .sorted((v1, v2) -> v2.compareTo(v1))
-                    .findFirst()
-                    .orElse(null);
-        } catch (VersionRangeResolutionException ex) { } 
+            return rangeResult.getVersions().stream()
+                .filter(v -> !v.toString().toLowerCase(Locale.ROOT).contains("snapshot"))
+                .max(Comparator.naturalOrder())
+                .orElse(null);
+        } catch (VersionRangeResolutionException ex) {
+            LOG.finer("VersionRangeResolutionException finding latest version for artifact " + artifact + ": " + ex);
+        }
         return null;
     }
     
     private void cleanMetadata(Artifact artifact) {
-        final String path = localRepo.getBasedir().getAbsolutePath() + File.separator
-                        + artifact.getGroupId().replaceAll("\\.", Matcher.quoteReplacement(File.separator)) + File.separator
-                        + artifact.getArtifactId() + File.separator;
+        final Path path = localRepo.getBasePath()
+            .resolve(artifact.getGroupId().replaceAll("\\.", Matcher.quoteReplacement(File.separator)))
+            .resolve(artifact.getArtifactId());
         final DefaultMetadata metadata = new DefaultMetadata("maven-metadata.xml", Metadata.Nature.RELEASE);
         getRepositories()
             .stream()
             .map(r -> session.getLocalRepositoryManager().getPathForRemoteMetadata(metadata, r, ""))
             .forEach(s -> {
-                File file = new File(path + s);
-                if (file.exists()) {
+                Path file = path.resolve(s);
+                if (Files.exists(file)) {
                     try {
-                        Files.delete(file.toPath());
-                        Files.delete(new File(path + s + ".sha1").toPath());
-                    } catch (IOException ex) { }
+                        Files.delete(file);
+                        Files.delete(new File(file + ".sha1").toPath());
+                    } catch (IOException ex) {
+                        LOG.finer("Error deleting file " + file + ": " + ex);
+                    }
                 }
             });
     }
         
     public String resolveArtifacts(RemoteRepository remoteRepository, Artifact... artifact) {
 
-        session.setLocalRepositoryManager(system.newLocalRepositoryManager(session, localRepo));
-
         List<Artifact> artifacts = Stream.of(artifact)
                 .map(a -> {
                     ArtifactRequest artifactRequest = new ArtifactRequest();
                     artifactRequest.setArtifact(a);
-                    artifactRequest.setRepositories(remoteRepository == null ? getRepositories() : 
-                            Arrays.asList(remoteRepository));
+                    artifactRequest.setRepositories(remoteRepository == null ? getRepositories() : List.of(remoteRepository));
                     return artifactRequest;
                 })
                 .map(ar -> {
                     try {
                         ArtifactResult result = system.resolveArtifact(session, ar);
                         return result.getArtifact();
-                    } catch (ArtifactResolutionException ex) { }
+                    } catch (ArtifactResolutionException ex) {
+                        LOG.finer("ArtifactResolutionException for artifact request " + ar + ": " + ex);
+                    }
                     return null;
                 })
                 .filter(Objects::nonNull)
-                .collect(Collectors.toList()); 
+                .toList();
 
-        List<File> sha1Files = null;
-        if (artifacts != null && !artifacts.isEmpty()) {
-            sha1Files = artifacts.stream()
-                .filter(a -> a.getFile() != null)
-                .map(a -> new File(a.getFile().getAbsolutePath().concat(".sha1")))
-                .collect(Collectors.toList());
-        
+        List<Path> sha1Paths = null;
+        if (!artifacts.isEmpty()) {
+            sha1Paths = artifacts.stream()
+                .filter(a -> a.getPath() != null)
+                .map(a -> Path.of(a.getPath().toAbsolutePath() + ".sha1"))
+                .toList();
+
             InstallRequest installRequest = new InstallRequest();
             installRequest.setArtifacts(artifacts);
             try {
                 system.install(session, installRequest);
-            } catch (InstallationException ex) { }
+            } catch (InstallationException ex) {
+                LOG.finer("InstallationException for install request " + installRequest + ": " + ex);
+            }
         } 
 
         // return path from local m2
@@ -289,38 +267,37 @@ public class MavenRepositorySystem {
         artifactRequest.setArtifact(artifact[0]);
         String absolutePath = "";
         try {
-            final File jarFile = system.resolveArtifact(session, artifactRequest).getArtifact().getFile();
-            absolutePath = jarFile.getAbsolutePath();
-            if (sha1Files != null) {
-                sha1Files.stream()
-                    .forEach(f -> {
-                        try {
-                            FileUtils.copyFile(f, new File(jarFile.getParent() + File.separator + f.getName()));
-                        } catch (IOException ex) { }
-                    });
+            final Path jarFile = system.resolveArtifact(session, artifactRequest).getArtifact().getPath();
+            absolutePath = jarFile.toAbsolutePath().toString();
+            if (sha1Paths != null) {
+                sha1Paths.forEach(path -> copyFile(path, jarFile.getParent().resolve(path.getFileName())));
             }
-        } catch (ArtifactResolutionException ex) { }
+        } catch (ArtifactResolutionException ex) {
+            LOG.finer("ArtifactResolutionException for artifact request " + artifactRequest + ": " + ex);
+        }
 
         return absolutePath;
     }
         
     public String resolveDependencies(RemoteRepository remoteRepository, Artifact artifact) {
-        DependencyFilter classpathFlter = DependencyFilterUtils.classpathFilter(JavaScopes.COMPILE);
         CollectRequest collectRequest = new CollectRequest();
-        collectRequest.setRoot(new Dependency(artifact, JavaScopes.COMPILE));
-        collectRequest.setRepositories(remoteRepository == null ? getRepositories() : 
-                Arrays.asList(remoteRepository));
+        collectRequest.setRoot(new Dependency(artifact, "compile"));
+        collectRequest.setRepositories(remoteRepository == null ? getRepositories() : List.of(remoteRepository));
 
-        DependencyRequest dependencyRequest = new DependencyRequest(collectRequest, classpathFlter);
+        DependencyRequest dependencyRequest = new DependencyRequest();
+        dependencyRequest.setCollectRequest(collectRequest);
+
         try {
-            List<ArtifactResult> artifactResults = system.resolveDependencies(session, dependencyRequest)
-                    .getArtifactResults();
-            
+            DependencyResult dependencyResult = system.resolveDependencies(session, dependencyRequest);
+            List<ArtifactResult> artifactResults = dependencyResult.getArtifactResults();
+
             return artifactResults.stream()
                     .skip(1) // exclude jar itself
-                    .map(a -> a.getArtifact().getFile().getAbsolutePath())
+                    .map(a -> a.getArtifact().getPath().toAbsolutePath().toString())
                     .collect(Collectors.joining(File.pathSeparator));
-        } catch (DependencyResolutionException ex) { }
+        } catch (DependencyResolutionException ex) {
+            LOG.finer("DependencyResolutionException for artifact " + artifact + ": " + ex);
+        }
         return "";
     }
     
@@ -333,13 +310,12 @@ public class MavenRepositorySystem {
                     .addPassword(repository.getPassword())
                     .build();
         }
-        
-        final RemoteRepository repo = new RemoteRepository
+
+        return new RemoteRepository
                 .Builder(repository.getId() , repository.getType(), repository.getURL())
                 .setSnapshotPolicy(onlyReleases ? new RepositoryPolicy(false, null, null) : new RepositoryPolicy())
                 .setAuthentication(auth)
                 .build();
-        return repo;
     }
     
     public String validateRepository(Repository repository) {
@@ -347,11 +323,11 @@ public class MavenRepositorySystem {
         
         ArtifactRequest artifactRequest = new ArtifactRequest();
         artifactRequest.setArtifact(new DefaultArtifact("test:test:1.0"));
-        artifactRequest.setRepositories(Arrays.asList(remoteRepository));
+        artifactRequest.setRepositories(List.of(remoteRepository));;
         try {
             system.resolveArtifact(session, artifactRequest);
         } catch (ArtifactResolutionException ex) {
-            final String rootCauseMessage = ExceptionUtils.getRootCauseMessage(ex);
+            final String rootCauseMessage = getExceptionCause(ex).toString();
             if (rootCauseMessage != null && !rootCauseMessage.contains("ArtifactNotFoundException")) {
                 return rootCauseMessage;
             }
@@ -359,4 +335,23 @@ public class MavenRepositorySystem {
         
         return "";
     }
+
+    private static void copyFile(Path source, Path destination)  {
+        try {
+            Files.createDirectories(destination.getParent());
+            Files.copy(source, destination, REPLACE_EXISTING);
+        } catch (IOException ex) {
+            LOG.finer("Error copying file " + source + " to destination " + destination + ": " + ex);
+        }
+    }
+
+    private static Throwable getExceptionCause(Throwable e) {
+        Throwable t = e;
+        Throwable cause;
+        while (null != (cause = t.getCause()) && t != cause) {
+            t = cause;
+        }
+        return t;
+    }
+
 }

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/maven/repository/RepositoryManagerController.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/maven/repository/RepositoryManagerController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Gluon and/or its affiliates.
+ * Copyright (c) 2016, 2024, Gluon and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -65,24 +65,22 @@ public class RepositoryManagerController extends AbstractFxmlWindowController {
     private ObservableList<RepositoryListItem> listItems;
 
     private final String userM2Repository;
-    private final String tempM2Repository;
     private final PreferencesControllerBase preferencesControllerBase;
     
     public RepositoryManagerController(EditorController editorController, String userM2Repository,
-                                       String tempM2Repository, PreferencesControllerBase preferencesControllerBase,
+                                       PreferencesControllerBase preferencesControllerBase,
                                        Stage owner) {
         super(LibraryPanelController.class.getResource("RepositoryManager.fxml"), I18N.getBundle(), owner); //NOI18N
         this.owner = owner;
         this.editorController = editorController;
         this.userM2Repository = userM2Repository;
-        this.tempM2Repository = tempM2Repository;
         this.preferencesControllerBase = preferencesControllerBase;
     }
 
     @Override
     protected void controllerDidCreateStage() {
         if (this.owner == null) {
-            // Dialog will be appliation modal
+            // Dialog will be application modal
             getStage().initModality(Modality.APPLICATION_MODAL);
         } else {
             // Dialog will be window modal
@@ -137,7 +135,7 @@ public class RepositoryManagerController extends AbstractFxmlWindowController {
 
     private void repositoryDialog(Repository repository) {
         RepositoryDialogController repositoryDialogController = new RepositoryDialogController(editorController,
-                userM2Repository, tempM2Repository, preferencesControllerBase, getStage());
+                userM2Repository, preferencesControllerBase, getStage());
         repositoryDialogController.openWindow();
         repositoryDialogController.setRepository(repository);
         repositoryDialogController.getStage().showingProperty().addListener(new InvalidationListener() {

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/maven/repository/dialog/RepositoryDialogController.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/maven/repository/dialog/RepositoryDialogController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Gluon and/or its affiliates.
+ * Copyright (c) 2016, 2024, Gluon and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -110,17 +110,15 @@ public class RepositoryDialogController extends AbstractFxmlWindowController {
     private final Service<String> testService;
 
     private final String userM2Repository;
-    private final String tempM2Repository;
     private final PreferencesControllerBase preferencesControllerBase;
     
     public RepositoryDialogController(EditorController editorController, String userM2Repository,
-                                      String tempM2Repository, PreferencesControllerBase preferencesControllerBase,
+                                      PreferencesControllerBase preferencesControllerBase,
                                       Stage owner) {
         super(LibraryPanelController.class.getResource("RepositoryDialog.fxml"), I18N.getBundle(), owner); //NOI18N
         this.owner = owner;
         this.editorController = editorController;
         this.userM2Repository = userM2Repository;
-        this.tempM2Repository = tempM2Repository;
         this.preferencesControllerBase = preferencesControllerBase;
         
         testService = new Service<String>() {
@@ -221,7 +219,7 @@ public class RepositoryDialogController extends AbstractFxmlWindowController {
         passwordTextfield.disableProperty().bind(privateCheckBox.selectedProperty().not());
         progress.visibleProperty().bind(testService.runningProperty());
         resultLabel.setText("");
-        maven = new MavenRepositorySystem(false, userM2Repository, tempM2Repository,
+        maven = new MavenRepositorySystem(false, userM2Repository,
                 preferencesControllerBase.getRepositoryPreferences());
     }
     

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/maven/search/SearchMavenDialogController.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/library/maven/search/SearchMavenDialogController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017 Gluon and/or its affiliates.
+ * Copyright (c) 2016, 2024, Gluon and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -66,7 +66,6 @@ import javafx.scene.control.TextField;
 import javafx.scene.control.Tooltip;
 import javafx.stage.Modality;
 import javafx.stage.Stage;
-import javafx.stage.Window;
 import javafx.stage.WindowEvent;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
@@ -110,7 +109,7 @@ public class SearchMavenDialogController extends AbstractFxmlWindowController {
     private final PreferencesControllerBase preferencesControllerBase;
     
     public SearchMavenDialogController(EditorController editorController, String userM2Repository,
-                                       String tempM2Repository, PreferencesControllerBase preferencesControllerBase,
+                                       PreferencesControllerBase preferencesControllerBase,
                                        Stage owner) {
         super(LibraryPanelController.class.getResource("SearchMavenDialog.fxml"), I18N.getBundle(), owner); //NOI18N
         this.userLibrary = (UserLibrary) editorController.getLibrary();
@@ -118,7 +117,7 @@ public class SearchMavenDialogController extends AbstractFxmlWindowController {
         this.editorController = editorController;
         this.preferencesControllerBase = preferencesControllerBase;
         
-        maven = new MavenRepositorySystem(true, userM2Repository, tempM2Repository,
+        maven = new MavenRepositorySystem(true, userM2Repository,
                 preferencesControllerBase.getRepositoryPreferences()); // only releases
         
         searchService = new SearchService(userM2Repository);

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/fxom/FXOMLoader.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/fxom/FXOMLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Gluon and/or its affiliates.
+ * Copyright (c) 2017, 2024, Gluon and/or its affiliates.
  * Copyright (c) 2012, 2014, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
@@ -120,7 +120,7 @@ class FXOMLoader implements LoadListener {
     }
 
     private void handleKnownCauses(Exception x) throws IOException {
-        if (x.getCause().getClass() == XMLStreamException.class) {
+        if (x.getCause() instanceof XMLStreamException) {
             knownErrorsHandler.accept(x);
         } else {                    
             handleUnknownAndMissingCauses(x);

--- a/kit/src/main/java/module-info.java
+++ b/kit/src/main/java/module-info.java
@@ -39,19 +39,17 @@ module com.gluonhq.scenebuilder.kit {
     requires transitive javafx.web;
     requires java.logging;
 
-    requires static javax.json.api;
+    requires java.net.http;
+    requires static jakarta.json;
     requires transitive static java.prefs;
 
-    requires transitive static aether.api;
+    requires aether.api;
     requires static aether.connector.basic;
     requires static aether.impl;
     requires static aether.spi;
     requires static aether.transport.file;
     requires static aether.transport.http;
     requires static aether.util;
-    requires static org.apache.commons.codec;
-    requires static org.apache.httpcomponents.httpclient;
-    requires static org.apache.httpcomponents.httpcore;
     requires static commons.lang3;
     requires static maven.aether.provider;
     requires static plexus.utils;

--- a/kit/src/main/java/module-info.java
+++ b/kit/src/main/java/module-info.java
@@ -43,16 +43,11 @@ module com.gluonhq.scenebuilder.kit {
     requires static jakarta.json;
     requires transitive static java.prefs;
 
-    requires aether.api;
-    requires static aether.connector.basic;
-    requires static aether.impl;
-    requires static aether.spi;
-    requires static aether.transport.file;
-    requires static aether.transport.http;
-    requires static aether.util;
-    requires static commons.lang3;
-    requires static maven.aether.provider;
-    requires static plexus.utils;
+    requires org.apache.maven.resolver;
+    requires org.apache.maven.resolver.spi;
+    requires org.apache.maven.resolver.impl;
+    requires org.apache.maven.resolver.supplier;
+    requires org.apache.maven.resolver.util;
 
     opens com.oracle.javafx.scenebuilder.kit to javafx.fxml;
     opens com.oracle.javafx.scenebuilder.kit.alert;

--- a/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/fxom/FXOMLoaderTest.java
+++ b/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/fxom/FXOMLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Gluon and/or its affiliates.
+ * Copyright (c) 2022, 2024, Gluon and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -38,6 +38,7 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
+import javax.xml.stream.XMLStreamException;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -58,7 +59,7 @@ public class FXOMLoaderTest {
         String validFxmlText = FXOMDocument.readContentFromURL(validResource);
         FXOMDocument document = new FXOMDocument(validFxmlText, validResource, null, null);
 
-        // When there are exceptions, than the error handler should store these here
+        // When there are exceptions, then the error handler should store these here
         Map<Class<?>, Throwable> handledErrors = new HashMap<>();
         
         // In Scene Builder, the error is displayed in an error dialog.
@@ -73,7 +74,7 @@ public class FXOMLoaderTest {
         FXOMLoader classUnderTest = new FXOMLoader(document, errorHandler);
         assertDoesNotThrow(()->classUnderTest.load(invalidXmlText));
 
-        assertTrue(handledErrors.containsKey(javax.xml.stream.XMLStreamException.class));
+        assertTrue(handledErrors.values().stream().anyMatch(v -> v instanceof XMLStreamException));
         assertTrue(handledErrors.containsKey(javafx.fxml.LoadException.class));
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
         <project.github.repository>gluonhq/scenebuilder</project.github.repository>
         <repository.url>github.com:${project.github.repository}</repository.url>
         <jreleaser.files.active>RELEASE</jreleaser.files.active>
+        <main.class.name/>
     </properties>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <maven.compiler.release>${java.version}</maven.compiler.release>
         <javafx.version>23.0.1</javafx.version>
-        <aether.version>1.1.0</aether.version>
+        <maven.resolver.version>2.0.0-alpha-8</maven.resolver.version>
         <charm.glisten.version>6.2.3</charm.glisten.version>
         <gluon.attach.version>4.0.21</gluon.attach.version>
         <junit.jupiter.version>5.10.0</junit.jupiter.version>


### PR DESCRIPTION
<!--- Provide a brief summary of the PR -->

### Issue

<!--- The issue this PR addresses -->
Fixes #757

Before this PR, when running the application, Maven warns about:
```
[WARNING] *****************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************
[WARNING] * Required filename-based automodules detected: [aether-api-1.1.0.jar, aether-impl-1.1.0.jar, aether-spi-1.1.0.jar, aether-util-1.1.0.jar, aether-connector-basic-1.1.0.jar, aether-transport-file-1.1.0.jar, aether-transport-http-1.1.0.jar, maven-aether-provider-3.3.9.jar, plexus-utils-3.0.22.jar, commons-lang3-3.4.jar, javax.json-api-1.0.jar]. Please don't publish this project to a public artifact repository! *
[WARNING] *****************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************
```

After this PR, the warning is fully gone.

The very old dependencies `aether-api-1.1.0.jar, aether-impl-1.1.0.jar, aether-spi-1.1.0.jar, aether-util-1.1.0.jar, aether-connector-basic-1.1.0.jar, aether-transport-file-1.1.0.jar, aether-transport-http-1.1.0.jar, maven-aether-provider-3.3.9.jar, plexus-utils-3.0.22.jar, commons-lang3-3.4.jar` are replaced with a very recent `org.apache.maven.resolver:2.0.0-alpha-8` (and many transitive dependencies),   `javax.json-api-1.0.jar` is replaced with `jakarta.json`, and the apache httpComponents are replaced with the built-in `HttpClient` from the JDK.

There are a number of changes, so I've split them in 4 different consecutive commits, for a better understanding.

### Progress

<!-- Please ensure you actioned and ticked each box below before requesting a review -->

- [ ] Change must not contain extraneous whitespace
- [ ] License header year is updated, if required
- [ ] The PR name must follow the [pre-defined format](https://github.com/gluonhq/scenebuilder/blob/master/CONTRIBUTING.md)
- [ ] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)