### PR TITLE
perf: Improve startup workflow and code

### DIFF
--- a/app/src/main/java/com/oracle/javafx/scenebuilder/app/SceneBuilderApp.java
+++ b/app/src/main/java/com/oracle/javafx/scenebuilder/app/SceneBuilderApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2024, Gluon and/or its affiliates.
+ * Copyright (c) 2016, 2026, Gluon and/or its affiliates.
  * Copyright (c) 2012, 2014, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
@@ -64,9 +64,8 @@ import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.beans.InvalidationListener;
 import javafx.beans.Observable;
-import javafx.beans.binding.Bindings;
-import javafx.beans.binding.BooleanBinding;
-import javafx.beans.value.ChangeListener;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.SimpleBooleanProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
@@ -89,7 +88,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
-import java.util.concurrent.CountDownLatch;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.logging.Level;
@@ -124,8 +122,7 @@ public class SceneBuilderApp extends Application implements AppPlatform.AppNotif
     private UserLibrary userLibrary;
     private ToolTheme toolTheme = ToolTheme.DEFAULT;
 
-    private final ObservableList<Runnable> startupTasks = FXCollections.observableArrayList();
-    private final BooleanBinding startupTasksFinished = Bindings.isEmpty(startupTasks);
+    private final BooleanProperty startupFinished = new SimpleBooleanProperty(false);
 
     static {
         try {
@@ -163,8 +160,12 @@ public class SceneBuilderApp extends Application implements AppPlatform.AppNotif
         });
     }
 
