### PR TITLE
build: use latest release to avoid workflow failure

### DIFF
--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   JAVA_RELEASE: '23'
-  JAVA_VERSION: '23.0.1'
+  JAVA_VERSION: 'latest'
   JAVAFX_VERSION: '23.0.1'
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ on:
 
 env:
   JAVA_RELEASE: '23'
-  JAVA_VERSION: '23.0.1'
+  JAVA_VERSION: 'latest'
   JAVAFX_VERSION: '23.0.1'
 
 jobs:


### PR DESCRIPTION
<!--- Provide a brief summary of the PR -->
A test run is available [here](https://github.com/abhinayagarwal/scenebuilder/actions/runs/13366022942) which builds with 23.0.2 (latest) released GA version.

### Issue

<!--- The issue this PR addresses -->
Fixes #801 

### Progress

<!-- Please ensure you actioned and ticked each box below before requesting a review -->

- [x] Change must not contain extraneous whitespace
- [x] License header year is updated, if required
- [x] The PR name must follow the [pre-defined format](https://github.com/gluonhq/scenebuilder/blob/master/CONTRIBUTING.md)
- [x] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)