### PR TITLE
fix: add missing css rule to hierarchy panel

### DIFF
--- a/kit/src/main/resources/com/oracle/javafx/scenebuilder/kit/css/ThemeDark.css
+++ b/kit/src/main/resources/com/oracle/javafx/scenebuilder/kit/css/ThemeDark.css
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024, Gluon and/or its affiliates.
  * Copyright (c) 2014, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
@@ -184,6 +185,7 @@
 .theme-presets .property-sheet > .viewport, 
 .theme-presets .SBKIT-library-panel, 
 .theme-presets .SBKIT-library-panel .accordion > .titled-pane > .content,
+.theme-presets .SBKIT-hierarchy-panel,
 .theme-presets .SBKIT-hierarchy-panel .tree-view {
     -fx-border-color: null;
     -fx-border-width: 0;

--- a/kit/src/main/resources/com/oracle/javafx/scenebuilder/kit/css/ThemeDefault.css
+++ b/kit/src/main/resources/com/oracle/javafx/scenebuilder/kit/css/ThemeDefault.css
@@ -164,7 +164,8 @@
 .theme-presets .property-sheet > .viewport, 
 .theme-presets .SBKIT-library-panel, 
 .theme-presets .SBKIT-library-panel .accordion > .titled-pane > .content,
-.theme-presets .SBKIT-hierarchy-panel .tree-view {
+.theme-presets .SBKIT-hierarchy-panel,
+.theme-presets .SBKIT-hierarchy-panel > .tree-view {
     -fx-border-color: null;
     -fx-border-width: 0;
     -fx-background-color: -sb-content-background;

--- a/kit/src/main/resources/com/oracle/javafx/scenebuilder/kit/css/ThemeDefault.css
+++ b/kit/src/main/resources/com/oracle/javafx/scenebuilder/kit/css/ThemeDefault.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Gluon and/or its affiliates.
+ * Copyright (c) 2017, 2024, Gluon and/or its affiliates.
  * Copyright (c) 2014, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *


### PR DESCRIPTION
<!--- Provide a brief summary of the PR -->

### Issue

<!--- The issue this PR addresses -->
Fixes #773 

The hierarchy panel (a `StackPane`) needs to set the padding to 0 as well, otherwise, when using Scene Builder Kit from an external application, modena default padding:
```
.titled-pane > .content > StackPane,
...
.titled-pane > .content > VBox {
    -fx-padding: 0.8em;
}
```
is set for the pane.
<img width="718" alt="image" src="https://github.com/user-attachments/assets/cc47ee01-2d5a-4264-a8c5-61f0fe6ca966">

### Progress

<!-- Please ensure you actioned and ticked each box below before requesting a review -->

- [ ] Change must not contain extraneous whitespace
- [ ] License header year is updated, if required
- [ ] The PR name must follow the [pre-defined format](https://github.com/gluonhq/scenebuilder/blob/master/CONTRIBUTING.md)
- [ ] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)