### PR TITLE
fix: Remove platform theme url from stylesheets, 

### DIFF
--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/EditorPlatform.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/EditorPlatform.java
@@ -159,6 +159,11 @@ public class EditorPlatform {
         // no-op
     }
 
+    public static boolean isPlatformThemeStylesheetURL(String stylesheetURL) {
+        // Return USER_AGENT css, which is Modena for fx 8.0
+        return stylesheetURL != null && stylesheetURL.equals(Theme.MODENA.getStylesheetURLs().getFirst());
+    }
+
     public static String getPlatformThemeStylesheetURL() {
         // Return USER_AGENT css, which is Modena for fx 8.0
         return Theme.MODENA.getStylesheetURLs().getFirst();

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/content/ContentPanelController.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/content/ContentPanelController.java
@@ -1075,7 +1075,7 @@ public class ContentPanelController extends AbstractFxmlPanelController
             final EditorPlatform.Theme theme = getEditorController().getTheme();
             List<String> themeStylesheets = new ArrayList<>(EditorPlatform.getStylesheetsForTheme(theme));
             themeStylesheets.addAll(theme.getStylesheetURLs());
-            workspaceController.setThemeStyleSheet(themeStylesheets, theme);
+            workspaceController.setThemeStylesheet(themeStylesheets, theme);
         }
     }
     

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/content/WorkspaceController.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/content/WorkspaceController.java
@@ -167,8 +167,10 @@ class WorkspaceController {
         assert themeStyleSheets != null;
         assert theme != null;
         List<String> stylesheets = new ArrayList<>(EditorPlatform.getStylesheetsForTheme(theme));
-        stylesheets.addAll(themeStyleSheets);
-        contentSubScene.setUserAgentStylesheet(stylesheets.getFirst());
+        themeStyleSheets.stream()
+            .filter(s -> !EditorPlatform.isPlatformThemeStylesheetURL(s))
+            .forEach(stylesheets::add);
+        contentSubScene.setUserAgentStylesheet(stylesheets.stream().findFirst().orElse(null));
 
         ObservableList<String> currentStyleSheets = FXCollections.observableArrayList(stylesheets);
         themeStylesheets.clear();

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/content/WorkspaceController.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/content/WorkspaceController.java
@@ -163,18 +163,18 @@ class WorkspaceController {
         return Collections.unmodifiableList(themeStylesheets);
     }
     
-    public void setThemeStyleSheet(List<String> themeStyleSheets, EditorPlatform.Theme theme) {
-        assert themeStyleSheets != null;
+    public void setThemeStylesheet(List<String> themeStylesheets, EditorPlatform.Theme theme) {
+        assert themeStylesheets != null;
         assert theme != null;
         List<String> stylesheets = new ArrayList<>(EditorPlatform.getStylesheetsForTheme(theme));
-        themeStyleSheets.stream()
+        themeStylesheets.stream()
             .filter(s -> !EditorPlatform.isPlatformThemeStylesheetURL(s))
             .forEach(stylesheets::add);
         contentSubScene.setUserAgentStylesheet(stylesheets.stream().findFirst().orElse(null));
 
-        ObservableList<String> currentStyleSheets = FXCollections.observableArrayList(stylesheets);
-        themeStylesheets.clear();
-        themeStylesheets.addAll(currentStyleSheets);
+        ObservableList<String> currentStylesheets = FXCollections.observableArrayList(stylesheets);
+        this.themeStylesheets.clear();
+        this.themeStylesheets.addAll(currentStylesheets);
         contentGroupApplyCss();
 
         // Update scenegraph layout, etc

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/preview/PreviewWindowController.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/preview/PreviewWindowController.java
@@ -271,7 +271,9 @@ public final class PreviewWindowController extends AbstractWindowController {
 
                     Object sceneGraphRoot = clone.getDisplayNodeOrSceneGraphRoot();
                     themeStyleSheetsList = new ArrayList<>(EditorPlatform.getStylesheetsForTheme(editorController.getTheme()));
-                    themeStyleSheetsList.addAll(editorControllerTheme.getStylesheetURLs());
+                    editorControllerTheme.getStylesheetURLs().stream()
+                        .filter(s -> !EditorPlatform.isPlatformThemeStylesheetURL(s))
+                            .forEach(themeStyleSheetsList::add);
 
                     if (sceneGraphRoot instanceof Parent) {
                         ((Parent) sceneGraphRoot).setId(NID_PREVIEW_ROOT);

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/util/CssInternal.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/util/CssInternal.java
@@ -46,6 +46,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 
+import com.oracle.javafx.scenebuilder.kit.editor.EditorPlatform;
 import javafx.beans.property.ReadOnlyProperty;
 import javafx.collections.FXCollections;
 import javafx.css.CssMetaData;
@@ -151,10 +152,12 @@ public class CssInternal {
 
     public static List<String> getThemeStyleClasses(Theme theme) {
         Set<String> themeClasses = new HashSet<>();
-        theme.getStylesheetURLs().forEach(themeStyleSheet -> {
-            URL resource = Button.class.getResource("/" + themeStyleSheet);
-            themeClasses.addAll(getStyleClasses(resource));
-        });
+        theme.getStylesheetURLs().stream()
+            .filter(s -> !EditorPlatform.isPlatformThemeStylesheetURL(s))
+            .forEach(themeStyleSheet -> {
+                URL resource = Button.class.getResource("/" + themeStyleSheet);
+                themeClasses.addAll(getStyleClasses(resource));
+            });
         return new ArrayList<>(themeClasses);
     }
 


### PR DESCRIPTION
to prevent user agent from being overwritten

<!--- Provide a brief summary of the PR -->

This PR removes the platform stylesheet from the theme in content/preview, which is modena.css, since it is already added to Scene Builder, preventing the user agent stylesheets from external controls in the custom library to be overwritten.

This was only working before #745 and #720 by an underlying bug (modena.bss was used to create an invalid URL and the real modena.css URL was never added to the theme stylesheets. 

### Issue

<!--- The issue this PR addresses -->
Fixes #760

### Progress

<!-- Please ensure you actioned and ticked each box below before requesting a review -->

- [ ] Change must not contain extraneous whitespace
- [ ] License header year is updated, if required
- [ ] The PR name must follow the [pre-defined format](https://github.com/gluonhq/scenebuilder/blob/master/CONTRIBUTING.md)
- [ ] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)