### PR TITLE
add service providers

### DIFF
--- a/app/src/main/resources/META-INF/services/com.oracle.javafx.scenebuilder.kit.editor.ExternalThemeProvider
+++ b/app/src/main/resources/META-INF/services/com.oracle.javafx.scenebuilder.kit.editor.ExternalThemeProvider
@@ -1,0 +1,1 @@
+com.gluonhq.scenebuilder.plugins.GluonExternalThemeProvider

--- a/app/src/main/resources/META-INF/services/com.oracle.javafx.scenebuilder.kit.library.ExternalSectionProvider
+++ b/app/src/main/resources/META-INF/services/com.oracle.javafx.scenebuilder.kit.library.ExternalSectionProvider
@@ -1,0 +1,1 @@
+com.gluonhq.scenebuilder.plugins.GluonSectionProvider

--- a/app/src/main/resources/META-INF/services/com.oracle.javafx.scenebuilder.kit.metadata.ExternalMetadataProvider
+++ b/app/src/main/resources/META-INF/services/com.oracle.javafx.scenebuilder.kit.metadata.ExternalMetadataProvider
@@ -1,0 +1,1 @@
+com.gluonhq.scenebuilder.plugins.GluonMetadataProvider

--- a/app/src/main/resources/META-INF/services/com.oracle.javafx.scenebuilder.kit.metadata.util.ExternalDesignHierarchyMaskProvider
+++ b/app/src/main/resources/META-INF/services/com.oracle.javafx.scenebuilder.kit.metadata.util.ExternalDesignHierarchyMaskProvider
@@ -1,0 +1,1 @@
+com.gluonhq.scenebuilder.plugins.GluonDesignHierarchyMaskProvider


### PR DESCRIPTION
<!--- Provide a brief summary of the PR -->

<!--- The issue this PR addresses -->
Fixes #812 by adding the service providers as old service files in `META-INF/services`, given that the package app is non-modular.

Trying to package the app as modular is not easy, given that many dependencies (like maven resolver supplier) are not fully modular yet.

### Progress

<!-- Please ensure you actioned and ticked each box below before requesting a review -->

- [ ] Change must not contain extraneous whitespace
- [ ] License header year is updated, if required
- [ ] The PR name must follow the [pre-defined format](https://github.com/gluonhq/scenebuilder/blob/master/CONTRIBUTING.md)
- [ ] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)