### PR TITLE
fix: Fix NPE in accordion

### DIFF
--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/inspector/InspectorPanelController.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/inspector/InspectorPanelController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018 Gluon and/or its affiliates.
+ * Copyright (c) 2016, 2024, Gluon and/or its affiliates.
  * Copyright (c) 2012, 2014, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
@@ -377,25 +377,16 @@ public class InspectorPanelController extends AbstractFxmlPanelController {
         if (!isInspectorLoaded()) {
             return;
         }
-        final TitledPane tp;
-
-        switch (getExpandedSection()) {
-            case NONE:
-                tp = null;
-                break;
-            case PROPERTIES:
-                tp = propertiesTitledPane;
-                break;
-            case LAYOUT:
-                tp = layoutTitledPane;
-                break;
-            case CODE:
-                tp = codeTitledPane;
-                break;
-            default:
-                throw new IllegalStateException("Unexpected section id " + getExpandedSection()); //NOI18N
-            }
-
+        SectionId expandedSection = getExpandedSection();
+        if (expandedSection == null) {
+            return;
+        }
+        final TitledPane tp = switch (expandedSection) {
+            case NONE -> null;
+            case PROPERTIES -> propertiesTitledPane;
+            case LAYOUT -> layoutTitledPane;
+            case CODE -> codeTitledPane;
+        };
         accordion.setExpandedPane(tp);
     }
 


### PR DESCRIPTION
<!--- Provide a brief summary of the PR -->

### Issue

<!--- The issue this PR addresses -->
Fixes #771

Using the inspector menu button to select view modes, the accordion panes are removed and added, based on selection. There is an instant where the `accordion.getExpandedPane()` value is null, and that should be filtered out from the switch expression in `InspectorPanelController::expandedSectionChanged`

### Progress

<!-- Please ensure you actioned and ticked each box below before requesting a review -->

- [ ] Change must not contain extraneous whitespace
- [ ] License header year is updated, if required
- [ ] The PR name must follow the [pre-defined format](https://github.com/gluonhq/scenebuilder/blob/master/CONTRIBUTING.md)
- [ ] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)