### PR TITLE
build: Allow importing FXML files with javascript

### DIFF
--- a/.github/scripts/jpackage.bat
+++ b/.github/scripts/jpackage.bat
@@ -23,6 +23,7 @@ REM set MODULES=java.desktop,java.logging,java.naming,java.prefs,java.security.j
 --runtime-image app/target/runtime ^
 --dest %INSTALL_DIR% ^
 --type msi ^
+--java-options "-Djavafx.allowjs=true" ^
 --java-options "--add-opens=javafx.fxml/javafx.fxml=ALL-UNNAMED" ^
 --java-options "-Djava.library.path=runtime\bin;runtime\lib" ^
 --icon app/assets/windows/icon-windows.ico ^

--- a/.github/workflows/bundles-linux.yml
+++ b/.github/workflows/bundles-linux.yml
@@ -77,6 +77,7 @@ jobs:
           .github/scripts/jpackage.sh \
             --icon app/assets/linux/icon-linux.png \
             --java-options '"-Djdk.gtk.version=2"' \
+            --java-options '"-Djavafx.allowjs=true"' \
             --java-options '"--add-opens=javafx.fxml/javafx.fxml=ALL-UNNAMED"' \
             --java-options '"-Djava.library.path=/opt/scenebuilder/lib/runtime/bin:/opt/scenebuilder/lib/runtime/lib"' \
             --linux-menu-group '"Development;Building;GUIDesigner;Java;"' \

--- a/.github/workflows/bundles-mac.yml
+++ b/.github/workflows/bundles-mac.yml
@@ -88,6 +88,7 @@ jobs:
         run: |
           .github/scripts/jpackage.sh \
             --icon app/assets/osx/icon-mac.icns \
+            --java-options '"-Djavafx.allowjs=true"' \
             --java-options '"--add-opens=javafx.fxml/javafx.fxml=ALL-UNNAMED"' \
             --type dmg \
             --mac-package-identifier com.gluonhq.scenebuilder \

--- a/.github/workflows/bundles-mac_aarch64.yml
+++ b/.github/workflows/bundles-mac_aarch64.yml
@@ -89,6 +89,7 @@ jobs:
         run: |
           .github/scripts/jpackage.sh \
             --icon app/assets/osx/icon-mac.icns \
+            --java-options '"-Djavafx.allowjs=true"' \
             --java-options '"--add-opens=javafx.fxml/javafx.fxml=ALL-UNNAMED"' \
             --type dmg \
             --mac-package-identifier com.gluonhq.scenebuilder \

--- a/kit/src/test/resources/com/oracle/javafx/scenebuilder/kit/fxom/HeaderWithNotOnlyImports.fxml
+++ b/kit/src/test/resources/com/oracle/javafx/scenebuilder/kit/fxom/HeaderWithNotOnlyImports.fxml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?language nameOfScriptLanguage?>
+<?language javascript?>
 
 <!-- This could be a license header -->
 

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,7 @@
                     <configuration>
                         <mainClass>${main.class.name}</mainClass>
                         <options>
+                            <option>-Djavafx.allowjs=true</option>
                             <option>--add-opens=javafx.fxml/javafx.fxml=com.gluonhq.scenebuilder.app</option>
                             <option>--add-opens=javafx.fxml/javafx.fxml=com.gluonhq.scenebuilder.kit</option>
                             <option>--add-opens=javafx.controls/com.sun.javafx.scene.control.skin.caspian=com.gluonhq.scenebuilder.kit</option>
@@ -139,7 +140,7 @@
                     <configuration>
                         <reuseForks>false</reuseForks>
                         <forkCount>1</forkCount>
-                        <argLine>--add-opens=javafx.fxml/javafx.fxml=com.gluonhq.scenebuilder.kit</argLine>
+                        <argLine>--add-opens=javafx.fxml/javafx.fxml=com.gluonhq.scenebuilder.kit -Djavafx.allowjs=true</argLine>
                     </configuration>
                 </plugin>
             </plugins>


### PR DESCRIPTION
<!--- Provide a brief summary of the PR -->

### Issue

<!--- The issue this PR addresses -->
Fixes #794, by adding flag that enables reading the FXML file with javascript language. Also reverts a small change done in #619, as now the test as it was before passes.

Important note: Scene Builder (workspace/preview) does not evaluate the onAction eventHandlers, so there is no need for a Nashorn engine, and there is no risk of opening any FXML file with any kind of malicious script.

### Progress

<!-- Please ensure you actioned and ticked each box below before requesting a review -->

- [x] Change must not contain extraneous whitespace
- [x] License header year is updated, if required
- [x] The PR name must follow the [pre-defined format](https://github.com/gluonhq/scenebuilder/blob/master/CONTRIBUTING.md)
- [x] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)