### PR TITLE
fix: Force refresh of theme and stylesheets when swatch color changes

### DIFF
--- a/app/src/main/java/com/oracle/javafx/scenebuilder/app/menubar/MenuBarController.java
+++ b/app/src/main/java/com/oracle/javafx/scenebuilder/app/menubar/MenuBarController.java
@@ -2343,6 +2343,8 @@ public class MenuBarController {
         @Override
         public void perform() {
             GluonEditorController.getInstance().setGluonSwatch(gluonSwatch);
+            // After swatch changes, force theme update to refresh the content
+            documentWindowController.getEditorController().refreshTheme();
         }
 
         @Override

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/EditorController.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/EditorController.java
@@ -581,6 +581,16 @@ public class EditorController {
     }
 
     /**
+     * Refresh the theme and related stylesheets in different
+     * places (content, preview, ...)
+     */
+    public void refreshTheme() {
+        EditorPlatform.Theme currentTheme = getTheme();
+        setTheme(null);
+        setTheme(currentTheme);
+    }
+
+    /**
      * 
      * @return the list of scene style sheet used by this editor
      */

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/content/ContentPanelController.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/content/ContentPanelController.java
@@ -1074,7 +1074,9 @@ public class ContentPanelController extends AbstractFxmlPanelController
         if (contentGroup != null) {
             final EditorPlatform.Theme theme = getEditorController().getTheme();
             List<String> themeStylesheets = new ArrayList<>(EditorPlatform.getStylesheetsForTheme(theme));
-            themeStylesheets.addAll(theme.getStylesheetURLs());
+            if (theme != null) {
+                themeStylesheets.addAll(theme.getStylesheetURLs());
+            }
             workspaceController.setThemeStylesheet(themeStylesheets, theme);
         }
     }


### PR DESCRIPTION
<!--- Provide a brief summary of the PR -->

### Issue

<!--- The issue this PR addresses -->
Fixes #764

When the swatch color property changes, the list of external stylesheets applied to the current theme changes too, so the editorController needs to make another call to retrieve those, if any (for instance, when the Gluon plugin is present), and refresh content/preview/... accordingly

### Progress

<!-- Please ensure you actioned and ticked each box below before requesting a review -->

- [ ] Change must not contain extraneous whitespace
- [ ] License header year is updated, if required
- [ ] The PR name must follow the [pre-defined format](https://github.com/gluonhq/scenebuilder/blob/master/CONTRIBUTING.md)
- [ ] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)