-    public BooleanBinding startupTasksFinishedBinding() {
-        return startupTasksFinished;
+    public final BooleanProperty startupFinishedProperty() {
+        return startupFinished;
+    }
+
+    public final boolean isStartupFinished() {
+        return startupFinished.get();
     }
 
     public void performControlAction(ApplicationControlAction a, DocumentWindowController source) {
@@ -369,64 +370,53 @@ public class SceneBuilderApp extends Application implements AppPlatform.AppNotif
      */
     @Override
     public void handleLaunch(List<String> files) {
-        var latch = new CountDownLatch(1);
-
-        startupTasksFinished.addListener((observableValue, aBoolean, isFinished) -> {
-            if (isFinished) {
-                latch.countDown();
-            }
-        });
-
-        boolean showWelcomeDialog = files.isEmpty();
+        boolean noFilesToLaunch = files.isEmpty();
 
         setApplicationUncaughtExceptionHandler();
 
-        startInBackground("Set up Scene Builder", () -> {
-            backgroundStart();
-            setUpUserLibrary(showWelcomeDialog);
-            createEmptyDocumentWindow();
-        });
-
-        if (showWelcomeDialog) {
-            // Unless we're on a Mac we're starting SB directly (fresh start)
-            // so we're not opening any file and as such we should show the Welcome Dialog
+        // No files should be opened initially, so show the welcome dialog instead.
+        if (noFilesToLaunch) {
             WelcomeDialogWindowController.getInstance().getStage().show();
-        } else {
-            // Open files passed as arguments by the platform
-
-            // we need an extra thread so that synchronized AppPlatform.getUserLibraryFolder() can finish
-            new Thread(
-                    () -> {
-                        if (!startupTasksFinished.get()) {
-                            // no blocking threads, so block manually until startup tasks finish
-                            try {
-                                latch.await();
-                            } catch (InterruptedException e) {
-                                Logger.getLogger(getClass().getName()).log(Level.SEVERE, "An exception was thrown:", e);
-                            }
-                        }
-
-                        Platform.runLater(() -> handleOpenFilesAction(files));
-                    }
-            ).start();
         }
+
+        startInBackground("Set up Scene Builder Thread", () -> {
+            preload();
+            setUpUserLibrary(noFilesToLaunch);
+        }, () -> {
+            createEmptyDocumentWindow();
+            startupFinished.set(true);
+
+            if (!noFilesToLaunch) {
+                handleOpenFilesAction(files);
+            }
+        });
     }
 
     /**
-     * Creates and starts a new daemon thread with [taskName] to executive given [task].
-     * The [task] is added to [startupTasks] to keep track of active background tasks.
-     * When the [task] is finished, it is removed from [startupTasks].
+     * Runs the task in the background {@link Thread} with the given taskName.
+     * @param taskName the name of the task and therefore {@link Thread}
+     * @param task the task that should run
+     * @param onSuccess handler that is run in the UI Thread after the task succeeded
+     * @param <T> the return type of the result from the task, that the onSuccess handler will receive
      */
-    private void startInBackground(String taskName, Runnable task) {
-        var t = new Thread(() -> {
+    public static <T> void startInBackground(String taskName, Supplier<T> task, Consumer<T> onSuccess) {
+        Thread.ofVirtual().name(taskName).start(() -> {
+            T result = task.get();
+            Platform.runLater(() -> onSuccess.accept(result));
+        });
+    }
+
+    /**
+     * Runs the task in the background {@link Thread} with the given taskName.
+     * @param taskName the name of the task and therefore {@link Thread}
+     * @param task the task that should run
+     * @param onSuccess handler that is run in the UI Thread after the task succeeded
+     */
+    public static void startInBackground(String taskName, Runnable task, Runnable onSuccess) {
+        startInBackground(taskName, () -> {
             task.run();
-
-            startupTasks.remove(task);
-        }, taskName + " Thread");
-        t.setDaemon(true);
-        t.start();
-
-        startupTasks.add(task);
+            return null;
+        }, _ -> onSuccess.run());
     }
 
     private void setUpUserLibrary(boolean showWelcomeDialog) {
@@ -457,7 +447,7 @@ public class SceneBuilderApp extends Application implements AppPlatform.AppNotif
             updateImportedGluonJars(jarReports);
         });
 
-        userLibrary.explorationCountProperty().addListener((ChangeListener<Number>) (ov, t, t1) -> userLibraryExplorationCountDidChange());
+        userLibrary.explorationCountProperty().addListener((ov, t, t1) -> userLibraryExplorationCountDidChange());
 
         userLibrary.startWatching();
 
@@ -892,7 +882,7 @@ public class SceneBuilderApp extends Application implements AppPlatform.AppNotif
     /**
      * This runs in a background thread to speed up SB startup.
      */
-    private void backgroundStart() {
+    private void preload() {
         PreferencesController.getSingleton();
         Metadata.getMetadata();
         BuiltinLibrary.getLibrary();
@@ -957,46 +947,6 @@ public class SceneBuilderApp extends Application implements AppPlatform.AppNotif
                 }
                 break;
         }
-    }
-
-    private void showUpdateDialogIfRequired(DocumentWindowController dwc) {
-        AppSettings.getLatestVersion(latestVersion -> {
-            if (latestVersion == null) {
-                // This can be because the url was not reachable so we don't show the update dialog.
-                return;
-            }
-            try {
-                boolean showUpdateDialog = true;
-                if (AppSettings.getSceneBuilderVersion().contains("SNAPSHOT")) {
-                    showUpdateDialog = false;
-                } else if (AppSettings.isCurrentVersionLowerThan(latestVersion)) {
-                    PreferencesController pc = PreferencesController.getSingleton();
-                    PreferencesRecordGlobal recordGlobal = pc.getRecordGlobal();
-
-                    if (isVersionToBeIgnored(recordGlobal, latestVersion)) {
-                        showUpdateDialog = false;
-                    }
-
-                    if (!isUpdateDialogDateReached(recordGlobal)) {
-                        showUpdateDialog = false;
-                    }
-                } else {
-                    showUpdateDialog = false;
-                }
-
-                if (showUpdateDialog) {
-                    String latestVersionText = AppSettings.getLatestVersionText();
-                    String latestVersionAnnouncementURL = AppSettings.getLatestVersionAnnouncementURL();
-                    Platform.runLater(() -> {
-                        UpdateSceneBuilderDialog dialog = new UpdateSceneBuilderDialog(latestVersion, latestVersionText,
-                                latestVersionAnnouncementURL, dwc.getStage());
-                        dialog.showAndWait();
-                    });
-                }
-            } catch (NumberFormatException ex) {
-                Platform.runLater(() -> showVersionNumberFormatError(dwc));
-            }
-        });
     }
 
     private void checkUpdates(DocumentWindowController source) {

--- a/app/src/main/java/com/oracle/javafx/scenebuilder/app/preferences/PreferencesRecordDocument.java
+++ b/app/src/main/java/com/oracle/javafx/scenebuilder/app/preferences/PreferencesRecordDocument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2024, Gluon and/or its affiliates.
+ * Copyright (c) 2016, 2026, Gluon and/or its affiliates.
  * Copyright (c) 2012, 2014, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
@@ -630,8 +630,10 @@ public class PreferencesRecordDocument {
         // Scene style sheets
         final String items = documentPreferences.get(SCENE_STYLE_SHEETS, null);
         if (items != null) {
-            final String[] itemsArray = items.split(File.pathSeparator); //NOI18N
-            sceneStyleSheets.addAll(Arrays.asList(itemsArray));
+            List<String> stylesheets = Arrays.stream(items.split(File.pathSeparator))
+                .filter(str -> !str.isEmpty())
+                .toList();
+            sceneStyleSheets.addAll(stylesheets);
         }
 
         // I18NResource

--- a/app/src/main/java/com/oracle/javafx/scenebuilder/app/util/AppSettings.java
+++ b/app/src/main/java/com/oracle/javafx/scenebuilder/app/util/AppSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2024, Gluon and/or its affiliates.
+ * Copyright (c) 2016, 2026, Gluon and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -59,8 +59,8 @@ public class AppSettings {
 
     private static final Logger LOGGER = Logger.getLogger(AppSettings.class.getName());
 
-    public static final String APP_ICON_16 = SceneBuilderApp.class.getResource("SceneBuilderLogo_16.png").toString();
-    public static final String APP_ICON_32 = SceneBuilderApp.class.getResource("SceneBuilderLogo_32.png").toString();
+    public static final Image APP_ICON_16 = new Image(SceneBuilderApp.class.getResource("SceneBuilderLogo_16.png").toString());
+    public static final Image APP_ICON_32 = new Image(SceneBuilderApp.class.getResource("SceneBuilderLogo_32.png").toString());
 
     public static final String LATEST_VERSION_CHECK_URL = "http://download.gluonhq.com/scenebuilder/settings.properties";
     public static final String LATEST_VERSION_NUMBER_PROPERTY = "latestversion";
@@ -97,9 +97,7 @@ public class AppSettings {
         setWindowIcon((Stage)alert.getDialogPane().getScene().getWindow());
     }
     public static void setWindowIcon(Stage stage) {
-        Image icon16 = new Image(AppSettings.APP_ICON_16);
-        Image icon32 = new Image(AppSettings.APP_ICON_32);
-        stage.getIcons().addAll(icon16, icon32);
+        stage.getIcons().addAll(APP_ICON_16, APP_ICON_32);
     }
 
     public static String getSceneBuilderVersion() {

--- a/app/src/main/java/com/oracle/javafx/scenebuilder/app/welcomedialog/WelcomeDialogWindowController.java
+++ b/app/src/main/java/com/oracle/javafx/scenebuilder/app/welcomedialog/WelcomeDialogWindowController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2024, Gluon and/or its affiliates.
+ * Copyright (c) 2017, 2026, Gluon and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -58,6 +58,7 @@ import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.geometry.Pos;
 import javafx.scene.control.Button;
+import javafx.scene.control.Control;
 import javafx.scene.control.Label;
 import javafx.scene.control.ProgressIndicator;
 import javafx.scene.control.Tooltip;
@@ -118,7 +119,7 @@ public class WelcomeDialogWindowController extends TemplatesBaseWindowController
         getStage().setTitle(I18N.getString("welcome.title"));
         getStage().initModality(Modality.APPLICATION_MODAL);
     }
-    
+
     @FXML
     void handleFileDraggedOver(DragEvent event) {
         if (event.getDragboard().hasFiles()) {
@@ -165,51 +166,40 @@ public class WelcomeDialogWindowController extends TemplatesBaseWindowController
         Label loadingRecentItems = new Label(I18N.getString("welcome.recent.items.loading"));
         loadingRecentItems.getStyleClass().add("no-recent-items-label");
 
-        recentDocuments.getChildren().add(loadingRecentItems);
+        recentDocuments.getChildren().setAll(loadingRecentItems);
 
-        var t = new Thread(() -> {
-            PreferencesRecordGlobal preferencesRecordGlobal = PreferencesController
-                    .getSingleton().getRecordGlobal();
-            List<String> recentItems = preferencesRecordGlobal.getRecentItems();
+        SceneBuilderApp.startInBackground("Recent Items Loading Thread",
+            this::createRecentItems, recentItems -> recentDocuments.getChildren().setAll(recentItems)
+        );
+    }
 
-            Platform.runLater(() -> recentDocuments.getChildren().clear());
+    private List<Control> createRecentItems() {
+        PreferencesRecordGlobal preferencesRecordGlobal = PreferencesController.getSingleton().getRecordGlobal();
+        final List<String> recentItems = preferencesRecordGlobal.getRecentItems();
 
-            if (recentItems.size() == 0) {
-                Label noRecentItems = new Label(I18N.getString("welcome.recent.items.no.recent.items"));
-                noRecentItems.getStyleClass().add("no-recent-items-label");
+        if (recentItems.isEmpty()) {
+            Label noRecentItems = new Label(I18N.getString("welcome.recent.items.no.recent.items"));
+            noRecentItems.getStyleClass().add("no-recent-items-label");
 
-                Platform.runLater(() -> {
-                    recentDocuments.getChildren().add(noRecentItems);
-                });
-            }
+            return List.of(noRecentItems);
+        }
 
-            List<Button> recentDocumentButtons = new ArrayList<>();
+        List<Control> recentDocumentButtons = new ArrayList<>(recentItems.size());
+        for (String recentItem : recentItems) {
+            File recentItemFile = new File(recentItem);
+            String recentItemTitle = recentItemFile.getName();
+            Button recentDocument = new Button(recentItemTitle);
+            recentDocument.getStyleClass().add("recent-document");
+            recentDocument.setMaxWidth(Double.MAX_VALUE);
+            recentDocument.setAlignment(Pos.BASELINE_LEFT);
+            recentDocument.setOnAction(event -> fireOpenRecentProject(event, recentItem));
+            recentDocument.setTooltip(new Tooltip(recentItem));
+            /* if MnemonicParsing is enabled, file names with underscores are displayed incorrectly */
+            recentDocument.setMnemonicParsing(false);
+            recentDocumentButtons.add(recentDocument);
+        }
 
-            for (int row = 0; row < preferencesRecordGlobal.getRecentItemsSize(); ++row) {
-                if (recentItems.size() < row + 1) {
-                    break;
-                }
-
-                String recentItem = recentItems.get(row);
-                File recentItemFile = new File(recentItems.get(row));
-                String recentItemTitle = recentItemFile.getName();
-                Button recentDocument = new Button(recentItemTitle);
-                recentDocument.getStyleClass().add("recent-document");
-                recentDocument.setMaxWidth(Double.MAX_VALUE);
-                recentDocument.setAlignment(Pos.BASELINE_LEFT);
-                recentDocument.setOnAction(event -> fireOpenRecentProject(event, recentItem));
-                recentDocument.setTooltip(new Tooltip(recentItem));
-                /* if MnemonicParsing is enabled, file names with underscores are displayed incorrectly */
-                recentDocument.setMnemonicParsing(false);
-                recentDocumentButtons.add(recentDocument);
-            }
-
-            Platform.runLater(() -> {
-                recentDocumentButtons.forEach(btn -> recentDocuments.getChildren().add(btn));
-            });
-        }, "Recent Items Loading Thread");
-        t.setDaemon(true);
-        t.start();
+        return recentDocumentButtons;
     }
 
     public static WelcomeDialogWindowController getInstance() {
@@ -224,15 +214,10 @@ public class WelcomeDialogWindowController extends TemplatesBaseWindowController
     }
 
     private void fireSelectTemplate(Template template) {
-        if (sceneBuilderApp.startupTasksFinishedBinding().get()) {
+        showMasker(() -> {
             sceneBuilderApp.performNewTemplate(template);
             getStage().hide();
-        } else {
-            showMasker(() -> {
-                sceneBuilderApp.performNewTemplate(template);
-                getStage().hide();
-            });
-        }
+        });
     }
 
     private void fireOpenRecentProject(ActionEvent event, String projectPath) {
@@ -304,11 +289,7 @@ public class WelcomeDialogWindowController extends TemplatesBaseWindowController
     }
 
     private void attemptOpenExistingFiles(List<String> paths) {
-        if (sceneBuilderApp.startupTasksFinishedBinding().get()) {
-            openFilesAndHideStage(paths);
-        } else {
-            showMasker(() -> openFilesAndHideStage(paths));
-        }
+        showMasker(() -> openFilesAndHideStage(paths));
     }
 
     private void openFilesAndHideStage(List<String> files) {
@@ -340,7 +321,7 @@ public class WelcomeDialogWindowController extends TemplatesBaseWindowController
                 missingFiles.add(file);
             }
         });
-        
+
         missingFilesHandler.accept(missingFiles);
 
         if (existingFiles.isEmpty()) {
@@ -357,22 +338,24 @@ public class WelcomeDialogWindowController extends TemplatesBaseWindowController
     }
 
     private void showMasker(Runnable onEndAction) {
+        if (sceneBuilderApp.isStartupFinished()) {
+            onEndAction.run();
+            return;
+        }
+
         contentPane.setDisable(true);
         masker.setVisible(true);
 
         // force progress indicator to render
         progress.setProgress(-1);
 
-        sceneBuilderApp.startupTasksFinishedBinding().addListener((o, old, isFinished) -> {
-            if (isFinished) {
-                Platform.runLater(() -> {
-                    onEndAction.run();
-                    // restore state in case welcome dialog is opened again
-                    contentPane.setDisable(false);
-                    masker.setVisible(false);
-                });
+        sceneBuilderApp.startupFinishedProperty().addListener(_ -> {
+            if (sceneBuilderApp.isStartupFinished()) {
+                onEndAction.run();
+                // restore state in case welcome dialog is opened again
+                contentPane.setDisable(false);
+                masker.setVisible(false);
             }
         });
     }
 }
-


### PR DESCRIPTION
This PR improves the startup workflow and code. The goal is to have a more reliable, stable and faster startup.
This aims to fix:
- https://github.com/gluonhq/scenebuilder/issues/846
- https://github.com/gluonhq/scenebuilder/issues/830

What changed
-
`SceneBuilderApp` has now two public static methods:
- `startInBackground(..)`, which takes an action and a task it should do after the action did run. 
This especially helpful to write code like: `startInBackground("Load Data", this::loadData, this::setData);`
Another advantage: The `SceneBuilderApp` is the central point to coordinate such background tasks. So in the future, we can easily rely on that (e.g. to show a `ScrollBar` with all active backgrounds tasks)

Startup code now uses this method to do everything that makes sense in the background, and everything UI related right after. This also avoids any sort of weird race conditions. The process what to do first, next and on the UI Thread is now very well defined.

I also found out that Scenebuilder sometimes processes an empty path for CSS in `PreferencesRecordDocument`. 
In `SCENE_STYLE_SHEETS`, an empty string might be written, which is then read out. This results in `""` to be treated as stylesheet, which will then be converted to your workspace/installation path. The CSS Parser later on then reads all files that are in the root of the Scenebuilder, so for example `.editorconfig`. This leads to a slower startup and CSS errors in the console.

Very minor: The two Scenebuilder images are now created just once in `AppSettings`. In my profiling, loading this images always for a new window made 2%, which is low, but still nice to save.

### Progress

- [x] Change must not contain extraneous whitespace
- [x] License header year is updated, if required
- [x] The PR name must follow the [pre-defined format](https://github.com/gluonhq/scenebuilder/blob/master/CONTRIBUTING.md)
- [x] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)