### PR TITLE
build: Bump JavaFX version to 24.0.1

### DIFF
--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -8,7 +8,7 @@ on:
 env:
   JAVA_RELEASE: '24'
   JAVA_VERSION: 'latest'
-  JAVAFX_VERSION: '24'
+  JAVAFX_VERSION: '24.0.1'
 
 jobs:
   precheck:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ on:
 env:
   JAVA_RELEASE: '24'
   JAVA_VERSION: 'latest'
-  JAVAFX_VERSION: '24'
+  JAVAFX_VERSION: '24.0.1'
 
 jobs:
   precheck:

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.gluonhq.scenebuilder</groupId>
         <artifactId>parent</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>24.0.1-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/gluon-plugin/pom.xml
+++ b/gluon-plugin/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>com.gluonhq.scenebuilder</groupId>
         <artifactId>parent</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>24.0.1-SNAPSHOT</version>
     </parent>
 
     <properties>
         <charm.glisten.version>6.2.3</charm.glisten.version>
-        <gluon.attach.version>4.0.21</gluon.attach.version>
+        <gluon.attach.version>4.0.22</gluon.attach.version>
     </properties>
 
     <repositories>

--- a/kit/pom.xml
+++ b/kit/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.gluonhq.scenebuilder</groupId>
         <artifactId>parent</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>24.0.1-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.gluonhq.scenebuilder</groupId>
     <artifactId>parent</artifactId>
     <packaging>pom</packaging>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>24.0.1-SNAPSHOT</version>
     <name>Scene Builder</name>
     <description>Scene Builder is a visual, drag n drop, layout tool for designing JavaFX application user interfaces</description>
     <inceptionYear>2012</inceptionYear>
@@ -21,7 +21,7 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <maven.compiler.release>${java.version}</maven.compiler.release>
-        <javafx.version>24</javafx.version>
+        <javafx.version>24.0.1</javafx.version>
         <maven.resolver.version>2.0.0-alpha-8</maven.resolver.version>
         <charm.glisten.version>6.2.3</charm.glisten.version>
         <gluon.attach.version>4.0.22</gluon.attach.version>


### PR DESCRIPTION
<!--- Provide a brief summary of the PR -->


Bump JavaFX version to 24.0.1, and bump current snapshot version to 24.0.1-SNAPSHOT, before Scene Builder 24.0.1 can be released.

### Issue

<!--- The issue this PR addresses -->
Fixes #

### Progress

<!-- Please ensure you actioned and ticked each box below before requesting a review -->

- [ ] Change must not contain extraneous whitespace
- [ ] License header year is updated, if required
- [ ] The PR name must follow the [pre-defined format](https://github.com/gluonhq/scenebuilder/blob/master/CONTRIBUTING.md)
- [ ] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)