### PR TITLE
fix: Prevent css parsing if any style textfield is empty

### DIFF
--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/inspector/editors/StyleEditor.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/inspector/editors/StyleEditor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017 Gluon and/or its affiliates.
+ * Copyright (c) 2016, 2024, Gluon and/or its affiliates.
  * Copyright (c) 2012, 2014, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
@@ -337,7 +337,7 @@ public class StyleEditor extends InlineListEditor {
         @Override
         public Object getValue() {
             String value;
-            if (propertyTf.getText().isEmpty() && valueTf.getText().isEmpty()) {
+            if (propertyTf.getText().isEmpty() || valueTf.getText().isEmpty()) {
                 return ""; //NOI18N
             } else {
                 String propertyVal = EditorUtils.getPlainString(propertyTf.getText()).trim();


### PR DESCRIPTION
<!--- Provide a brief summary of the PR -->

### Issue

<!--- The issue this PR addresses -->
Fixes #774

The css expression `propertyVal + ": " + valueVal + ";"` only makes sense if _both_ property and value are not empty. This fix prevents an unnecessary parsing call that derives in uncaught CSS warnings.
 
### Progress

<!-- Please ensure you actioned and ticked each box below before requesting a review -->

- [ ] Change must not contain extraneous whitespace
- [ ] License header year is updated, if required
- [ ] The PR name must follow the [pre-defined format](https://github.com/gluonhq/scenebuilder/blob/master/CONTRIBUTING.md)
- [ ] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)