### PR TITLE
add consoleHandler

### DIFF
--- a/app/src/main/resources/logging.properties
+++ b/app/src/main/resources/logging.properties
@@ -1,4 +1,8 @@
-handlers= java.util.logging.FileHandler
+handlers = java.util.logging.ConsoleHandler, java.util.logging.FileHandler
+
+# Console Logging
+java.util.logging.ConsoleHandler.level = ALL
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
 
 # File Logging
 java.util.logging.FileHandler.pattern = %h/.scenebuilder/logs/scenebuilder-${version}.log


### PR DESCRIPTION
<!--- Provide a brief summary of the PR -->

### Issue

<!--- The issue this PR addresses -->
Fixes #782

Even for releases, I'd say we keep the console handler, as running from the installer won't show a terminal window. But if users/developers need it, they still can run the executable from a terminal.

### Progress

<!-- Please ensure you actioned and ticked each box below before requesting a review -->

- [ ] Change must not contain extraneous whitespace
- [ ] License header year is updated, if required
- [ ] The PR name must follow the [pre-defined format](https://github.com/gluonhq/scenebuilder/blob/master/CONTRIBUTING.md)
- [ ] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)